### PR TITLE
Remove redundant MCP tools (get_dashboard, get_pipeline, get_activity_log)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 2026-04-06
 
+### Remove redundant MCP tools
+- Cut `get_dashboard` (data available via `search_contacts`)
+- Cut `get_pipeline` (data available via `search_contacts` with stage filter)
+- Cut `get_activity_log` (debugging tool, not an agent action)
+- Removed from all 3 MCP servers (remote, stdio, client)
+- REST API endpoints (`/api/dashboard`, `/api/activity`) unchanged — UI still uses them
+
 ### Remove plugin system — flatten into core (#35)
 - Removed the `plugins/` directory and `CrmPlugin` abstraction entirely
 - Meetings routes, briefings routes, activity log routes inlined into `server/routes.ts`

--- a/README.md
+++ b/README.md
@@ -87,15 +87,13 @@ curl -H "X-API-Key: <key>" https://your-domain.com/api/contacts
 | `set_followup` | Create a follow-up task with due date |
 | `complete_followup` | Mark done + log outcome to timeline |
 | `delete_followup` | Remove a task without completing it |
-| `get_pipeline` | Contacts grouped by stage |
-| `get_dashboard` | Summary: active count, overdue follow-ups, violations |
 | `list_rules` | All business rules |
 | `create_rule` | Add a business rule |
 | `update_rule` | Modify rule logic, params, exceptions, or enable/disable |
 | `delete_rule` | Remove a rule |
 | `list_violations` | Active rule violations |
 
-Additional tools: `set_meeting`, `get_upcoming_meetings`, `cancel_meeting`, `save_briefing`, `get_briefing`, `get_activity_log`.
+Additional tools: `set_meeting`, `get_upcoming_meetings`, `cancel_meeting`, `save_briefing`, `get_briefing`.
 
 ---
 

--- a/app/server/mcp-client.ts
+++ b/app/server/mcp-client.ts
@@ -84,26 +84,6 @@ server.tool(
 );
 
 server.tool(
-  "get_pipeline",
-  "Get contacts grouped by pipeline stage with counts",
-  {},
-  async () => {
-    const pipeline = await api("GET", "/api/pipeline");
-    return { content: [{ type: "text" as const, text: JSON.stringify(pipeline, null, 2) }] };
-  }
-);
-
-server.tool(
-  "get_dashboard",
-  "Get CRM dashboard summary: pipeline counts, overdue follow-ups, stale contacts, recent activity",
-  {},
-  async () => {
-    const dashboard = await api("GET", "/api/dashboard");
-    return { content: [{ type: "text" as const, text: JSON.stringify(dashboard, null, 2) }] };
-  }
-);
-
-server.tool(
   "list_violations",
   "Get all active rule violations",
   { severity: z.string().optional().describe("Filter by severity") },

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -3,9 +3,9 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { z } from "zod";
 import { storage } from "./storage";
 import { toNoonUTC, parseDateToNoonUTC } from "@shared/dates";
-import { briefings, activityLog, followups } from "@shared/schema";
+import { briefings, followups } from "@shared/schema";
 import { db } from "./db";
-import { eq, and, isNull, gte, lte, asc, desc } from "drizzle-orm";
+import { eq, and, isNull, gte, lte, asc } from "drizzle-orm";
 import { sseManager } from "./sse";
 import type { Express, Request, Response } from "express";
 import { randomUUID } from "crypto";
@@ -100,9 +100,6 @@ After a meeting happens, log it as an interaction with add_interaction.
 Use save_briefing to store prep notes for a contact (one per contact, upsert).
 Good for: talking points, recent news, open items before a meeting.
 
-## Activity Log
-Use get_activity_log to see what the system and agents have been doing.
-Useful for troubleshooting: rule evaluations, agent actions, violations, meeting scheduling.
 
 ## Confidentiality
 - NEVER put pricing or deal terms in the CRM
@@ -136,26 +133,6 @@ Useful for troubleshooting: rule evaluations, agent actions, violations, meeting
       return { content: [{ type: "text" as const, text: JSON.stringify(contact, null, 2) }] };
     } catch (err: any) {
       return { content: [{ type: "text" as const, text: `Error reading contact ${contactId}: ${err.message}` }], isError: true };
-    }
-  });
-
-  server.tool("get_pipeline", "Contacts grouped by stage", {}, async () => {
-    try {
-      const pipeline = await storage.getPipeline();
-      return { content: [{ type: "text" as const, text: JSON.stringify(pipeline, null, 2) }] };
-    } catch (err: any) {
-      return { content: [{ type: "text" as const, text: `Error: ${err.message}` }], isError: true };
-    }
-  });
-
-  server.tool("get_dashboard", "CRM summary", {}, async () => {
-    try {
-      const [contacts, overdue, violations, pipeline] = await Promise.all([storage.getContacts(), storage.getOverdueFollowups(), storage.getViolations(), storage.getPipeline()]);
-      const stageCounts: Record<string, number> = {};
-      for (const [s, c] of Object.entries(pipeline)) stageCounts[s] = c.length;
-      return { content: [{ type: "text" as const, text: JSON.stringify({ totalContacts: contacts.length, activeContacts: contacts.filter(c => c.status === "ACTIVE").length, overdueFollowups: overdue.length, activeViolations: violations.length, stageCounts }, null, 2) }] };
-    } catch (err: any) {
-      return { content: [{ type: "text" as const, text: `Error: ${err.message}` }], isError: true };
     }
   });
 
