### PR TITLE
Move plugin tools to plugin READMEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-03-31
+
+### Documentation
+- README MCP tools section now shows only core tools; plugin tools documented in plugin READMEs
+- Each plugin has its own README with tools, routes, and data model docs
+- CLAUDE.md PR checklist: README update + CHANGELOG entry required
+
 ## 2026-03-30
 
 ### Plugin Architecture

--- a/README.md
+++ b/README.md
@@ -73,67 +73,30 @@ curl -H "X-API-Key: <key>" https://your-domain.com/api/contacts
 
 ---
 
-## MCP Tools Reference
+## MCP Tools (Core)
 
-### Guide
 | Tool | Description |
 |------|-------------|
 | `get_crm_guide` | Returns full agent usage guide. Recommended first call. |
-
-### Contacts
-| Tool | Description |
-|------|-------------|
 | `search_contacts` | Find by name, company, stage, or status |
-| `get_contact` | Full contact with interactions, follow-ups, meetings, briefing, violations |
+| `get_contact` | Full contact with all related data |
 | `create_contact` | Add a new contact. Search first to avoid duplicates. |
 | `update_contact` | Modify contact fields |
 | `delete_contact` | Permanently delete a contact and all related data |
-
-### Timeline
-| Tool | Description |
-|------|-------------|
 | `add_interaction` | Log a note, email, meeting, or call |
 | `delete_interaction` | Remove a timeline entry |
-
-### Tasks
-| Tool | Description |
-|------|-------------|
 | `set_followup` | Create a follow-up task with due date |
 | `complete_followup` | Mark done + log outcome to timeline |
 | `delete_followup` | Remove a task without completing it |
-
-### Meetings
-| Tool | Description |
-|------|-------------|
-| `set_meeting` | Schedule a meeting (call, video, in-person, coffee) |
-| `get_upcoming_meetings` | List meetings in next N hours/days |
-| `cancel_meeting` | Soft-cancel a meeting |
-
-### Briefings
-| Tool | Description |
-|------|-------------|
-| `save_briefing` | Save prep notes for a contact (one per contact, upsert) |
-| `get_briefing` | Retrieve a contact's briefing |
-
-### Pipeline
-| Tool | Description |
-|------|-------------|
 | `get_pipeline` | Contacts grouped by stage |
-| `get_dashboard` | Summary: active count, overdue follow-ups, violations, meetings today |
-
-### Rules
-| Tool | Description |
-|------|-------------|
+| `get_dashboard` | Summary: active count, overdue follow-ups, violations |
 | `list_rules` | All business rules |
 | `create_rule` | Add a business rule |
 | `update_rule` | Modify rule logic, params, exceptions, or enable/disable |
 | `delete_rule` | Remove a rule |
 | `list_violations` | Active rule violations |
 
-### Activity Log
-| Tool | Description |
-|------|-------------|
-| `get_activity_log` | View system activity: rule evaluations, agent actions, violations. Filter by contact, event type, or source. |
+Plugins add their own tools — see each plugin's README for details.
 
 ---
 

--- a/app/plugins/activity-log/README.md
+++ b/app/plugins/activity-log/README.md
@@ -1,0 +1,31 @@
+# Activity Log Plugin
+
+Audit trail for all system, agent, and user actions.
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `get_activity_log` | Query the log. Filter by `contactId`, `event`, `source`, `limit`. |
+
+## API Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/activity` | Query log. `?contactId=N`, `?event=rule.evaluated`, `?source=agent`, `?limit=50` |
+
+## Events Logged
+
+| Event | Source | Example |
+|-------|--------|---------|
+| `contact.created` | agent | "Created Kyle Cross" |
+| `contact.updated` | agent | "Updated Kyle Cross: stage, status" |
+| `contact.deleted` | agent | "Deleted Kyle Cross" |
+| `meeting.created` | agent | "Scheduled call for 4/1 2pm" |
+| `meeting.cancelled` | agent | "Cancelled meeting" |
+| `briefing.saved` | agent | "Briefing saved (412 chars)" |
+| `violation.created` | rule:1 | "No interaction for 27 days" |
+
+## UI
+
+Activity drawer accessible from the header (pulse icon). Shows a chronological list of recent activity.

--- a/app/plugins/briefings/README.md
+++ b/app/plugins/briefings/README.md
@@ -1,0 +1,22 @@
+# Briefings Plugin
+
+Store per-contact prep notes for upcoming conversations.
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `save_briefing` | Save prep notes for a contact (one per contact, upsert) |
+| `get_briefing` | Retrieve a contact's briefing |
+
+## API Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/briefings/:contactId` | Get briefing |
+| PUT | `/api/briefings/:contactId` | Save/update briefing |
+| DELETE | `/api/briefings/:contactId` | Delete briefing |
+
+## Data
+
+One briefing per contact (upsert semantics). Good for: talking points, recent news, open items, relationship notes. Briefings appear when expanding a meeting in the "Today" section.

--- a/app/plugins/meetings/README.md
+++ b/app/plugins/meetings/README.md
@@ -1,0 +1,34 @@
+# Meetings Plugin
+
+Schedule and track meetings with contacts.
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `set_meeting` | Schedule a meeting (call, video, in-person, coffee) |
+| `get_upcoming_meetings` | List meetings in next N hours/days |
+| `cancel_meeting` | Soft-cancel a meeting |
+
+## Rule Conditions
+
+| Condition | Description | Params |
+|-----------|-------------|--------|
+| `meeting_within_hours` | Contact has a meeting within N hours | `{ hours: 24 }` |
+
+## API Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/meetings` | List meetings. `?contactId=N`, `?today=true` |
+| GET | `/api/meetings/upcoming` | Upcoming meetings. `?hours=24` |
+| POST | `/api/meetings` | Create meeting |
+| PUT | `/api/meetings/:id` | Update meeting |
+| POST | `/api/meetings/:id/cancel` | Cancel meeting |
+| POST | `/api/meetings/:id/complete` | Mark meeting as completed |
+
+## Data
+
+Meetings are future events — not interactions. After a meeting happens, log it as an interaction with `add_interaction`. Meetings appear in the "Today" section on the CRM page.
+
+Types: `call`, `video`, `in-person`, `coffee`


### PR DESCRIPTION
## Summary
- Main README MCP tools section now shows only 18 core tools
- Each plugin has its own README with tools, routes, and data docs:
  - `app/plugins/meetings/README.md`
  - `app/plugins/briefings/README.md`
  - `app/plugins/activity-log/README.md`
- CHANGELOG updated

## Test plan
- [ ] READMEs render correctly on GitHub

Generated with [Claude Code](https://claude.com/claude-code)