### PR TITLE
Configurable upcoming window (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2026-04-01
 
+### Configurable Upcoming Window (#28)
+- Inline day toggle (1d / 2d / 3d / 7d / 14d) in the Upcoming section header
+- Preference saved to DB via `/api/settings` and served via `/api/config`
+- Defaults to 7 days; switching filters upcoming items instantly
+
 ### Claw Icon + Dynamic Color Cleanup (#22)
 - Added Claw mark icon (three diagonal slashes): SVG favicon, PWA icons (192px, 512px), Apple touch icon
 - All hardcoded color constants (`C = {...}`) replaced with `useColors()` hook — UI now fully adapts to the user's chosen primary color

--- a/app/client/src/App.tsx
+++ b/app/client/src/App.tsx
@@ -35,10 +35,10 @@ function deriveColors(hex: string) {
   };
 }
 
-interface AppConfig { orgName: string; primaryColor: string; badges: PluginBadge[]; colors: ReturnType<typeof deriveColors> }
+interface AppConfig { orgName: string; primaryColor: string; upcomingDays: number; badges: PluginBadge[]; colors: ReturnType<typeof deriveColors> }
 
 const defaultColors = deriveColors("#2bbcb3");
-const ConfigContext = createContext<AppConfig>({ orgName: "Claw CRM", primaryColor: "#2bbcb3", badges: [], colors: defaultColors });
+const ConfigContext = createContext<AppConfig>({ orgName: "Claw CRM", primaryColor: "#2bbcb3", upcomingDays: 7, badges: [], colors: defaultColors });
 export function useConfig() { return useContext(ConfigContext); }
 
 // Static palette colors that don't change with the primary color
