### PR TITLE
Add pre-PR hook enforcing CHANGELOG and E2E testing

### DIFF
--- a/.claude/hooks/pre-pr.sh
+++ b/.claude/hooks/pre-pr.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Pre-PR hook: blocks gh pr create unless checklist is complete
+# Receives JSON on stdin with tool_input.command
+# Only activates when the command contains "gh pr create"
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null)
+
+# Only check for PR creation commands
+if ! echo "$COMMAND" | grep -q "gh pr create"; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR" 2>/dev/null || exit 0
+
+ERRORS=""
+
+# 1. Check CHANGELOG was modified on this branch vs main
+CHANGELOG_CHANGED=$(git diff main --name-only 2>/dev/null | grep -c "CHANGELOG.md")
+if [ "$CHANGELOG_CHANGED" -eq 0 ]; then
+  ERRORS="$ERRORS CHANGELOG.md not updated."
+fi
+
+# 2. Check for recent E2E test screenshots (within last 30 minutes)
+RECENT_SCREENSHOTS=$(find .playwright-mcp -name "*.png" -mmin -30 2>/dev/null | head -1)
+if [ -z "$RECENT_SCREENSHOTS" ]; then
+  ERRORS="$ERRORS No recent E2E test screenshots — run the E2E test skill first."
+fi
+
+if [ -n "$ERRORS" ]; then
+  cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Pre-PR checklist failed:${ERRORS} Fix these before creating a PR."
+  }
+}
+EOF
+  exit 0
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-pr.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-03-31
 
+### Pre-PR Hook
+- Claude Code hook blocks `gh pr create` unless CHANGELOG is updated and E2E tests were run
+
 ### Unified Items Model
 - Tasks and meetings are now the same entity: items with a `type` field on the core `followups` table
 - Tasks show □ checkbox, meetings show 📅 icon — both inline in contact cards, sorted by date


### PR DESCRIPTION
## Summary
Adds a Claude Code PreToolUse hook that intercepts `gh pr create` and blocks it unless:
1. CHANGELOG.md was modified on the branch vs main
2. Recent E2E test screenshots exist (within 30 min)

This enforces the PR workflow: agentic testing + changelog + readme before every PR.

## Files
- `.claude/settings.json` — hook configuration
- `.claude/hooks/pre-pr.sh` — checklist script

## Test plan
- [ ] Try `gh pr create` without CHANGELOG changes → blocked
- [ ] Try `gh pr create` without recent screenshots → blocked
- [ ] Both satisfied → PR creates normally

Generated with [Claude Code](https://claude.com/claude-code)