### PR TITLE
Plugin badges + briefings page (#20)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"a5aa49af-0173-4b61-8295-bc144fe1491f","pid":23069,"acquiredAt":1774973825470}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 test-results/
 playwright-report/
 CLAUDE.local.md
+.claude/scheduled_tasks.lock
 seed-magnetic.ts
 current-crm-data.md
 .claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 - MCP sessions no longer expire after ~30 seconds. Sessions persist for 30 min of inactivity with automatic cleanup. (#9)
 - Dates stored as noon UTC to eliminate timezone off-by-one bugs. Times stored as display strings in user's local timezone. No timezone settings needed. (#10, closes #11)
 
+### Plugin Badges + Briefings Page
+- Plugin `badges` interface: plugins declare data keys, icons, and routes for contact card badges
+- Briefings plugin: 📋 badge on contacts with briefings, links to `/briefings/:contactId`
+- Briefings page: full-page view with upcoming meetings, editable content, create/edit flow
+- Keeps main notebook view clean — badges are small, content lives on its own page
+
 ### Deploy Fix
 - Fixed Railway deploy crash: NIXPACKS builder used Node 18 which lacks `import.meta.dirname`. Simplified railway.json to let Railway auto-detect RAILPACK + Node 22.
 

--- a/app/client/src/App.tsx
+++ b/app/client/src/App.tsx
@@ -14,16 +14,23 @@ import BriefingPage from "@/pages/briefing-page";
 import NotFound from "@/pages/not-found";
 
 // App config context — org name from DB
-const ConfigContext = createContext<{ orgName: string }>({ orgName: "Claw CRM" });
+export interface PluginBadge {
+  dataKey: string;
+  icon: string;
+  route: string;
+  tooltip?: string;
+}
+
+const ConfigContext = createContext<{ orgName: string; badges: PluginBadge[] }>({ orgName: "Claw CRM", badges: [] });
 export function useConfig() { return useContext(ConfigContext); }
 
 function ConfigProvider({ children }: { children: React.ReactNode }) {
-  const { data } = useQuery<{ orgName: string }>({
+  const { data } = useQuery<{ orgName: string; badges: PluginBadge[] }>({
     queryKey: ["/api/config"],
     staleTime: 60_000,
   });
   return (
-    <ConfigContext.Provider value={{ orgName: data?.orgName || "Claw CRM" }}>
+    <ConfigContext.Provider value={{ orgName: data?.orgName || "Claw CRM", badges: data?.badges || [] }}>
       {children}
     </ConfigContext.Provider>
   );

--- a/app/client/src/App.tsx
+++ b/app/client/src/App.tsx
@@ -10,6 +10,7 @@ import CrmPage from "@/pages/crm-page";
 import RulesPage from "@/pages/rules-page";
 import SettingsPage from "@/pages/settings-page";
 import AuthPage from "@/pages/auth-page";
+import BriefingPage from "@/pages/briefing-page";
 import NotFound from "@/pages/not-found";
 
 // App config context — org name from DB
@@ -34,6 +35,7 @@ function Router() {
       <ProtectedRoute path="/" component={CrmPage} />
       <ProtectedRoute path="/rules" component={RulesPage} />
       <ProtectedRoute path="/settings" component={SettingsPage} />
+      <ProtectedRoute path="/briefings/:contactId" component={BriefingPage} />
       <Route path="/auth" component={AuthPage} />
       <Route component={NotFound} />
     </Switch>

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -196,6 +196,11 @@ export function ContactBlock({
 
         {isStale && <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" style={{ color: C.stale }} />}
         {hasViolations && !isStale && <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" style={{ color: C.stale }} />}
+
+        {/* Plugin badges */}
+        {(contact as any).briefing && (
+          <a href={`/briefings/${contact.id}`} className="flex-shrink-0 hover:opacity-70 transition-colors" title="View briefing" style={{ fontSize: "14px" }}>📋</a>
+        )}
       </div>
 
       {/* Details preview — first two lines, then "more..." */}

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -3,6 +3,7 @@ import { format, isPast, isToday, differenceInDays } from "date-fns";
 import { ChevronDown, ChevronRight, Square, AlertTriangle, Trash2 } from "lucide-react";
 import type { ContactWithRelations } from "@shared/schema";
 import { fmtDate, fmtDateInput } from "@/lib/utils";
+import { useConfig } from "@/App";
 
 const STAGE_OPTIONS = ["LEAD", "MEETING", "PROPOSAL", "NEGOTIATION", "LIVE", "PASS", "RELATIONSHIP"] as const;
 
@@ -46,6 +47,7 @@ export function ContactBlock({
   onCreateFollowup, onUpdateFollowup, onDeleteFollowup, onCompleteFollowup,
   onUpdateContact,
 }: ContactBlockProps) {
+  const { badges: pluginBadges } = useConfig();
   const isInactive = contact.status !== "ACTIVE";
   const [isExpanded, setIsExpanded] = useState(!isInactive);
   const [showDetails, setShowDetails] = useState(false);
@@ -197,9 +199,11 @@ export function ContactBlock({
         {isStale && <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" style={{ color: C.stale }} />}
         {hasViolations && !isStale && <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" style={{ color: C.stale }} />}
 
-        {/* Plugin badges */}
-        {(contact as any).briefing && (
-          <a href={`/briefings/${contact.id}`} className="flex-shrink-0 hover:opacity-70 transition-colors" title="View briefing" style={{ fontSize: "14px" }}>📋</a>
+        {/* Plugin badges — rendered from plugin badge declarations */}
+        {pluginBadges.map((badge, i) =>
+          (contact as any)[badge.dataKey] ? (
+            <a key={i} href={badge.route.replace(":contactId", String(contact.id))} className="flex-shrink-0 hover:opacity-70 transition-colors" title={badge.tooltip || ""} style={{ fontSize: "14px" }}>{badge.icon}</a>
+          ) : null
         )}
       </div>
 

--- a/app/client/src/pages/briefing-page.tsx
+++ b/app/client/src/pages/briefing-page.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { apiRequest, queryClient } from "@/lib/queryClient";
+import { ArrowLeft } from "lucide-react";
+import { Link, useParams } from "wouter";
+import type { ContactWithRelations } from "@shared/schema";
+
+const C = {
+  text: "#1a2f2f", muted: "#5a7a7a", border: "#d4e8e8",
+  accent: "#2bbcb3", accentDark: "#1a9e96", accentLight: "#e6f7f6",
+};
+
+export default function BriefingPage() {
+  const params = useParams<{ contactId: string }>();
+  const contactId = parseInt(params.contactId || "0");
+
+  const { data: contact } = useQuery<ContactWithRelations>({
+    queryKey: [`/api/contacts/${contactId}`],
+    enabled: contactId > 0,
+  });
+
+  const briefing = (contact as any)?.briefing;
+  const [editing, setEditing] = useState(false);
+  const [content, setContent] = useState("");
+
+  // Init content from briefing
+  if (briefing && !editing && content !== briefing.content) {
+    setContent(briefing.content);
+  }
+
+  const saveBriefing = useMutation({
+    mutationFn: async (text: string) => {
+      const res = await apiRequest("PUT", `/api/briefings/${contactId}`, { content: text });
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/contacts/${contactId}`] });
+      queryClient.invalidateQueries({ queryKey: ["/api/contacts"] });
+      setEditing(false);
+    },
+  });
+
+  const contactName = contact ? `${contact.firstName} ${contact.lastName}` : "Loading...";
+  const companyName = contact?.company?.name || "";
+
+  // Find upcoming meetings for this contact
+  const upcomingMeetings = (contact?.followups || []).filter(
+    (f: any) => f.type === "meeting" && !f.completed && new Date(f.dueDate) >= new Date()
+  );
+
+  return (
+    <div className="min-h-screen" style={{ backgroundColor: "#f0f8f8" }}>
+      <header className="sticky top-0 z-50 bg-white" style={{ borderBottom: `1px solid ${C.border}` }}>
+        <div className="max-w-[640px] mx-auto px-4 py-3 flex items-center gap-3">
+          <Link href="/" className="transition-colors hover:opacity-70" style={{ color: C.muted }}>
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+          <div>
+            <h1 className="text-sm font-semibold" style={{ color: C.text }}>
+              {contactName}
+              {companyName && <span className="font-normal ml-1.5" style={{ color: C.muted }}>{companyName}</span>}
+            </h1>
+            <p className="text-[11px]" style={{ color: C.muted }}>Briefing</p>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-[640px] mx-auto px-4 py-5">
+        {/* Upcoming meetings */}
+        {upcomingMeetings.length > 0 && (
+          <div className="mb-4 text-xs" style={{ color: C.muted }}>
+            {upcomingMeetings.map((m: any) => (
+              <div key={m.id} className="flex items-center gap-1.5 mb-1">
+                <span>📅</span>
+                <span className="font-semibold" style={{ color: C.accentDark }}>
+                  {new Date(m.dueDate).toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" })}
+                  {m.time && ` ${m.time}`}
+                </span>
+                <span>{m.content}</span>
+                {m.location && <span style={{ color: C.muted }}>— {m.location}</span>}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Briefing content */}
+        <div className="bg-white" style={{ border: `1px solid ${C.border}`, borderRadius: "12px", padding: "1.25rem" }}>
+          {editing ? (
+            <div>
+              <textarea
+                autoFocus
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                className="w-full text-sm leading-relaxed rounded-lg p-3 outline-none resize-none min-h-[300px]"
+                style={{ color: C.text, backgroundColor: C.accentLight, border: `1px solid ${C.border}` }}
+                placeholder="Write your briefing here...&#10;&#10;Talking points:&#10;- &#10;&#10;Open items:&#10;- &#10;&#10;Notes:&#10;- "
+              />
+              <div className="flex gap-2 mt-3">
+                <button
+                  onClick={() => saveBriefing.mutate(content)}
+                  className="text-xs font-medium text-white px-3 py-1.5 rounded-lg"
+                  style={{ backgroundColor: C.accentDark }}
+                >Save</button>
+                <button
+                  onClick={() => { setEditing(false); setContent(briefing?.content || ""); }}
+                  className="text-xs px-3 py-1.5"
+                  style={{ color: C.muted }}
+                >Cancel</button>
+              </div>
+            </div>
+          ) : briefing ? (
+            <div>
+              <div
+                className="text-sm leading-relaxed whitespace-pre-wrap cursor-text"
+                style={{ color: C.text }}
+                onClick={() => setEditing(true)}
+              >
+                {briefing.content}
+              </div>
+              <div className="flex items-center justify-between mt-4 pt-3" style={{ borderTop: `1px dashed ${C.border}` }}>
+                <span className="text-[10px]" style={{ color: C.muted }}>
+                  Updated {new Date(briefing.updatedAt).toLocaleDateString()}
+                </span>
+                <button
+                  onClick={() => setEditing(true)}
+                  className="text-xs font-medium"
+                  style={{ color: C.accentDark }}
+                >Edit</button>
+              </div>
+            </div>
+          ) : (
+            <div className="text-center py-8">
+              <p className="text-sm mb-3" style={{ color: C.muted }}>No briefing yet</p>
+              <button
+                onClick={() => { setContent(""); setEditing(true); }}
+                className="text-xs font-medium text-white px-4 py-2 rounded-lg"
+                style={{ backgroundColor: C.accentDark }}
+              >Create Briefing</button>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/plugins/briefings/index.ts
+++ b/app/plugins/briefings/index.ts
@@ -69,6 +69,15 @@ const briefingsPlugin: CrmPlugin = {
     });
   },
 
+  badges: [
+    {
+      dataKey: "briefing",
+      icon: "📋",
+      route: "/briefings/:contactId",
+      tooltip: "View briefing",
+    },
+  ],
+
   async enrichContact(contactId, ctx) {
     const [briefing] = await ctx.db.select().from(briefings).where(eq(briefings.contactId, contactId));
     return { briefing: briefing ?? null };

--- a/app/plugins/index.ts
+++ b/app/plugins/index.ts
@@ -46,6 +46,18 @@ export interface CrmPlugin {
   /** Register new item types (tasks, meetings, etc.) */
   itemTypes?: ItemType[];
 
+  /** Badges shown on contact cards when plugin data exists */
+  badges?: Array<{
+    /** Data key to check on enriched contact (e.g., "briefing") */
+    dataKey: string;
+    /** Icon to show when data exists */
+    icon: string;
+    /** Route path to navigate to on click. Use :contactId as placeholder. */
+    route: string;
+    /** Tooltip text */
+    tooltip?: string;
+  }>;
+
   /** Guide text appended to get_crm_guide output. */
   guideText?: string;
 }

--- a/app/server/routes.ts
+++ b/app/server/routes.ts
@@ -23,7 +23,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // --- Public config (no auth — needed for login page branding) ---
   app.get("/api/config", async (_req, res) => {
     const user = await storage.getFirstUser();
-    res.json({ orgName: user?.orgName || "Claw CRM" });
+    const badges = getPlugins().flatMap(p => p.badges || []);
+    res.json({ orgName: user?.orgName || "Claw CRM", badges });
   });
 
   // --- Settings (auth required) ---


### PR DESCRIPTION
## Summary
Adds plugin badge system and a dedicated briefings page. Closes #20.

### Plugin badges
- New `badges` array on CrmPlugin interface: `dataKey`, `icon`, `route`, `tooltip`
- Core contact card renders badges when enriched data exists
- Small, unobtrusive — keeps the notebook view clean

### Briefings page (`/briefings/:contactId`)
- Full-page briefing view with contact header and upcoming meetings
- Click to edit inline, save/cancel
- Create briefing for contacts that don't have one
- 📋 badge appears on contact cards that have briefings

## Test plan
- [x] TypeScript passes
- [x] Briefings page renders at /briefings/:contactId
- [x] Badge only shows when contact has briefing data
- [x] Edit/create flow works

Generated with [Claude Code](https://claude.com/claude-code)