### PR TITLE
Add CLAUDE.md, fix timezone off-by-one bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run Commands
+
+```bash
+cd app
+npm install              # install dependencies
+npm run dev              # dev server at http://localhost:3000
+npm run build            # production build (vite + esbuild)
+npm run start            # run production build
+npm run check            # typecheck (tsc --noEmit)
+npm run db:push          # push schema changes to Postgres (drizzle-kit push)
+npm run db:seed          # seed database with initial data
+npm run mcp              # run MCP server (stdio transport, for local Claude Desktop/Code)
+```
+
+For production DB operations, prefix with the Railway connection string:
+```bash
+DATABASE_URL="postgresql://...@shuttle.proxy.rlwy.net:53371/railway" npm run db:push
+```
+
+## Architecture
+
+Four-layer system: **Data → Rules → API/MCP → UI**
+
+```
+[Browser UI] <--REST/SSE--> [Express API + Postgres] <--eval--> [Rules Engine]
+                                      ^
+                                      |
+                              [MCP Server (remote)]
+```
+
+**All source code is in `app/`**. The repo root just has README, CLAUDE.md, and gitignore.
+
+### Backend (`app/server/`)
+- `index.ts` — Express server entry point, starts rules scheduler
+- `routes.ts` — REST API endpoints for all entities + SSE event stream
+- `storage.ts` — Database CRUD layer. All mutations broadcast SSE events and trigger rules evaluation. Contains `logActivity()` which logs to the activity_log table.
+- `rules-engine.ts` — Evaluates business rules reactively (on data change) and on schedule (every 15 min). Conditions: `no_interaction_for_days`, `followup_past_due`, `no_followup_after_meeting`, `meeting_within_hours`, `status_is`, `stage_is`. Exceptions: `has_future_followup`, `stage_in`.
+- `mcp-remote.ts` — Remote MCP endpoint at `/mcp/:token` using StreamableHTTP transport. Creates a fresh MCP server per session. All tools have try/catch to prevent session poisoning.
+- `mcp-client.ts` — Local MCP client (stdio) that calls the REST API. For Claude Desktop/Code.
+- `mcp-server.ts` — Direct DB MCP server (stdio). Legacy, prefer mcp-client.ts.
+- `auth.ts` — PIN-based auth + API key middleware
+- `sse.ts` — SSE broadcast manager
+- `seed.ts` — Seeds database with initial contact data
+- `db.ts` — Postgres connection via node-postgres + Drizzle
+
+### Frontend (`app/client/`)
+- `src/pages/crm-page.tsx` — Main notebook view. "Today" meetings, "Upcoming" follow-ups, contact cards.
+- `src/pages/rules-page.tsx` — Rules management with violation display
+- `src/pages/auth-page.tsx` — PIN login with teal gradient
+- `src/components/contact-block.tsx` — Contact card with inline editing, slash commands, follow-up completion flow
+- `src/hooks/use-crm.ts` — React Query mutations for all CRM operations
+- `src/hooks/use-sse.ts` — SSE listener that invalidates React Query cache
+- `src/hooks/use-auth.tsx` — Auth context (PIN + session)
+- `src/App.tsx` — Privacy screen overlay when window loses focus
+
+### Shared (`app/shared/`)
+- `schema.ts` — Drizzle ORM schema. Tables: users, companies, contacts, interactions, followups, meetings, briefings, rules, rule_violations, activity_log. The `ContactWithRelations` type includes all related data.
+
+## Key Patterns
+
+- **Storage layer is the single write path.** All mutations go through `storage.ts` which handles SSE broadcast, rules evaluation trigger, and activity logging.
+- **MCP tools must have try/catch.** An unhandled exception in a tool crashes the MCP session, causing all subsequent calls to fail.
+- **Rules are data, not code.** Stored as JSONB in the `rules` table. Agents can CRUD rules via MCP.
+- **Activity log is the audit trail.** `storage.logActivity()` is called from mutations. Agents can query it via `get_activity_log` MCP tool.
+- **SSE pushes all data changes to the browser.** The frontend invalidates React Query cache on any event.
+- **MCP sessions auto-recover after deploys.** Stale session IDs get a fresh session instead of an error.
+
+## Data Model
+
+- **Stage** = pipeline position: LEAD → MEETING → PROPOSAL → NEGOTIATION → LIVE → PASS, plus RELATIONSHIP
+- **Status** = active or paused: ACTIVE or HOLD. HOLD is NOT a stage.
+- **Follow-ups** are forward-looking tasks. When completed, the outcome is logged as an interaction.
+- **Meetings** are future events (not interactions). After a meeting happens, log it as an interaction.
+- **Briefings** are one per contact (upsert) — prep notes for upcoming conversations.
+
+## Workflow Rules
+
+- **Always use feature branches and PRs.** Never push directly to main. Parker (openclaw agent) reviews PRs.
+- **Railway auto-deploys from main.** Root directory is `app/`. Every merge to main triggers a build+deploy.
+- **Remote MCP endpoint** is at `/mcp/:token` — the token is a secret URL path for auth.
+- **Never put pricing or deal terms in the CRM.** Never cross-reference client details between contacts.
+
+## Style Guide
+
+- Font: Montserrat (300-700) + JetBrains Mono for dates/code
+- Palette: Background `#f0f8f8`, cards white, borders `#d4e8e8`, text `#1a2f2f`, muted `#5a7a7a`, accent `#2bbcb3`
+- Max content width: 640px
+- Cards: 12px border-radius, 1px border
+- Contact cards are compact: no chevron toggle, details collapsed behind "more..." preview
+- Follow-ups: square checkbox icon (not checkmark), no emoji

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -3,6 +3,23 @@ import { format, isPast, isToday, differenceInDays } from "date-fns";
 import { ChevronDown, ChevronRight, Square, AlertTriangle, Trash2 } from "lucide-react";
 import type { ContactWithRelations } from "@shared/schema";
 
