### PR TITLE
Store dates at noon UTC, no timezone settings needed (#10, #11)

### DIFF
--- a/.claude/hooks/pre-pr.sh
+++ b/.claude/hooks/pre-pr.sh
@@ -27,6 +27,11 @@ if [ -z "$RECENT_SCREENSHOTS" ]; then
   ERRORS="$ERRORS No recent E2E test screenshots — run the E2E test skill first."
 fi
 
+# 3. Check PR is assigned to Parker
+if ! echo "$COMMAND" | grep -q "parkervoss"; then
+  ERRORS="$ERRORS PR must be assigned to parkervoss (add --assignee parkervoss)."
+fi
+
 if [ -n "$ERRORS" ]; then
   cat <<EOF
 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 - MCP sessions no longer expire after ~30 seconds. Sessions persist for 30 min of inactivity with automatic cleanup. (#9)
+- Dates stored as noon UTC to eliminate timezone off-by-one bugs. Times stored as display strings in user's local timezone. No timezone settings needed. (#10, closes #11)
 
 ### UI Fixes
 - Upcoming strip: long meeting text truncates instead of overflowing and breaking layout

--- a/app/client/src/lib/utils.ts
+++ b/app/client/src/lib/utils.ts
@@ -5,6 +5,12 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+// Normalize a date to noon UTC — prevents timezone shift to wrong day
+export function toNoonUTC(dateStr: string | Date): string {
+  const d = new Date(dateStr);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth()+1).padStart(2,"0")}-${String(d.getUTCDate()).padStart(2,"0")}T12:00:00.000Z`;
+}
+
 // UTC date formatters — prevent timezone off-by-one when rendering date-only values
 export function fmtDate(dateStr: string | Date): string {
   const d = new Date(dateStr);

--- a/app/plugins/meetings/index.ts
+++ b/app/plugins/meetings/index.ts
@@ -1,6 +1,7 @@
 import type { CrmPlugin } from "../index";
 import { z } from "zod";
 import { followups } from "@shared/schema";
+import { toNoonUTC } from "@shared/dates";
 import { eq, and, isNull, gte, lte, asc } from "drizzle-orm";
 
 const meetingsPlugin: CrmPlugin = {
@@ -62,7 +63,7 @@ const meetingsPlugin: CrmPlugin = {
       time: z.string().optional().describe("Display time, e.g. '2:00 PM'. Auto-parsed from date if not provided."),
     }, async ({ contactId, date, content, type: meetingType, location, time }) => {
       try {
-        const d = new Date(date);
+        const d = toNoonUTC(date);
         const displayTime = time || d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
         const [item] = await db.insert(followups).values({
           contactId, type: "meeting", dueDate: d, content,

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -3,6 +3,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { z } from "zod";
 import { storage } from "./storage";
 import { getPlugins } from "../plugins";
+import { toNoonUTC, parseDateToNoonUTC } from "@shared/dates";
 import type { Express, Request, Response } from "express";
 import { randomUUID } from "crypto";
 
@@ -57,6 +58,8 @@ Note: PASS is a STAGE (declined/not a fit), not a status.
 - additionalContacts: "Name (Role): email" separated by newlines
 - interaction content: past tense, factual, concise (e.g. "AF had intro call. 30 min, discussed AI strategy.")
 - followup content: action-oriented (e.g. "Check for reply on proposal")
+- dates: use YYYY-MM-DD or M/D format. The CRM stores dates only, not datetimes. No timezone conversion.
+- times: for meetings, store as a display string in the user's local timezone (e.g. "2:30 PM"). Don't convert timezones.
 
 ## Rules
 Rules auto-flag issues (stale contacts, overdue follow-ups). You can create, update, and delete rules.
@@ -229,7 +232,7 @@ Do NOT log follow-up tasks here — use set_followup for those.`,
     },
     async ({ contactId, content, date, type }) => {
       try {
-        const i = await storage.createInteraction({ contactId, content, date: date ? new Date(date) : new Date(), type: type || "note" });
+        const i = await storage.createInteraction({ contactId, content, date: date ? toNoonUTC(date) : toNoonUTC(new Date()), type: type || "note" });
         return { content: [{ type: "text" as const, text: `Logged ${i.type} for contact ${contactId}` }] };
       } catch (err: any) {
         return { content: [{ type: "text" as const, text: `Error logging interaction: ${err.message}` }], isError: true };
@@ -250,14 +253,9 @@ Examples: "Check for reply on proposal", "Send intro email", "Prep agenda for ki
     },
     async ({ contactId, content, dueDate }) => {
       try {
-        let d: Date;
-        if (dueDate.includes("/") && !dueDate.includes("T")) {
-          const [m, day] = dueDate.split("/").map(Number);
-          d = new Date(new Date().getFullYear(), m - 1, day);
-          if (d < new Date()) d.setFullYear(d.getFullYear() + 1);
-        } else { d = new Date(dueDate); }
+        const d = parseDateToNoonUTC(dueDate);
         await storage.createFollowup({ contactId, content, dueDate: d, completed: false });
-        return { content: [{ type: "text" as const, text: `Follow-up set for ${d.toLocaleDateString()}: "${content}"` }] };
+        return { content: [{ type: "text" as const, text: `Follow-up set for ${d.getUTCMonth()+1}/${d.getUTCDate()}: "${content}"` }] };
       } catch (err: any) {
         return { content: [{ type: "text" as const, text: `Error creating follow-up: ${err.message}` }], isError: true };
       }
@@ -278,7 +276,7 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
         const fu = await storage.completeFollowup(followupId);
         if (!fu) return { content: [{ type: "text" as const, text: `Follow-up ${followupId} not found` }], isError: true };
         if (outcome?.trim()) {
-          await storage.createInteraction({ contactId: fu.contactId, content: outcome.trim(), date: new Date(), type: "note" });
+          await storage.createInteraction({ contactId: fu.contactId, content: outcome.trim(), date: toNoonUTC(new Date()), type: "note" });
           return { content: [{ type: "text" as const, text: `Completed and logged: "${outcome.trim()}"` }] };
         }
         return { content: [{ type: "text" as const, text: `Completed: "${fu.content}"` }] };

--- a/app/server/routes.ts
+++ b/app/server/routes.ts
@@ -11,6 +11,7 @@ import {
   insertRuleSchema,
 } from "@shared/schema";
 import { getPlugins } from "../plugins";
+import { toNoonUTC } from "@shared/dates";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   setupAuth(app);
@@ -98,7 +99,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   app.post("/api/interactions", requireAuth, async (req, res) => {
-    const data = { ...req.body, date: new Date(req.body.date) };
+    const data = { ...req.body, date: toNoonUTC(req.body.date) };
     const parsed = insertInteractionSchema.safeParse(data);
     if (!parsed.success) return res.status(400).json({ message: parsed.error.message });
     const interaction = await storage.createInteraction(parsed.data);
@@ -106,7 +107,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   app.put("/api/interactions/:id", requireAuth, async (req, res) => {
-    const data = req.body.date ? { ...req.body, date: new Date(req.body.date) } : req.body;
+    const data = req.body.date ? { ...req.body, date: toNoonUTC(req.body.date) } : req.body;
     const interaction = await storage.updateInteraction(parseInt(req.params.id), data);
     if (!interaction) return res.status(404).json({ message: "Interaction not found" });
     res.json(interaction);
@@ -131,7 +132,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   app.post("/api/followups", requireAuth, async (req, res) => {
-    const data = { ...req.body, dueDate: new Date(req.body.dueDate) };
+    const data = { ...req.body, dueDate: toNoonUTC(req.body.dueDate) };
     const parsed = insertFollowupSchema.safeParse(data);
     if (!parsed.success) return res.status(400).json({ message: parsed.error.message });
     const followup = await storage.createFollowup(parsed.data);
@@ -139,7 +140,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   app.put("/api/followups/:id", requireAuth, async (req, res) => {
-    const data = req.body.dueDate ? { ...req.body, dueDate: new Date(req.body.dueDate) } : req.body;
+    const data = req.body.dueDate ? { ...req.body, dueDate: toNoonUTC(req.body.dueDate) } : req.body;
     const followup = await storage.updateFollowup(parseInt(req.params.id), data);
     if (!followup) return res.status(404).json({ message: "Follow-up not found" });
     res.json(followup);
@@ -155,7 +156,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       await storage.createInteraction({
         contactId: followup.contactId,
         content: outcome.trim(),
-        date: new Date(),
+        date: toNoonUTC(new Date()),
         type: "note",
       });
     }

--- a/app/shared/dates.ts
+++ b/app/shared/dates.ts
@@ -1,0 +1,30 @@
+/**
+ * Normalize a date to noon UTC.
+ * Dates in the CRM are date-only — "April 15" not "April 15 at 3pm UTC".
+ * Storing at noon UTC ensures no timezone can shift it to the wrong day.
+ * Times (for meetings) are stored separately as display strings ("2:30 PM").
+ */
+export function toNoonUTC(input: string | Date): Date {
+  const d = new Date(input);
+  // If the input is just a date string like "2026-04-15" or "4/15",
+  // new Date() may parse it as midnight UTC. Shift to noon.
+  d.setUTCHours(12, 0, 0, 0);
+  return d;
+}
+
+/**
+ * Parse a date string that might be M/D or YYYY-MM-DD format.
+ * Returns a Date at noon UTC.
+ */
+export function parseDateToNoonUTC(dateStr: string): Date {
+  // M/D format (e.g., "4/15")
+  if (/^\d{1,2}\/\d{1,2}$/.test(dateStr)) {
+    const [month, day] = dateStr.split("/").map(Number);
+    const year = new Date().getFullYear();
+    const d = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+    if (d < new Date()) d.setUTCFullYear(year + 1);
+    return d;
+  }
+  // ISO or other format — normalize to noon
+  return toNoonUTC(dateStr);
+}


### PR DESCRIPTION
## Summary
Eliminates timezone as a concept from the CRM:
- All dates stored at noon UTC via `shared/dates.ts` — no timezone can shift them to the wrong day
- Meeting times stored as display strings ("2:30 PM") — no conversion, user's local time
- No settings page needed — complexity eliminated

Closes #10, closes #11

## Changes
- `shared/dates.ts` — new `toNoonUTC()` and `parseDateToNoonUTC()` helpers
- `server/routes.ts` — all date writes use `toNoonUTC()`
- `server/mcp-remote.ts` — interaction/followup creation uses noon UTC, guide updated
- `plugins/meetings/index.ts` — meeting date uses noon UTC
- `client/src/lib/utils.ts` — added `toNoonUTC()` for frontend

## Test plan
- [ ] Create interaction via MCP → date stored at noon UTC, renders as correct day
- [ ] Create follow-up for 4/15 → renders as 4/15 in any timezone
- [ ] Create meeting for 4/3 2:30 PM → date is 4/3, time shows "2:30 PM"

Generated with [Claude Code](https://claude.com/claude-code)