### PR TITLE
Fix item overflow and icon alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-03-31
 
+### UI Fixes
+- Upcoming strip: long meeting text truncates instead of overflowing and breaking layout
+- Contact card items: icons align to top on multi-line items, text truncates at 80 chars with "..."
+
 ### Pre-PR Hook
 - Claude Code hook blocks `gh pr create` unless CHANGELOG is updated and E2E tests were run
 

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -359,23 +359,27 @@ export function ContactBlock({
                 const isMeeting = fu.type === "meeting";
                 const icon = isMeeting ? "📅" : null;
 
+                // Truncate long content
+                const maxLen = 80;
+                const fullText = fu.content + (fu.location ? ` — ${fu.location}` : "");
+                const truncated = fullText.length > maxLen ? fullText.slice(0, maxLen) + "..." : fullText;
+
                 return (
-                  <div key={fu.id} className="flex items-center gap-1 text-xs">
+                  <div key={fu.id} className="flex items-start gap-1 text-xs">
                     {isMeeting ? (
-                      <span className="flex-shrink-0 text-sm" title="Meeting">{icon}</span>
+                      <span className="flex-shrink-0 text-sm mt-px" title="Meeting">{icon}</span>
                     ) : (
                       <button onClick={() => { setCompletingFollowupId(fu.id); setCompletingFollowupText(fu.content); }}
-                        className="flex-shrink-0 hover:opacity-70" title="Complete" style={{ color: fuColor }}>
+                        className="flex-shrink-0 hover:opacity-70 mt-px" title="Complete" style={{ color: fuColor }}>
                         <Square className="h-3.5 w-3.5" />
                       </button>
                     )}
-                    <span className="cursor-pointer hover:underline decoration-dotted underline-offset-2"
+                    <span className="cursor-pointer hover:underline decoration-dotted underline-offset-2 min-w-0"
                       onClick={() => { setEditingFollowupId(fu.id); setEditingFollowupText(fu.content); setEditingFollowupDate(fmtDateInput(due)); }}>
                       <span className="font-semibold" style={{ color: fuColor }}>
                         {fmtDate(due)}{fu.time ? ` ${fu.time}` : ""}
                       </span>
-                      <span style={{ color: isOverdue ? C.red : C.text }}> {fu.content}</span>
-                      {fu.location && <span style={{ color: C.muted }}> — {fu.location}</span>}
+                      <span style={{ color: isOverdue ? C.red : C.text }}> {truncated}</span>
                       {isOverdue && <span className="font-semibold" style={{ color: C.red }}> OVERDUE</span>}
                       {isTodayDue && <span className="font-semibold" style={{ color: C.stale }}> TODAY</span>}
                       {!isOverdue && !isTodayDue && daysUntil <= 7 && <span style={{ color: C.muted }}> {daysUntil}d</span>}

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -328,13 +328,13 @@ export default function CrmPage() {
                 const isMeeting = fu.type === "meeting";
 
                 return (
-                  <div key={fu.id} className="flex items-start gap-2 text-sm">
+                  <div key={fu.id} className="flex items-center gap-2 text-sm">
                     {isMeeting ? (
-                      <span className="flex-shrink-0 mt-0.5">📅</span>
+                      <span className="flex-shrink-0">📅</span>
                     ) : (
                       <button
                         onClick={() => { setCompletingUpcomingId(fu.id); setCompletingUpcomingText(fu.content); }}
-                        className="flex-shrink-0 mt-0.5 hover:opacity-70 transition-colors"
+                        className="flex-shrink-0 hover:opacity-70 transition-colors"
                         title="Complete"
                       >
                         <Square className="h-3.5 w-3.5" style={{ color: dateColor }} />
@@ -343,9 +343,10 @@ export default function CrmPage() {
                     <span className="font-bold flex-shrink-0" style={{ color: isMeeting ? "#2563eb" : dateColor }}>
                       {fmtDate(due)}{fu.time ? ` ${fu.time}` : ""}
                     </span>
-                    <span style={{ color: C.text }}>{fu.content}</span>
-                    {fu.location && <span className="text-xs" style={{ color: C.muted }}>— {fu.location}</span>}
-                    <span className="ml-auto text-xs flex-shrink-0 whitespace-nowrap" style={{ color: C.muted }}>
+                    <span className="truncate min-w-0" style={{ color: C.text }}>
+                      {fu.content}{fu.location ? ` — ${fu.location}` : ""}
+                    </span>
+                    <span className="text-xs flex-shrink-0 whitespace-nowrap" style={{ color: C.muted }}>
                       {contactName}
                     </span>
                     {isOverdue && (


### PR DESCRIPTION
## Summary
Fixes two visual bugs from screenshot review:

1. **Upcoming strip**: Long meeting text + location overflowed, pushing contact name and day indicator off screen. Now truncates with CSS.
2. **Contact card items**: Multi-line items had icons centered vertically. Now icons align to top. Long text truncates at 80 chars with "...".

## Test plan
- [ ] Meeting with long description + location renders on one line in Upcoming strip
- [ ] Contact card items: icon aligns to top when text wraps
- [ ] Truncated text shows "..." for items over 80 chars

Generated with [Claude Code](https://claude.com/claude-code)