+// Format a UTC date as M/D without timezone shift (fixes off-by-one bug)
+function fmtDate(dateStr: string | Date): string {
+  const d = new Date(dateStr);
+  return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+}
+
+function fmtDateFull(dateStr: string | Date): string {
+  const d = new Date(dateStr);
+  const months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+  return `${months[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}
+
+function fmtDateInput(dateStr: string | Date): string {
+  const d = new Date(dateStr);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth()+1).padStart(2,"0")}-${String(d.getUTCDate()).padStart(2,"0")}`;
+}
+
 const STAGE_OPTIONS = ["LEAD", "MEETING", "PROPOSAL", "NEGOTIATION", "LIVE", "PASS", "RELATIONSHIP"] as const;
 
 const FU_PREFIX = /^\/(fu|f|follow|followup|todo|task)\s/i;
@@ -243,7 +260,7 @@ export function ContactBlock({
                     return (
                       <div key={interaction.id} className="flex items-start gap-1.5 text-xs">
                         <span className="font-semibold flex-shrink-0 pt-0.5" style={{ color: C.accentDark }}>
-                          {format(new Date(interaction.date), "M/d")}
+                          {fmtDate(interaction.date)}
                         </span>
                         <input autoFocus value={editingInteractionText} onChange={(e) => setEditingInteractionText(e.target.value)}
                           onBlur={() => handleInteractionSave(interaction.id)}
@@ -258,7 +275,7 @@ export function ContactBlock({
                     <div key={interaction.id} className="flex items-start gap-1.5 text-xs cursor-text group/line"
                       onClick={() => { setEditingInteractionId(interaction.id); setEditingInteractionText(interaction.content); }}>
                       <span className="font-semibold flex-shrink-0 pt-px" style={{ color: C.accentDark }}>
-                        {format(new Date(interaction.date), "M/d")}
+                        {fmtDate(interaction.date)}
                       </span>
                       <span className="group-hover/line:bg-[#e6f7f6] rounded px-0.5 -mx-0.5 transition-colors" style={{ color: C.text }}>
                         {interaction.content}
@@ -326,8 +343,8 @@ export function ContactBlock({
                       <Square className="h-3.5 w-3.5" />
                     </button>
                     <span className="cursor-pointer hover:underline decoration-dotted underline-offset-2"
-                      onClick={() => { setEditingFollowupId(fu.id); setEditingFollowupText(fu.content); setEditingFollowupDate(format(due, "yyyy-MM-dd")); }}>
-                      <span className="font-semibold" style={{ color: fuColor }}>{format(due, "M/d")}</span>
+                      onClick={() => { setEditingFollowupId(fu.id); setEditingFollowupText(fu.content); setEditingFollowupDate(fmtDateInput(due)); }}>
+                      <span className="font-semibold" style={{ color: fuColor }}>{fmtDate(due)}</span>
                       <span style={{ color: isOverdue ? C.red : C.text }}> {fu.content}</span>
                       {isOverdue && <span className="font-semibold" style={{ color: C.red }}> OVERDUE</span>}
                       {isTodayDue && <span className="font-semibold" style={{ color: C.stale }}> TODAY</span>}

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -2,23 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { format, isPast, isToday, differenceInDays } from "date-fns";
 import { ChevronDown, ChevronRight, Square, AlertTriangle, Trash2 } from "lucide-react";
 import type { ContactWithRelations } from "@shared/schema";
-
-// Format a UTC date as M/D without timezone shift (fixes off-by-one bug)
-function fmtDate(dateStr: string | Date): string {
-  const d = new Date(dateStr);
-  return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
-}
-
-function fmtDateFull(dateStr: string | Date): string {
-  const d = new Date(dateStr);
-  const months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
-  return `${months[d.getUTCMonth()]} ${d.getUTCDate()}`;
-}
-
-function fmtDateInput(dateStr: string | Date): string {
-  const d = new Date(dateStr);
-  return `${d.getUTCFullYear()}-${String(d.getUTCMonth()+1).padStart(2,"0")}-${String(d.getUTCDate()).padStart(2,"0")}`;
-}
+import { fmtDate, fmtDateInput } from "@/lib/utils";
 
 const STAGE_OPTIONS = ["LEAD", "MEETING", "PROPOSAL", "NEGOTIATION", "LIVE", "PASS", "RELATIONSHIP"] as const;
 

--- a/app/client/src/lib/utils.ts
+++ b/app/client/src/lib/utils.ts
@@ -4,3 +4,20 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// UTC date formatters — prevent timezone off-by-one when rendering date-only values
+export function fmtDate(dateStr: string | Date): string {
+  const d = new Date(dateStr);
+  return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+}
+
+export function fmtDateFull(dateStr: string | Date): string {
+  const d = new Date(dateStr);
+  const months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+  return `${months[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}
+
+export function fmtDateInput(dateStr: string | Date): string {
+  const d = new Date(dateStr);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth()+1).padStart(2,"0")}-${String(d.getUTCDate()).padStart(2,"0")}`;
+}

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -8,11 +8,7 @@ import { Loader2, LogOut, Settings, Square, Activity, X, ChevronDown } from "luc
 import { Link } from "wouter";
 import { format, isPast, isToday, differenceInDays } from "date-fns";
 import type { ContactWithRelations, Followup, Meeting, Briefing, ActivityLogEntry } from "@shared/schema";
-
-function fmtDate(dateStr: string | Date): string {
-  const d = new Date(dateStr);
-  return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
-}
+import { fmtDate } from "@/lib/utils";
 
 const STAGES = ["ALL", "NEGOTIATION", "PROPOSAL", "MEETING", "LEAD", "LIVE", "RELATIONSHIP", "PASS"] as const;
 

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -9,6 +9,11 @@ import { Link } from "wouter";
 import { format, isPast, isToday, differenceInDays } from "date-fns";
 import type { ContactWithRelations, Followup, Meeting, Briefing, ActivityLogEntry } from "@shared/schema";
 
+function fmtDate(dateStr: string | Date): string {
+  const d = new Date(dateStr);
+  return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+}
+
 const STAGES = ["ALL", "NEGOTIATION", "PROPOSAL", "MEETING", "LEAD", "LIVE", "RELATIONSHIP", "PASS"] as const;
 
 const STAGE_ACCENT: Record<string, string> = {
@@ -287,7 +292,7 @@ export default function CrmPage() {
                   return (
                     <div key={fu.id} className="rounded-lg px-3 py-2 space-y-2" style={{ backgroundColor: C.accentLight, border: `1px solid ${C.accent}40` }}>
                       <div className="text-xs font-medium" style={{ color: C.accentDark }}>
-                        Completing: {format(due, "M/d")} {fu.content} — {contactName}
+                        Completing: {fmtDate(due)} {fu.content} — {contactName}
                       </div>
                       <input
                         autoFocus
@@ -334,7 +339,7 @@ export default function CrmPage() {
                       <Square className="h-3.5 w-3.5" style={{ color: dateColor }} />
                     </button>
                     <span className="font-bold flex-shrink-0" style={{ color: dateColor }}>
-                      {format(due, "M/d")}
+                      {fmtDate(due)}
                     </span>
                     <span style={{ color: C.text }}>{fu.content}</span>
                     <span className="ml-auto text-xs flex-shrink-0 whitespace-nowrap" style={{ color: C.muted }}>


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` with project instructions for all Claude instances (build commands, architecture, patterns, workflow rules, style guide)
- Fixes #2: interaction and follow-up dates displayed one day behind due to UTC→local timezone conversion. Now uses `getUTC*` methods to render dates without timezone shift.

## Changes
- `CLAUDE.md` — new file with project guidance
- `contact-block.tsx` — added `fmtDate`/`fmtDateFull`/`fmtDateInput` helpers, replaced all `format(new Date(...), "M/d")` calls
- `crm-page.tsx` — same fix for Upcoming strip dates

## Test plan
- [ ] Verify interaction dates display correctly (e.g., 3/30 logged interaction shows as 3/30, not 3/29)
- [ ] Verify follow-up due dates display correctly
- [ ] Verify date picker pre-fills correct date when editing a follow-up

Generated with [Claude Code](https://claude.com/claude-code)