### PR TITLE
Customizable color scheme (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - MCP sessions no longer expire after ~30 seconds. Sessions persist for 30 min of inactivity with automatic cleanup. (#9)
 - Dates stored as noon UTC to eliminate timezone off-by-one bugs. Times stored as display strings in user's local timezone. No timezone settings needed. (#10, closes #11)
 
+### Customizable Color Scheme
+- Pick one primary color in Settings — UI derives accent dark, accent light, and background automatically
+- CSS custom properties (--accent, --accent-dark, --accent-light, --bg) set at runtime
+- Stored in DB, served via /api/config, persists across sessions
+
 ### Plugin Badges + Briefings Page
 - Plugin `badges` interface: plugins declare data keys, icons, and routes for contact card badges
 - Briefings plugin: 📋 badge on contacts with briefings, links to `/briefings/:contactId`

--- a/app/client/src/App.tsx
+++ b/app/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, createContext, useContext } from "react";
+import { useState, useEffect, createContext, useContext, useMemo } from "react";
 import { QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { queryClient } from "./lib/queryClient";
 import { Toaster } from "@/components/ui/toaster";
@@ -21,16 +21,44 @@ export interface PluginBadge {
   tooltip?: string;
 }
 
-const ConfigContext = createContext<{ orgName: string; badges: PluginBadge[] }>({ orgName: "Claw CRM", badges: [] });
+// Derive color variants from a hex primary color
+function deriveColors(hex: string) {
+  const r = parseInt(hex.slice(1, 3), 16), g = parseInt(hex.slice(3, 5), 16), b = parseInt(hex.slice(5, 7), 16);
+  const darken = (amt: number) => `#${[r,g,b].map(c => Math.max(0, Math.round(c * (1 - amt))).toString(16).padStart(2, "0")).join("")}`;
+  const lighten = (amt: number) => `#${[r,g,b].map(c => Math.min(255, Math.round(c + (255 - c) * amt)).toString(16).padStart(2, "0")).join("")}`;
+  return {
+    accent: hex,
+    accentDark: darken(0.15),
+    accentLight: lighten(0.9),
+    bg: lighten(0.95),
+  };
+}
+
+interface AppConfig { orgName: string; primaryColor: string; badges: PluginBadge[]; colors: ReturnType<typeof deriveColors> }
+
+const defaultColors = deriveColors("#2bbcb3");
+const ConfigContext = createContext<AppConfig>({ orgName: "Claw CRM", primaryColor: "#2bbcb3", badges: [], colors: defaultColors });
 export function useConfig() { return useContext(ConfigContext); }
 
 function ConfigProvider({ children }: { children: React.ReactNode }) {
-  const { data } = useQuery<{ orgName: string; badges: PluginBadge[] }>({
+  const { data } = useQuery<{ orgName: string; primaryColor: string; badges: PluginBadge[] }>({
     queryKey: ["/api/config"],
     staleTime: 60_000,
   });
+  const primaryColor = data?.primaryColor || "#2bbcb3";
+  const colors = deriveColors(primaryColor);
+
+  // Set CSS custom properties on document root
+  useEffect(() => {
+    const root = document.documentElement;
+    root.style.setProperty("--accent", colors.accent);
+    root.style.setProperty("--accent-dark", colors.accentDark);
+    root.style.setProperty("--accent-light", colors.accentLight);
+    root.style.setProperty("--bg", colors.bg);
+  }, [colors]);
+
   return (
-    <ConfigContext.Provider value={{ orgName: data?.orgName || "Claw CRM", badges: data?.badges || [] }}>
+    <ConfigContext.Provider value={{ orgName: data?.orgName || "Claw CRM", primaryColor, badges: data?.badges || [], colors }}>
       {children}
     </ConfigContext.Provider>
   );

--- a/app/client/src/pages/settings-page.tsx
+++ b/app/client/src/pages/settings-page.tsx
@@ -10,20 +10,25 @@ const C = {
 };
 
 export default function SettingsPage() {
-  const { data: settings } = useQuery<{ orgName: string; apiKey: string; mcpToken: string }>({
+  const { data: settings } = useQuery<{ orgName: string; primaryColor: string; apiKey: string; mcpToken: string }>({
     queryKey: ["/api/settings"],
   });
 
   const [orgName, setOrgName] = useState("");
   const [orgNameDirty, setOrgNameDirty] = useState(false);
+  const [primaryColor, setPrimaryColor] = useState("#2bbcb3");
+  const [colorDirty, setColorDirty] = useState(false);
   const [currentPin, setCurrentPin] = useState("");
   const [newPin, setNewPin] = useState("");
   const [pinMessage, setPinMessage] = useState("");
   const [copied, setCopied] = useState<string | null>(null);
 
-  // Initialize orgName from settings
+  // Initialize from settings
   if (settings && !orgNameDirty && orgName !== settings.orgName) {
     setOrgName(settings.orgName);
+  }
+  if (settings && !colorDirty && primaryColor !== settings.primaryColor) {
+    setPrimaryColor(settings.primaryColor);
   }
 
   const updateOrgName = useMutation({
@@ -35,6 +40,18 @@ export default function SettingsPage() {
       queryClient.invalidateQueries({ queryKey: ["/api/settings"] });
       queryClient.invalidateQueries({ queryKey: ["/api/config"] });
       setOrgNameDirty(false);
+    },
+  });
+
+  const updateColor = useMutation({
+    mutationFn: async (color: string) => {
+      const res = await apiRequest("PUT", "/api/settings", { primaryColor: color });
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/settings"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/config"] });
+      setColorDirty(false);
     },
   });
 
@@ -100,6 +117,34 @@ export default function SettingsPage() {
             <button
               onClick={() => updateOrgName.mutate(orgName)}
               disabled={!orgNameDirty}
+              className="text-xs font-medium text-white px-3 py-1.5 rounded-lg disabled:opacity-40"
+              style={{ backgroundColor: C.accentDark }}
+            >Save</button>
+          </div>
+        </div>
+
+        {/* Brand Color */}
+        <div className="bg-white" style={{ border: `1px solid ${C.border}`, borderRadius: "12px", padding: "1rem 1.25rem" }}>
+          <label className="text-xs font-semibold uppercase tracking-wider" style={{ color: C.muted }}>Brand Color</label>
+          <p className="text-[11px] mt-0.5 mb-2" style={{ color: C.muted }}>Pick a primary color. The UI adapts automatically.</p>
+          <div className="flex items-center gap-3">
+            <input
+              type="color"
+              value={primaryColor}
+              onChange={(e) => { setPrimaryColor(e.target.value); setColorDirty(true); }}
+              className="w-10 h-10 rounded-lg cursor-pointer border-0"
+              style={{ backgroundColor: primaryColor }}
+            />
+            <input
+              value={primaryColor}
+              onChange={(e) => { setPrimaryColor(e.target.value); setColorDirty(true); }}
+              className="text-sm font-mono rounded-lg px-3 py-1.5 outline-none w-24"
+              style={{ border: `1px solid ${C.border}`, color: C.text }}
+            />
+            <div className="flex-1 h-8 rounded-lg" style={{ background: `linear-gradient(135deg, ${primaryColor}, ${primaryColor}dd)` }} />
+            <button
+              onClick={() => updateColor.mutate(primaryColor)}
+              disabled={!colorDirty}
               className="text-xs font-medium text-white px-3 py-1.5 rounded-lg disabled:opacity-40"
               style={{ backgroundColor: C.accentDark }}
             >Save</button>

--- a/app/server/routes.ts
+++ b/app/server/routes.ts
@@ -24,7 +24,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/config", async (_req, res) => {
     const user = await storage.getFirstUser();
     const badges = getPlugins().flatMap(p => p.badges || []);
-    res.json({ orgName: user?.orgName || "Claw CRM", badges });
+    res.json({ orgName: user?.orgName || "Claw CRM", primaryColor: user?.primaryColor || "#2bbcb3", badges });
   });
 
   // --- Settings (auth required) ---
@@ -33,6 +33,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     if (!user) return res.status(404).json({ message: "No user" });
     res.json({
       orgName: user.orgName,
+      primaryColor: user.primaryColor,
       apiKey: user.apiKey,
       mcpToken: user.mcpToken,
     });
@@ -41,9 +42,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.put("/api/settings", requireAuth, async (req, res) => {
     const user = await storage.getFirstUser();
     if (!user) return res.status(404).json({ message: "No user" });
-    const { orgName } = req.body;
+    const { orgName, primaryColor } = req.body;
     const updates: any = {};
     if (orgName !== undefined) updates.orgName = orgName;
+    if (primaryColor !== undefined) updates.primaryColor = primaryColor;
     const updated = await storage.updateUser(user.id, updates);
     res.json({ orgName: updated?.orgName });
   });

--- a/app/server/storage.ts
+++ b/app/server/storage.ts
@@ -73,7 +73,7 @@ export class Storage {
     return user;
   }
 
-  async updateUser(id: number, data: Partial<{ pin: string; apiKey: string; mcpToken: string; orgName: string }>): Promise<User | undefined> {
+  async updateUser(id: number, data: Partial<{ pin: string; apiKey: string; mcpToken: string; orgName: string; primaryColor: string }>): Promise<User | undefined> {
     const [user] = await db.update(users).set(data).where(eq(users.id, id)).returning();
     return user;
   }

--- a/app/shared/schema.ts
+++ b/app/shared/schema.ts
@@ -9,6 +9,7 @@ export const users = pgTable("users", {
   apiKey: text("api_key").notNull(),
   mcpToken: text("mcp_token").notNull().default(""),
   orgName: text("org_name").notNull().default("Claw CRM"),
+  primaryColor: text("primary_color").notNull().default("#2bbcb3"),
   createdAt: timestamp("created_at").notNull().defaultNow(),
 });
 


### PR DESCRIPTION
## Summary
One color picker in Settings → full UI adapts. Partially addresses #22 (color scheme only, icon is separate).

- User picks primary color → system derives accent dark (-15%), accent light (+90%), background (+95%)
- CSS custom properties set at runtime via useEffect on document root
- Stored in DB (users.primaryColor), served via /api/config
- Color picker with hex input and live gradient preview in Settings

## Test plan
- [x] TypeScript passes
- [x] Color picker visible in Settings
- [x] Changing color updates CSS custom properties

Generated with [Claude Code](https://claude.com/claude-code)