### PR TITLE
Add CHANGELOG, update README for plugin architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+## 2026-03-30
+
+### Plugin Architecture
+- Extracted meetings, briefings, and activity-log from core into self-contained plugins under `app/plugins/`
+- New `CrmPlugin` interface: registerRoutes, registerTools, enrichContact, ruleConditions, guideText
+- Core is now: contacts, interactions, follow-ups, rules, violations. Everything else is a plugin.
+- Rule conditions are pluggable — plugins can register custom condition evaluators
+
+### CI/CD
+- GitHub Actions CI pipeline: build + Playwright E2E tests on every PR
+- E2E test skill (`.claude/skills/e2e-test/`) for agentic pre-PR testing
+
+### Meetings & Briefings
+- Meetings: schedule calls/video/in-person/coffee, cancel, complete. MCP tools + API + "Today" UI section
+- Briefings: one-per-contact prep notes (upsert). MCP tools + API
+- Activity Log: audit trail for all system/agent actions. MCP tool + API + drawer in header
+
+## 2026-03-29
+
+### Stage/Status Separation
+- HOLD is a status, not a stage. Stages: LEAD → MEETING → PROPOSAL → NEGOTIATION → LIVE → PASS + RELATIONSHIP
+
+### Design Overhaul
+- Applied Magnetic Advisors teal style guide (Montserrat, #2bbcb3 palette, 640px max-width)
+- Compact contact cards: details collapsed behind "more...", last 3 interactions shown
+- Privacy screen: teal overlay when window loses focus (screen share protection)
+
+### MCP Improvements
+- Remote MCP at `/mcp/:token` for Claude custom connectors
+- Session auto-recovery after deploys
+- Detailed tool descriptions to guide agent formatting
+- `get_crm_guide` tool as recommended first call
+- Delete tools: contacts, interactions, follow-ups
+- try/catch on all tools to prevent session poisoning
+
+### Follow-up Completion Flow
+- Completing a follow-up prompts for outcome, logged as interaction
+- `/fu`, `/f`, `/follow`, `/todo`, `/task` all create follow-ups
+
+### Rules Engine
+- `stage_in` exception type for excluding stages from rules
+- `meeting_within_hours` condition (via meetings plugin)
+- `update_rule` accepts conditionParams and exceptions
+
+## 2026-03-27
+
+### Initial Build
+- Document-first CRM: contacts, interactions, follow-ups, rules, violations
+- PIN auth + API key auth
+- MCP server with 20+ tools
+- Rules engine: reactive + scheduled evaluation
+- SSE real-time updates
+- Seeded with 11 contacts from Magnetic Advisors pipeline
+- Deployed to Railway at crm.magneticadvisors.ai
+- PWA for iOS + Pake Mac desktop app

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,9 @@ npm run test         # Playwright E2E tests
 - Style: Montserrat font, teal palette (#2bbcb3), 640px max-width, 12px border-radius cards.
 
 ## Before submitting a PR
-Run the E2E test skill (`.claude/skills/e2e-test/SKILL.md`): start the dev server, log in via Playwright, add a note, create and complete a follow-up, call MCP tools, verify the UI reflects agent-written data. Screenshot each step. Do not create the PR if any step fails.
+1. Run the E2E test skill (`.claude/skills/e2e-test/SKILL.md`): start dev server, test UI + MCP flows, screenshot each step. Do not create PR if any step fails.
+2. Update README.md if the PR changes architecture, adds tools, or changes how things work.
+3. Add a CHANGELOG.md entry describing what changed.
 
 ## Watch out for
 - Dates render in UTC (fmtDate in `lib/utils.ts`). Using `format()` from date-fns causes off-by-one timezone bugs.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ AI-first personal CRM. A single scrollable notebook view of your entire pipeline
                               (primary write path — agents)
 ```
 
-- **Data**: Postgres — contacts, companies, interactions, follow-ups, meetings, briefings, rules, violations, activity log
+- **Core**: Postgres — contacts, companies, interactions, follow-ups, rules, violations
+- **Plugins**: Meetings, briefings, activity log — each in `app/plugins/` with own schema, routes, MCP tools
 - **Frontend**: React notebook-style view. Inline editing, slash commands, SSE real-time updates
-- **Rules**: Business logic stored as data (JSONB). Evaluated reactively on writes + every 15 minutes
-- **MCP**: Remote endpoint for AI agents. Primary interface for data mutation.
-- **Activity Log**: Audit trail for all system, agent, and user actions
+- **Rules**: Business logic stored as data (JSONB). Evaluated reactively on writes + every 15 minutes. Plugin-extensible conditions.
+- **MCP**: Remote endpoint for AI agents. Core + plugin tools auto-registered.
 - **Deploy**: Railway (auto-deploy from GitHub on merge to main)
 
 ---
@@ -238,3 +238,34 @@ Use `complete_followup(followupId, outcome: "what happened")` to do both in one 
 - **Deploy**: Railway (auto-deploy from main)
 - **Desktop**: Pake (Tauri-based native Mac app)
 - **Mobile**: PWA (Add to Home Screen on iOS)
+
+---
+
+## Plugins
+
+The CRM core is thin — contacts, interactions, follow-ups, rules. Everything else is a plugin.
+
+### Included Plugins
+
+| Plugin | What it adds |
+|--------|-------------|
+| **meetings** | Schedule meetings, "Today" view, `meeting_within_hours` rule condition |
+| **briefings** | Per-contact prep notes (upsert), MCP tools |
+| **activity-log** | Audit trail for all system/agent actions, MCP query tool |
+
+### Creating a Plugin
+
+```
+app/plugins/my-plugin/
+├── schema.ts     # Drizzle table definition
+└── index.ts      # Implements CrmPlugin interface
+```
+
+The `CrmPlugin` interface:
+- `registerRoutes(app, ctx)` — add Express API routes
+- `registerTools(server, ctx)` — add MCP tools
+- `enrichContact(contactId, ctx)` — add data to contact responses
+- `ruleConditions` — register custom rule condition evaluators
+- `guideText` — append to the `get_crm_guide` output
+
+Register in `app/server/index.ts` and the plugin auto-integrates with the API, MCP, rules engine, and UI.


### PR DESCRIPTION
## Summary
- Created CHANGELOG.md with full project history (3/27 → 3/30)
- Updated README: plugins section with table of included plugins + "Creating a Plugin" guide
- Updated CLAUDE.md: PR checklist now requires README update + CHANGELOG entry

## Test plan
- [ ] README renders correctly on GitHub
- [ ] CHANGELOG covers all major features shipped

Generated with [Claude Code](https://claude.com/claude-code)