@@ -442,25 +419,6 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
       const [b] = await db.select().from(briefings).where(eq(briefings.contactId, contactId));
       if (!b) return { content: [{ type: "text" as const, text: `No briefing for contact ${contactId}` }] };
       return { content: [{ type: "text" as const, text: b.content }] };
-    } catch (err: any) { return { content: [{ type: "text" as const, text: `Error: ${err.message}` }], isError: true }; }
-  });
-
-  // --- Activity Log ---
-  server.tool("get_activity_log", "View the system activity log. Shows rule evaluations, agent actions, violations. Useful for troubleshooting.", {
-    limit: z.number().optional().describe("Max entries. Default 50"),
-    contactId: z.number().optional(),
-    event: z.string().optional().describe("Filter: rule.evaluated, meeting.created, contact.updated, violation.created, etc."),
-    source: z.string().optional().describe("Filter: system, agent, user, rule:N"),
-  }, async ({ limit, contactId, event, source }) => {
-    try {
-      const conditions = [];
-      if (contactId) conditions.push(eq(activityLog.contactId, contactId));
-      if (event) conditions.push(eq(activityLog.event, event));
-      if (source) conditions.push(eq(activityLog.source, source));
-      let query = db.select().from(activityLog).orderBy(desc(activityLog.createdAt));
-      if (conditions.length > 0) query = query.where(and(...conditions)) as any;
-      const result = await (query as any).limit(limit || 50);
-      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
     } catch (err: any) { return { content: [{ type: "text" as const, text: `Error: ${err.message}` }], isError: true }; }
   });
 

--- a/app/server/mcp-server.ts
+++ b/app/server/mcp-server.ts
@@ -65,67 +65,6 @@ server.tool(
 );
 
 server.tool(
-  "get_pipeline",
-  "Get contacts grouped by pipeline stage with counts",
-  {},
-  async () => {
-    const pipeline = await storage.getPipeline();
-    const result: Record<string, any> = {};
-    for (const [stage, stageContacts] of Object.entries(pipeline)) {
-      result[stage] = {
-        count: stageContacts.length,
-        contacts: stageContacts.map((c) => ({
-          id: c.id,
-          name: `${c.firstName} ${c.lastName}`,
-          company: null as string | null, // Will be enriched below
-          status: c.status,
-        })),
-      };
-    }
-    return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
-  }
-);
-
-server.tool(
-  "get_dashboard",
-  "Get CRM dashboard summary: pipeline counts, overdue follow-ups, stale contacts, recent activity",
-  {},
-  async () => {
-    const [allContacts, overdueFollowups, violations, pipeline] = await Promise.all([
-      storage.getContacts(),
-      storage.getOverdueFollowups(),
-      storage.getViolations(),
-      storage.getPipeline(),
-    ]);
-
-    const stageCounts: Record<string, number> = {};
-    for (const [stage, stageContacts] of Object.entries(pipeline)) {
-      stageCounts[stage] = stageContacts.length;
-    }
-
-    const result = {
-      totalContacts: allContacts.length,
-      activeContacts: allContacts.filter((c) => c.status === "ACTIVE").length,
-      overdueFollowups: overdueFollowups.map((f) => ({
-        id: f.id,
-        contactId: f.contactId,
-        dueDate: f.dueDate,
-        content: f.content,
-      })),
-      activeViolations: violations.map((v) => ({
-        id: v.id,
-        contactId: v.contactId,
-        message: v.message,
-        severity: v.severity,
-      })),
-      stageCounts,
-    };
-
-    return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
-  }
-);
-
-server.tool(
   "list_violations",
   "Get all active rule violations",
   { severity: z.string().optional().describe("Filter by severity (info, warning, critical)") },


### PR DESCRIPTION
## Summary
- Removed 3 redundant MCP tools from all 3 MCP servers (remote, stdio, client)
- `get_dashboard` — data available via `search_contacts`
- `get_pipeline` — data available via `search_contacts` with stage filter
- `get_activity_log` — debugging tool, not an agent action
- REST API endpoints (`/api/dashboard`, `/api/activity`) unchanged — UI still uses them
- 25 → 22 MCP tools

## Test plan
- [x] `npm run build` passes
- [ ] Call remaining MCP tools to verify they work
- [ ] Verify `/api/dashboard` REST endpoint still works (UI uses it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)