### PR TITLE
Fix Railway deploy: simplified railway.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - MCP sessions no longer expire after ~30 seconds. Sessions persist for 30 min of inactivity with automatic cleanup. (#9)
 - Dates stored as noon UTC to eliminate timezone off-by-one bugs. Times stored as display strings in user's local timezone. No timezone settings needed. (#10, closes #11)
 
+### Deploy Fix
+- Fixed Railway deploy crash: NIXPACKS builder used Node 18 which lacks `import.meta.dirname`. Simplified railway.json to let Railway auto-detect RAILPACK + Node 22.
+
 ### Header Icons
 - Rules: lightning bolt (Zap), Settings: gear, Activity: pulse, Logout: arrow
 - Rules is no longer a subset of Settings — separate icon and page

--- a/app/railway.json
+++ b/app/railway.json
@@ -1,12 +1,7 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
-  "build": {
-    "builder": "NIXPACKS"
-  },
   "deploy": {
-    "startCommand": "node dist/index.js",
     "healthcheckPath": "/api/config",
-    "restartPolicyType": "ON_FAILURE",
-    "preDeployCommand": "npx drizzle-kit push"
+    "restartPolicyType": "ON_FAILURE"
   }
 }


### PR DESCRIPTION
## Summary
Railway deploys failing — NIXPACKS builder used Node 18 which lacks import.meta.dirname.
Simplified railway.json to only healthcheck + restart policy. Let Railway auto-detect RAILPACK + Node 22.

Generated with [Claude Code](https://claude.com/claude-code)