### PR TITLE
Fix MCP session expiry — 30 min TTL (#9)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"a5aa49af-0173-4b61-8295-bc144fe1491f","pid":52907,"acquiredAt":1774925568178}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-03-31
 
+### Bug Fixes
+- MCP sessions no longer expire after ~30 seconds. Sessions persist for 30 min of inactivity with automatic cleanup. (#9)
+
 ### UI Fixes
 - Upcoming strip: long meeting text truncates instead of overflowing and breaking layout
 - Contact card items: icons align to top on multi-line items, text truncates at 80 chars with "..."

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -425,24 +425,42 @@ function checkToken(req: Request, res: Response): boolean {
   return true;
 }
 
+const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const sessionLastUsed = new Map<string, number>();
+
 function createTransportAndServer(): StreamableHTTPServerTransport {
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: () => randomUUID(),
     onsessioninitialized: (id) => {
       transports.set(id, transport);
+      sessionLastUsed.set(id, Date.now());
     },
   });
 
-  transport.onclose = () => {
-    const id = [...transports.entries()].find(([, t]) => t === transport)?.[0];
-    if (id) transports.delete(id);
-  };
+  // Don't delete on close — sessions persist until TTL expires
+  // The transport.onclose fires after each HTTP response, which would
+  // incorrectly destroy the session between sequential tool calls
 
   const server = createMcpServer();
   server.connect(transport);
 
   return transport;
 }
+
+function touchSession(sessionId: string) {
+  sessionLastUsed.set(sessionId, Date.now());
+}
+
+// Cleanup stale sessions every 5 minutes
+setInterval(() => {
+  const now = Date.now();
+  for (const [id, lastUsed] of sessionLastUsed.entries()) {
+    if (now - lastUsed > SESSION_TTL_MS) {
+      transports.delete(id);
+      sessionLastUsed.delete(id);
+    }
+  }
+}, 5 * 60 * 1000);
 
 export function registerMcpRoutes(app: Express) {
   // Handle POST /mcp/:token
@@ -453,6 +471,7 @@ export function registerMcpRoutes(app: Express) {
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
 
     if (sessionId && transports.has(sessionId)) {
+      touchSession(sessionId);
       const transport = transports.get(sessionId)!;
       await transport.handleRequest(req, res, req.body);
       return;
@@ -464,12 +483,12 @@ export function registerMcpRoutes(app: Express) {
   });
 
   // Handle GET /mcp/:token - SSE stream
-  // If session is stale, create a new one instead of erroring
   app.get("/mcp/:token", async (req: Request, res: Response) => {
     if (!checkToken(req, res)) return;
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
 
     if (sessionId && transports.has(sessionId)) {
+      touchSession(sessionId);
       const transport = transports.get(sessionId)!;
       await transport.handleRequest(req, res);
       return;


### PR DESCRIPTION
## Summary
MCP sessions expired after ~30 seconds because `transport.onclose` fired after each HTTP response, deleting the session from the map. Now sessions persist with a 30-minute TTL and automatic cleanup.

Closes #9

## Changes
- Removed `transport.onclose` handler (was deleting sessions prematurely)
- Added `sessionLastUsed` map with timestamps
- `touchSession()` called on every request to reset TTL
- Cleanup interval every 5 min removes sessions idle for 30+ min

## Test plan
- [ ] Make sequential MCP tool calls with 30+ seconds between them — session should persist
- [ ] After 30 min of inactivity, session should be cleaned up (next call creates new session)

Generated with [Claude Code](https://claude.com/claude-code)