@@ -54,7 +54,7 @@ export function useColors() {
 }
 
 function ConfigProvider({ children }: { children: React.ReactNode }) {
-  const { data } = useQuery<{ orgName: string; primaryColor: string; badges: PluginBadge[] }>({
+  const { data } = useQuery<{ orgName: string; primaryColor: string; upcomingDays: number; badges: PluginBadge[] }>({
     queryKey: ["/api/config"],
     staleTime: 60_000,
   });
@@ -71,7 +71,7 @@ function ConfigProvider({ children }: { children: React.ReactNode }) {
   }, [colors]);
 
   return (
-    <ConfigContext.Provider value={{ orgName: data?.orgName || "Claw CRM", primaryColor, badges: data?.badges || [], colors }}>
+    <ConfigContext.Provider value={{ orgName: data?.orgName || "Claw CRM", primaryColor, upcomingDays: data?.upcomingDays ?? 7, badges: data?.badges || [], colors }}>
       {children}
     </ConfigContext.Provider>
   );

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useCrm } from "@/hooks/use-crm";
 import { useSSE } from "@/hooks/use-sse";
 import { useAuth } from "@/hooks/use-auth";
@@ -36,8 +37,17 @@ export default function CrmPage() {
   const { contacts, isLoading, addInteraction, updateInteraction, deleteInteraction, createFollowup, updateFollowup, deleteFollowup, completeFollowup, updateContact } = useCrm();
   const { logoutMutation } = useAuth();
   const [activeStage, setActiveStage] = useState<string>("ALL");
-  const { orgName } = useConfig();
+  const { orgName, upcomingDays: configDays } = useConfig();
+  const [localDays, setLocalDays] = useState<number | null>(null);
+  const days = localDays ?? configDays;
   useSSE();
+
+  const saveDays = useMutation({
+    mutationFn: async (d: number) => {
+      await apiRequest("PUT", "/api/settings", { upcomingDays: d });
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["/api/config"] }),
+  });
 
   const sortedContacts = useMemo(() => {
     const sorted = [...contacts].sort((a, b) => {
@@ -73,21 +83,21 @@ export default function CrmPage() {
     return counts;
   }, [contacts]);
 
-  // Follow-ups due within 7 days (including overdue), sorted by due date
+  // Follow-ups due within N days (including overdue), sorted by due date
   const allFollowups = useMemo(() => {
-    const sevenDaysOut = new Date();
-    sevenDaysOut.setDate(sevenDaysOut.getDate() + 7);
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() + days);
     const fus: Array<{ followup: Followup; contactName: string; contactId: number }> = [];
     for (const c of contacts) {
       for (const fu of c.followups) {
-        if (!fu.completed && new Date(fu.dueDate) <= sevenDaysOut) {
+        if (!fu.completed && new Date(fu.dueDate) <= cutoff) {
           fus.push({ followup: fu, contactName: `${c.firstName} ${c.lastName}`, contactId: c.id });
         }
       }
     }
     fus.sort((a, b) => new Date(a.followup.dueDate).getTime() - new Date(b.followup.dueDate).getTime());
     return fus;
-  }, [contacts]);
+  }, [contacts, days]);
 
   const [completingUpcomingId, setCompletingUpcomingId] = useState<number | null>(null);
   const [completingUpcomingText, setCompletingUpcomingText] = useState("");
@@ -264,11 +274,26 @@ export default function CrmPage() {
           </div>
         )}
 
-        {/* Upcoming tasks — next 7 days + overdue */}
+        {/* Upcoming tasks — configurable window + overdue */}
         {allFollowups.length > 0 && (
           <div className="bg-white mb-5" style={{ border: `1px solid ${C.border}`, borderRadius: "12px", padding: "1rem 1.25rem" }}>
-            <div className="text-xs font-semibold uppercase tracking-wider mb-2" style={{ color: C.muted }}>
-              Upcoming
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: C.muted }}>Upcoming</span>
+              <div className="flex items-center gap-0.5">
+                {[1, 2, 3, 7, 14].map((d) => (
+                  <button
+                    key={d}
+                    onClick={() => { setLocalDays(d); saveDays.mutate(d); }}
+                    className="px-1.5 py-0.5 rounded text-[10px] font-medium transition-colors"
+                    style={{
+                      backgroundColor: days === d ? C.accent : "transparent",
+                      color: days === d ? "white" : C.muted,
+                    }}
+                  >
+                    {d}d
+                  </button>
+                ))}
+              </div>
             </div>
             <div className="space-y-1.5">
               {allFollowups.map(({ followup: fu, contactName }) => {

--- a/app/server/routes.ts
+++ b/app/server/routes.ts
@@ -24,7 +24,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/config", async (_req, res) => {
     const user = await storage.getFirstUser();
     const badges = getPlugins().flatMap(p => p.badges || []);
-    res.json({ orgName: user?.orgName || "Claw CRM", primaryColor: user?.primaryColor || "#2bbcb3", badges });
+    res.json({ orgName: user?.orgName || "Claw CRM", primaryColor: user?.primaryColor || "#2bbcb3", upcomingDays: user?.upcomingDays ?? 7, badges });
   });
 
   // --- Settings (auth required) ---
@@ -34,6 +34,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     res.json({
       orgName: user.orgName,
       primaryColor: user.primaryColor,
+      upcomingDays: user.upcomingDays,
       apiKey: user.apiKey,
       mcpToken: user.mcpToken,
     });
@@ -42,10 +43,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.put("/api/settings", requireAuth, async (req, res) => {
     const user = await storage.getFirstUser();
     if (!user) return res.status(404).json({ message: "No user" });
-    const { orgName, primaryColor } = req.body;
+    const { orgName, primaryColor, upcomingDays } = req.body;
     const updates: any = {};
     if (orgName !== undefined) updates.orgName = orgName;
     if (primaryColor !== undefined) updates.primaryColor = primaryColor;
+    if (upcomingDays !== undefined) updates.upcomingDays = upcomingDays;
     const updated = await storage.updateUser(user.id, updates);
     res.json({ orgName: updated?.orgName });
   });

--- a/app/shared/schema.ts
+++ b/app/shared/schema.ts
@@ -10,6 +10,7 @@ export const users = pgTable("users", {
   mcpToken: text("mcp_token").notNull().default(""),
   orgName: text("org_name").notNull().default("Claw CRM"),
   primaryColor: text("primary_color").notNull().default("#2bbcb3"),
+  upcomingDays: integer("upcoming_days").notNull().default(7),
   createdAt: timestamp("created_at").notNull().defaultNow(),
 });
 


### PR DESCRIPTION
## Summary
- Inline day toggle (1d / 2d / 3d / 7d / 14d) next to "Upcoming" header — one click to filter
- Preference saved to DB (`upcomingDays` column on users table) via `PUT /api/settings`
- Served via `/api/config` so it loads on page refresh
- Defaults to 7 days; instant filtering on toggle click

## Test plan
- [x] Playwright CI tests pass (7/7)
- [x] Headless E2E: toggle visible, 2d filters to fewer items, 7d shows full list
- [x] API round-trip: `PUT /api/settings {upcomingDays: 3}` → `GET /api/config` returns 3
- [x] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)