### PR TITLE
Add Kanban board view with drag-and-drop (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-04-09
+
+### Add Kanban board view (#38)
+- New toggleable Kanban view alongside existing list view (icon toggle in header)
+- Desktop: full-width columns per pipeline stage with drag-and-drop contact cards
+- Mobile (<768px): compact horizontal swimlane strips with pill-shaped tiles
+- Drag-and-drop between stages updates contact via API with optimistic updates
+- HOLD contacts excluded from Kanban view; view preference saved to localStorage
+- New dependencies: @dnd-kit/core, @dnd-kit/sortable, @dnd-kit/utilities
+
 ## 2026-04-06
 
 ### Remove redundant MCP tools

--- a/app/client/src/components/kanban/kanban-board.tsx
+++ b/app/client/src/components/kanban/kanban-board.tsx
@@ -1,0 +1,132 @@
+import { useState, useMemo, useEffect, Fragment } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragStartEvent,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { KanbanColumn } from "./kanban-column";
+import { KanbanCard } from "./kanban-card";
+import type { ContactWithRelations } from "@shared/schema";
+import type { UseMutationResult } from "@tanstack/react-query";
+
+const COLUMN_ORDER = ["LEAD", "MEETING", "PROPOSAL", "NEGOTIATION", "LIVE", "RELATIONSHIP", "PASS"];
+
+const STAGE_ACCENT: Record<string, string> = {
+  LIVE: "#2e7d32",
+  NEGOTIATION: "#d4880f",
+  PROPOSAL: "#2563eb",
+  MEETING: "#2bbcb3",
+  LEAD: "#5a7a7a",
+  PASS: "#c0392b",
+  RELATIONSHIP: "#1a9e96",
+};
+
+function useIsMobile(breakpoint = 768) {
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < breakpoint);
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [breakpoint]);
+  return isMobile;
+}
+
+interface KanbanBoardProps {
+  contacts: ContactWithRelations[];
+  updateContact: UseMutationResult<unknown, Error, { id: number } & Record<string, unknown>>;
+}
+
+export function KanbanBoard({ contacts, updateContact }: KanbanBoardProps) {
+  const [activeId, setActiveId] = useState<number | null>(null);
+  const isMobile = useIsMobile();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+  );
+
+  const grouped = useMemo(() => {
+    const map: Record<string, ContactWithRelations[]> = {};
+    for (const stage of COLUMN_ORDER) map[stage] = [];
+    for (const c of contacts) {
+      if (map[c.stage]) map[c.stage].push(c);
+    }
+    return map;
+  }, [contacts]);
+
+  const activeContact = useMemo(
+    () => (activeId ? contacts.find((c) => c.id === activeId) : undefined),
+    [activeId, contacts],
+  );
+
+  function handleDragStart(event: DragStartEvent) {
+    setActiveId(event.active.id as number);
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    setActiveId(null);
+    if (!over) return;
+
+    const contactId = active.id as number;
+    const contact = contacts.find((c) => c.id === contactId);
+    if (!contact) return;
+
+    const targetStage = (over.data.current?.stage as string) || (over.id as string);
+    if (contact.stage === targetStage) return;
+    if (!COLUMN_ORDER.includes(targetStage)) return;
+
+    updateContact.mutate({ id: contactId, stage: targetStage });
+  }
+
+  return (
+    <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      {isMobile ? (
+        /* Mobile: vertical swimlane strips */
+        <div className="flex flex-col gap-1.5 px-3 py-3">
+          {COLUMN_ORDER.map((stage) => (
+            <Fragment key={stage}>
+              <KanbanColumn
+                stage={stage}
+                contacts={grouped[stage]}
+                accentColor={STAGE_ACCENT[stage] || "#5a7a7a"}
+                compact
+              />
+              {stage === "LIVE" && (
+                <hr className="border-0 my-1" style={{ borderTop: "1px solid #d4e8e830" }} />
+              )}
+            </Fragment>
+          ))}
+        </div>
+      ) : (
+        /* Desktop: horizontal columns */
+        <div className="flex gap-3 overflow-x-auto px-4 py-4" style={{ minHeight: "calc(100vh - 120px)" }}>
+          {COLUMN_ORDER.map((stage) => (
+            <KanbanColumn
+              key={stage}
+              stage={stage}
+              contacts={grouped[stage]}
+              accentColor={STAGE_ACCENT[stage] || "#5a7a7a"}
+            />
+          ))}
+        </div>
+      )}
+      <DragOverlay>
+        {activeContact ? (
+          <KanbanCard
+            contact={activeContact}
+            accentColor={STAGE_ACCENT[activeContact.stage] || "#5a7a7a"}
+            isDragOverlay
+            compact={isMobile}
+          />
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  );
+}

--- a/app/client/src/components/kanban/kanban-card.tsx
+++ b/app/client/src/components/kanban/kanban-card.tsx
@@ -1,0 +1,106 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useColors } from "@/App";
+import { fmtDate } from "@/lib/utils";
+import type { ContactWithRelations } from "@shared/schema";
+
+interface KanbanCardProps {
+  contact: ContactWithRelations;
+  accentColor: string;
+  isDragOverlay?: boolean;
+  compact?: boolean;
+}
+
+export function KanbanCard({ contact, accentColor, isDragOverlay, compact }: KanbanCardProps) {
+  const C = useColors();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: contact.id, data: { stage: contact.stage } });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  const nextItem = contact.followups
+    .filter((f) => !f.completed && !f.cancelledAt)
+    .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime())[0];
+
+  const initials = `${contact.firstName[0]}${contact.lastName[0]}`;
+
+  const companyFirstWord = contact.company?.name?.split(/\s+/)[0] || "";
+
+  // Compact pill for mobile swimlanes
+  if (compact) {
+    const bubble = (
+      <div
+        className="flex-shrink-0 select-none cursor-grab active:cursor-grabbing"
+        style={{ opacity: isDragging ? 0.4 : 1 }}
+      >
+        <div
+          className="flex flex-col justify-center overflow-hidden"
+          style={{
+            width: 72,
+            height: 36,
+            borderRadius: 10,
+            padding: "4px 8px",
+            background: `linear-gradient(135deg, ${accentColor}18, ${accentColor}06)`,
+            border: `1.5px solid ${accentColor}30`,
+            boxShadow: isDragOverlay ? `0 8px 24px ${accentColor}30` : "none",
+            transition: "border-color 0.2s, box-shadow 0.2s",
+          }}
+        >
+          <span className="text-[10px] font-bold leading-none overflow-hidden whitespace-nowrap" style={{ color: accentColor }}>
+            {contact.firstName}
+          </span>
+          <span className="text-[9px] leading-none mt-0.5 overflow-hidden whitespace-nowrap" style={{ color: C.muted }}>
+            {companyFirstWord}
+          </span>
+        </div>
+      </div>
+    );
+
+    if (isDragOverlay) return bubble;
+
+    return (
+      <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+        {bubble}
+      </div>
+    );
+  }
+
+  // Full desktop card
+  const cardContent = (
+    <div
+      className="bg-white rounded-xl px-3 py-2.5 mb-2 cursor-grab active:cursor-grabbing select-none"
+      style={{
+        border: `1px solid ${C.border}`,
+        boxShadow: isDragOverlay ? "0 8px 24px rgba(0,0,0,0.15)" : "0 1px 3px rgba(0,0,0,0.04)",
+      }}
+    >
+      <div className="text-sm font-semibold truncate" style={{ color: C.text }}>
+        {contact.firstName} {contact.lastName}
+      </div>
+      {contact.company && (
+        <div className="text-xs truncate mt-0.5" style={{ color: C.muted }}>
+          {contact.company.name}
+        </div>
+      )}
+      {nextItem && (
+        <div className="mt-2 flex items-center gap-1.5 text-[11px]" style={{ color: accentColor }}>
+          <span>{nextItem.type === "meeting" ? "📅" : "☐"}</span>
+          <span className="font-medium">{fmtDate(new Date(nextItem.dueDate))}</span>
+          <span className="truncate" style={{ color: C.muted }}>{nextItem.content}</span>
+        </div>
+      )}
+    </div>
+  );
+
+  if (isDragOverlay) return cardContent;
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      {cardContent}
+    </div>
+  );
+}

--- a/app/client/src/components/kanban/kanban-column.tsx
+++ b/app/client/src/components/kanban/kanban-column.tsx
@@ -1,0 +1,115 @@
+import { useDroppable } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy, horizontalListSortingStrategy } from "@dnd-kit/sortable";
+import { useColors } from "@/App";
+import { KanbanCard } from "./kanban-card";
+import type { ContactWithRelations } from "@shared/schema";
+
+interface KanbanColumnProps {
+  stage: string;
+  contacts: ContactWithRelations[];
+  accentColor: string;
+  compact?: boolean;
+}
+
+export function KanbanColumn({ stage, contacts, accentColor, compact }: KanbanColumnProps) {
+  const C = useColors();
+  const { setNodeRef, isOver } = useDroppable({ id: stage, data: { stage } });
+
+  // Mobile swimlane layout
+  if (compact) {
+    return (
+      <div
+        className="flex overflow-hidden rounded-lg"
+        style={{
+          backgroundColor: isOver ? `${accentColor}10` : `${C.border}20`,
+          border: isOver ? `2px dashed ${accentColor}50` : "2px solid transparent",
+          transition: "all 0.2s",
+        }}
+      >
+        {/* Left accent bar */}
+        <div className="flex-shrink-0" style={{ width: 4, backgroundColor: accentColor }} />
+
+        <div className="flex-1 min-w-0">
+          {/* Stage header */}
+          <div className="px-2.5 pt-1.5 pb-1">
+            <span className="text-[11px] font-bold uppercase tracking-wider" style={{ color: C.text }}>
+              {stage}
+            </span>
+          </div>
+
+          {/* Pills row */}
+          <div
+            ref={setNodeRef}
+            className="flex gap-1.5 px-2.5 pb-1.5 overflow-x-auto"
+            style={{ minHeight: 40 }}
+          >
+            <SortableContext items={contacts.map((c) => c.id)} strategy={horizontalListSortingStrategy}>
+              {contacts.map((contact) => (
+                <KanbanCard
+                  key={contact.id}
+                  contact={contact}
+                  accentColor={accentColor}
+                  compact
+                />
+              ))}
+            </SortableContext>
+            {contacts.length === 0 && (
+              <div className="flex items-center text-[11px] px-1" style={{ color: C.muted }}>
+                Empty
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop column layout
+  return (
+    <div
+      className="flex-shrink-0 flex flex-col rounded-xl"
+      style={{
+        width: 280,
+        minWidth: 280,
+        backgroundColor: isOver ? `${accentColor}08` : `${C.border}30`,
+        border: isOver ? `2px dashed ${accentColor}60` : "2px solid transparent",
+        transition: "background-color 0.15s, border-color 0.15s",
+      }}
+    >
+      <div className="px-3 pt-3 pb-2 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="w-2 h-2 rounded-full" style={{ backgroundColor: accentColor }} />
+          <span
+            className="text-[11px] font-semibold uppercase tracking-wider"
+            style={{ color: C.text }}
+          >
+            {stage}
+          </span>
+        </div>
+        <span
+          className="text-[10px] font-medium px-1.5 py-0.5 rounded-full"
+          style={{ backgroundColor: `${accentColor}18`, color: accentColor }}
+        >
+          {contacts.length}
+        </span>
+      </div>
+
+      <div
+        ref={setNodeRef}
+        className="flex-1 overflow-y-auto px-2 pb-2"
+        style={{ maxHeight: "calc(100vh - 160px)", minHeight: 120 }}
+      >
+        <SortableContext items={contacts.map((c) => c.id)} strategy={verticalListSortingStrategy}>
+          {contacts.map((contact) => (
+            <KanbanCard key={contact.id} contact={contact} accentColor={accentColor} />
+          ))}
+        </SortableContext>
+        {contacts.length === 0 && (
+          <div className="text-xs text-center py-8 rounded-lg" style={{ color: C.muted }}>
+            No contacts
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/client/src/hooks/use-crm.ts
+++ b/app/client/src/hooks/use-crm.ts
@@ -13,7 +13,23 @@ export function useCrm() {
       const res = await apiRequest("PUT", `/api/contacts/${id}`, data);
       return res.json();
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["/api/contacts"] }),
+    onMutate: async ({ id, ...data }) => {
+      await queryClient.cancelQueries({ queryKey: ["/api/contacts"] });
+      const previous = queryClient.getQueryData<ContactWithRelations[]>(["/api/contacts"]);
+      if (previous) {
+        queryClient.setQueryData<ContactWithRelations[]>(
+          ["/api/contacts"],
+          previous.map((c) => (c.id === id ? { ...c, ...data } as ContactWithRelations : c)),
+        );
+      }
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(["/api/contacts"], context.previous);
+      }
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ["/api/contacts"] }),
   });
 
   const createContact = useMutation({

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -1,11 +1,12 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useCrm } from "@/hooks/use-crm";
 import { useSSE } from "@/hooks/use-sse";
 import { useAuth } from "@/hooks/use-auth";
 import { ContactBlock } from "@/components/contact-block";
-import { Loader2, LogOut, Settings, Square, Activity, X, ChevronDown, Zap } from "lucide-react";
+import { Loader2, LogOut, Settings, Square, Activity, X, ChevronDown, Zap, LayoutList, Kanban } from "lucide-react";
+import { KanbanBoard } from "@/components/kanban/kanban-board";
 import { Link } from "wouter";
 import { format, isPast, isToday, differenceInDays } from "date-fns";
 import type { ContactWithRelations, Followup, ActivityLogEntry } from "@shared/schema";
@@ -40,6 +41,10 @@ export default function CrmPage() {
   const { orgName, upcomingDays: configDays } = useConfig();
   const [localDays, setLocalDays] = useState<number | null>(null);
   const days = localDays ?? configDays;
+  const [viewMode, setViewMode] = useState<"list" | "kanban">(() =>
+    (localStorage.getItem("crm-view-mode") as "list" | "kanban") || "list",
+  );
+  useEffect(() => { localStorage.setItem("crm-view-mode", viewMode); }, [viewMode]);
   useSSE();
 
   const saveDays = useMutation({
@@ -82,6 +87,8 @@ export default function CrmPage() {
     }
     return counts;
   }, [contacts]);
+
+  const kanbanContacts = useMemo(() => contacts.filter((c) => c.status !== "HOLD"), [contacts]);
 
   // Follow-ups due within N days (including overdue), sorted by due date
   const allFollowups = useMemo(() => {
@@ -137,7 +144,7 @@ export default function CrmPage() {
     <div className="min-h-screen" style={{ backgroundColor: "#f0f8f8" }}>
       {/* Header */}
       <header className="sticky top-0 z-50 bg-white" style={{ borderBottom: `1px solid ${C.border}` }}>
-        <div className="max-w-[640px] mx-auto px-4 py-3 flex items-center justify-between">
+        <div className={`${viewMode === "list" ? "max-w-[640px]" : ""} mx-auto px-4 py-3 flex items-center justify-between`}>
           <div>
             <h1 className="text-[13px] font-semibold tracking-[0.2em] uppercase" style={{ color: C.text }}>
               {orgName}
@@ -149,6 +156,25 @@ export default function CrmPage() {
             </p>
           </div>
           <div className="flex items-center gap-1">
+            {/* View mode toggle */}
+            <div className="flex items-center rounded-lg mr-1" style={{ border: `1px solid ${C.border}` }}>
+              <button
+                onClick={() => setViewMode("list")}
+                className="p-1.5 rounded-l-lg transition-colors"
+                style={{ backgroundColor: viewMode === "list" ? C.accent : "transparent", color: viewMode === "list" ? "#fff" : C.muted }}
+                title="List view"
+              >
+                <LayoutList className="h-3.5 w-3.5" />
+              </button>
+              <button
+                onClick={() => setViewMode("kanban")}
+                className="p-1.5 rounded-r-lg transition-colors"
+                style={{ backgroundColor: viewMode === "kanban" ? C.accent : "transparent", color: viewMode === "kanban" ? "#fff" : C.muted }}
+                title="Kanban view"
+              >
+                <Kanban className="h-3.5 w-3.5" />
+              </button>
+            </div>
             <Link href="/rules" className="p-2 transition-colors" style={{ color: C.muted }} title="Rules">
               <Zap className="h-4 w-4" />
             </Link>
@@ -164,29 +190,31 @@ export default function CrmPage() {
           </div>
         </div>
 
-        {/* Stage filter pills */}
-        <div className="max-w-[640px] mx-auto px-4 pb-2.5 flex gap-1.5 overflow-x-auto">
-          {STAGES.map((stage) => {
-            const count = stageCounts[stage] || 0;
-            if (stage !== "ALL" && count === 0) return null;
-            const isActive = activeStage === stage;
-            return (
-              <button
-                key={stage}
-                onClick={() => setActiveStage(stage)}
-                className="px-3 py-1 rounded-full text-[11px] font-medium whitespace-nowrap transition-all"
-                style={
-                  isActive
-                    ? { backgroundColor: C.accent, color: "#ffffff" }
-                    : { backgroundColor: "transparent", color: C.muted, border: `1px solid ${C.border}` }
-                }
-              >
-                {stage === "ALL" ? "All" : stage.charAt(0) + stage.slice(1).toLowerCase()}
-                <span className="ml-1" style={{ opacity: 0.7 }}>{count}</span>
-              </button>
-            );
-          })}
-        </div>
+        {/* Stage filter pills — list view only */}
+        {viewMode === "list" && (
+          <div className="max-w-[640px] mx-auto px-4 pb-2.5 flex gap-1.5 overflow-x-auto">
+            {STAGES.map((stage) => {
+              const count = stageCounts[stage] || 0;
+              if (stage !== "ALL" && count === 0) return null;
+              const isActive = activeStage === stage;
+              return (
+                <button
+                  key={stage}
+                  onClick={() => setActiveStage(stage)}
+                  className="px-3 py-1 rounded-full text-[11px] font-medium whitespace-nowrap transition-all"
+                  style={
+                    isActive
+                      ? { backgroundColor: C.accent, color: "#ffffff" }
+                      : { backgroundColor: "transparent", color: C.muted, border: `1px solid ${C.border}` }
+                  }
+                >
+                  {stage === "ALL" ? "All" : stage.charAt(0) + stage.slice(1).toLowerCase()}
+                  <span className="ml-1" style={{ opacity: 0.7 }}>{count}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
       </header>
 
       {/* Activity drawer */}
@@ -220,166 +248,170 @@ export default function CrmPage() {
         </div>
       )}
 
-      <main className="max-w-[640px] mx-auto px-4 py-5">
-        {/* Upcoming — all follow-ups and meetings in one list */}
-        {allFollowups.length > 0 && (
-          <div className="bg-white mb-5" style={{ border: `1px solid ${C.border}`, borderRadius: "12px", padding: "1rem 1.25rem" }}>
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: C.muted }}>Upcoming</span>
-              <div className="flex items-center gap-0.5">
-                {[1, 2, 3, 7, 14].map((d) => (
-                  <button
-                    key={d}
-                    onClick={() => { setLocalDays(d); saveDays.mutate(d); }}
-                    className="px-1.5 py-0.5 rounded text-[10px] font-medium transition-colors"
-                    style={{
-                      backgroundColor: days === d ? C.accent : "transparent",
-                      color: days === d ? "white" : C.muted,
-                    }}
-                  >
-                    {d}d
-                  </button>
-                ))}
+      {viewMode === "kanban" ? (
+        <KanbanBoard contacts={kanbanContacts} updateContact={updateContact} />
+      ) : (
+        <main className="max-w-[640px] mx-auto px-4 py-5">
+          {/* Upcoming — all follow-ups and meetings in one list */}
+          {allFollowups.length > 0 && (
+            <div className="bg-white mb-5" style={{ border: `1px solid ${C.border}`, borderRadius: "12px", padding: "1rem 1.25rem" }}>
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: C.muted }}>Upcoming</span>
+                <div className="flex items-center gap-0.5">
+                  {[1, 2, 3, 7, 14].map((d) => (
+                    <button
+                      key={d}
+                      onClick={() => { setLocalDays(d); saveDays.mutate(d); }}
+                      className="px-1.5 py-0.5 rounded text-[10px] font-medium transition-colors"
+                      style={{
+                        backgroundColor: days === d ? C.accent : "transparent",
+                        color: days === d ? "white" : C.muted,
+                      }}
+                    >
+                      {d}d
+                    </button>
+                  ))}
+                </div>
               </div>
-            </div>
-            <div className="space-y-1.5">
-              {allFollowups.map(({ followup: fu, contactName, briefing }) => {
-                const due = new Date(fu.dueDate);
-                const isOverdue = isPast(due) && !isToday(due);
-                const isTodayDue = isToday(due);
-                const daysUntil = differenceInDays(due, new Date());
-                const dateColor = isOverdue ? C.red : isTodayDue ? C.stale : C.accentDark;
-                const isCompleting = completingUpcomingId === fu.id;
+              <div className="space-y-1.5">
+                {allFollowups.map(({ followup: fu, contactName, briefing }) => {
+                  const due = new Date(fu.dueDate);
+                  const isOverdue = isPast(due) && !isToday(due);
+                  const isTodayDue = isToday(due);
+                  const daysUntil = differenceInDays(due, new Date());
+                  const dateColor = isOverdue ? C.red : isTodayDue ? C.stale : C.accentDark;
+                  const isCompleting = completingUpcomingId === fu.id;
 
-                if (isCompleting) {
-                  return (
-                    <div key={fu.id} className="rounded-lg px-3 py-2 space-y-2" style={{ backgroundColor: C.accentLight, border: `1px solid ${C.accent}40` }}>
-                      <div className="text-xs font-medium" style={{ color: C.accentDark }}>
-                        Completing: {fmtDate(due)} {fu.content} — {contactName}
-                      </div>
-                      <input
-                        autoFocus
-                        value={completingUpcomingText}
-                        onChange={(e) => setCompletingUpcomingText(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter" && completingUpcomingText.trim()) {
-                            completeFollowup.mutate({ id: fu.id, outcome: completingUpcomingText.trim() });
-                            setCompletingUpcomingId(null);
-                          }
-                          if (e.key === "Escape") setCompletingUpcomingId(null);
-                        }}
-                        placeholder="What happened?"
-                        className="w-full text-sm bg-white rounded px-2 py-1 outline-none"
-                        style={{ color: C.text, border: `1px solid ${C.accent}40` }}
-                      />
-                      <div className="flex items-center gap-2">
-                        <button
-                          onClick={() => {
-                            if (completingUpcomingText.trim()) {
+                  if (isCompleting) {
+                    return (
+                      <div key={fu.id} className="rounded-lg px-3 py-2 space-y-2" style={{ backgroundColor: C.accentLight, border: `1px solid ${C.accent}40` }}>
+                        <div className="text-xs font-medium" style={{ color: C.accentDark }}>
+                          Completing: {fmtDate(due)} {fu.content} — {contactName}
+                        </div>
+                        <input
+                          autoFocus
+                          value={completingUpcomingText}
+                          onChange={(e) => setCompletingUpcomingText(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" && completingUpcomingText.trim()) {
                               completeFollowup.mutate({ id: fu.id, outcome: completingUpcomingText.trim() });
                               setCompletingUpcomingId(null);
                             }
+                            if (e.key === "Escape") setCompletingUpcomingId(null);
                           }}
-                          className="text-xs font-medium text-white px-2.5 py-1 rounded"
-                          style={{ backgroundColor: C.accentDark }}
-                        >Done</button>
-                        <button onClick={() => { completeFollowup.mutate({ id: fu.id }); setCompletingUpcomingId(null); }}
-                          className="text-xs" style={{ color: C.muted }}>Skip note</button>
-                        <button onClick={() => setCompletingUpcomingId(null)}
-                          className="text-xs" style={{ color: C.muted }}>Cancel</button>
+                          placeholder="What happened?"
+                          className="w-full text-sm bg-white rounded px-2 py-1 outline-none"
+                          style={{ color: C.text, border: `1px solid ${C.accent}40` }}
+                        />
+                        <div className="flex items-center gap-2">
+                          <button
+                            onClick={() => {
+                              if (completingUpcomingText.trim()) {
+                                completeFollowup.mutate({ id: fu.id, outcome: completingUpcomingText.trim() });
+                                setCompletingUpcomingId(null);
+                              }
+                            }}
+                            className="text-xs font-medium text-white px-2.5 py-1 rounded"
+                            style={{ backgroundColor: C.accentDark }}
+                          >Done</button>
+                          <button onClick={() => { completeFollowup.mutate({ id: fu.id }); setCompletingUpcomingId(null); }}
+                            className="text-xs" style={{ color: C.muted }}>Skip note</button>
+                          <button onClick={() => setCompletingUpcomingId(null)}
+                            className="text-xs" style={{ color: C.muted }}>Cancel</button>
+                        </div>
                       </div>
+                    );
+                  }
+
+                  const isMeeting = fu.type === "meeting";
+                  const meetingType = (fu.metadata as any)?.meetingType;
+                  const meetingIcon = isMeeting
+                    ? ({ call: "📞", video: "📹", "in-person": "🤝", coffee: "☕" } as any)[meetingType] || "📅"
+                    : null;
+                  const isTodayMeeting = isMeeting && isTodayDue;
+                  const isExp = isTodayMeeting && expandedMeetingIds.has(fu.id);
+
+                  return (
+                    <div key={fu.id}>
+                      <div className="flex items-center gap-2 text-sm">
+                        {isMeeting ? (
+                          <span
+                            className={`flex-shrink-0 ${isTodayMeeting ? "cursor-pointer" : ""}`}
+                            onClick={isTodayMeeting ? () => toggleMeetingExpand(fu.id) : undefined}
+                          >{meetingIcon}</span>
+                        ) : (
+                          <button
+                            onClick={() => { setCompletingUpcomingId(fu.id); setCompletingUpcomingText(fu.content); }}
+                            className="flex-shrink-0 hover:opacity-70 transition-colors"
+                            title="Complete"
+                          >
+                            <Square className="h-3.5 w-3.5" style={{ color: dateColor }} />
+                          </button>
+                        )}
+                        <span className="font-bold flex-shrink-0" style={{ color: isMeeting ? "#2563eb" : dateColor }}>
+                          {fmtDate(due)}{fu.time ? ` ${fu.time}` : ""}
+                        </span>
+                        <span className="truncate min-w-0" style={{ color: C.text }}>
+                          {fu.content}{fu.location ? ` — ${fu.location}` : ""}
+                        </span>
+                        <span className="text-xs flex-shrink-0 whitespace-nowrap" style={{ color: C.muted }}>
+                          {contactName}
+                        </span>
+                        {isOverdue && (
+                          <span className="text-xs font-semibold flex-shrink-0" style={{ color: C.red }}>OVERDUE</span>
+                        )}
+                        {isTodayDue && (
+                          <span className="text-xs font-semibold flex-shrink-0" style={{ color: C.stale }}>TODAY</span>
+                        )}
+                        {!isOverdue && !isTodayDue && daysUntil <= 7 && (
+                          <span className="text-xs flex-shrink-0" style={{ color: C.muted }}>{daysUntil}d</span>
+                        )}
+                        {isTodayMeeting && (
+                          <ChevronDown className={`h-3 w-3 flex-shrink-0 transition-transform cursor-pointer ${isExp ? "rotate-180" : ""}`} style={{ color: C.muted }} onClick={() => toggleMeetingExpand(fu.id)} />
+                        )}
+                      </div>
+                      {isExp && briefing && (
+                        <div className="mt-1.5 ml-6 text-xs rounded-lg px-3 py-2 whitespace-pre-wrap" style={{ backgroundColor: C.accentLight, color: C.text }}>
+                          <div className="text-[10px] font-semibold uppercase tracking-wider mb-1" style={{ color: C.accentDark }}>Briefing</div>
+                          {briefing.content}
+                        </div>
+                      )}
+                      {isExp && !briefing && (
+                        <div className="mt-1.5 ml-6 text-[10px] italic" style={{ color: C.muted }}>No briefing yet</div>
+                      )}
                     </div>
                   );
-                }
-
-                const isMeeting = fu.type === "meeting";
-                const meetingType = (fu.metadata as any)?.meetingType;
-                const meetingIcon = isMeeting
-                  ? ({ call: "📞", video: "📹", "in-person": "🤝", coffee: "☕" } as any)[meetingType] || "📅"
-                  : null;
-                const isTodayMeeting = isMeeting && isTodayDue;
-                const isExp = isTodayMeeting && expandedMeetingIds.has(fu.id);
-
-                return (
-                  <div key={fu.id}>
-                    <div className="flex items-center gap-2 text-sm">
-                      {isMeeting ? (
-                        <span
-                          className={`flex-shrink-0 ${isTodayMeeting ? "cursor-pointer" : ""}`}
-                          onClick={isTodayMeeting ? () => toggleMeetingExpand(fu.id) : undefined}
-                        >{meetingIcon}</span>
-                      ) : (
-                        <button
-                          onClick={() => { setCompletingUpcomingId(fu.id); setCompletingUpcomingText(fu.content); }}
-                          className="flex-shrink-0 hover:opacity-70 transition-colors"
-                          title="Complete"
-                        >
-                          <Square className="h-3.5 w-3.5" style={{ color: dateColor }} />
-                        </button>
-                      )}
-                      <span className="font-bold flex-shrink-0" style={{ color: isMeeting ? "#2563eb" : dateColor }}>
-                        {fmtDate(due)}{fu.time ? ` ${fu.time}` : ""}
-                      </span>
-                      <span className="truncate min-w-0" style={{ color: C.text }}>
-                        {fu.content}{fu.location ? ` — ${fu.location}` : ""}
-                      </span>
-                      <span className="text-xs flex-shrink-0 whitespace-nowrap" style={{ color: C.muted }}>
-                        {contactName}
-                      </span>
-                      {isOverdue && (
-                        <span className="text-xs font-semibold flex-shrink-0" style={{ color: C.red }}>OVERDUE</span>
-                      )}
-                      {isTodayDue && (
-                        <span className="text-xs font-semibold flex-shrink-0" style={{ color: C.stale }}>TODAY</span>
-                      )}
-                      {!isOverdue && !isTodayDue && daysUntil <= 7 && (
-                        <span className="text-xs flex-shrink-0" style={{ color: C.muted }}>{daysUntil}d</span>
-                      )}
-                      {isTodayMeeting && (
-                        <ChevronDown className={`h-3 w-3 flex-shrink-0 transition-transform cursor-pointer ${isExp ? "rotate-180" : ""}`} style={{ color: C.muted }} onClick={() => toggleMeetingExpand(fu.id)} />
-                      )}
-                    </div>
-                    {isExp && briefing && (
-                      <div className="mt-1.5 ml-6 text-xs rounded-lg px-3 py-2 whitespace-pre-wrap" style={{ backgroundColor: C.accentLight, color: C.text }}>
-                        <div className="text-[10px] font-semibold uppercase tracking-wider mb-1" style={{ color: C.accentDark }}>Briefing</div>
-                        {briefing.content}
-                      </div>
-                    )}
-                    {isExp && !briefing && (
-                      <div className="mt-1.5 ml-6 text-[10px] italic" style={{ color: C.muted }}>No briefing yet</div>
-                    )}
-                  </div>
-                );
-              })}
+                })}
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {/* Contact cards */}
-        {filteredContacts.map((contact) => (
-          <ContactBlock
-            key={contact.id}
-            contact={contact}
-            accentColor={STAGE_ACCENT[contact.stage] || "#5a7a7a"}
-            onAddInteraction={(content, date, type) =>
-              addInteraction.mutate({ contactId: contact.id, content, date, type })
-            }
-            onUpdateInteraction={(id, data) => updateInteraction.mutate({ id, ...data })}
-            onDeleteInteraction={(id) => deleteInteraction.mutate(id)}
-            onCreateFollowup={(content, dueDate, opts) =>
-              createFollowup.mutate({ contactId: contact.id, content, dueDate, ...opts })
-            }
-            onUpdateFollowup={(id, data) => updateFollowup.mutate({ id, ...data })}
-            onDeleteFollowup={(id) => deleteFollowup.mutate(id)}
-            onCompleteFollowup={(id, outcome) => completeFollowup.mutate({ id, outcome })}
-            onUpdateContact={(data) => updateContact.mutate({ id: contact.id, ...data })}
-          />
-        ))}
+          {/* Contact cards */}
+          {filteredContacts.map((contact) => (
+            <ContactBlock
+              key={contact.id}
+              contact={contact}
+              accentColor={STAGE_ACCENT[contact.stage] || "#5a7a7a"}
+              onAddInteraction={(content, date, type) =>
+                addInteraction.mutate({ contactId: contact.id, content, date, type })
+              }
+              onUpdateInteraction={(id, data) => updateInteraction.mutate({ id, ...data })}
+              onDeleteInteraction={(id) => deleteInteraction.mutate(id)}
+              onCreateFollowup={(content, dueDate, opts) =>
+                createFollowup.mutate({ contactId: contact.id, content, dueDate, ...opts })
+              }
+              onUpdateFollowup={(id, data) => updateFollowup.mutate({ id, ...data })}
+              onDeleteFollowup={(id) => deleteFollowup.mutate(id)}
+              onCompleteFollowup={(id, outcome) => completeFollowup.mutate({ id, outcome })}
+              onUpdateContact={(data) => updateContact.mutate({ id: contact.id, ...data })}
+            />
+          ))}
 
-        {filteredContacts.length === 0 && (
-          <p className="text-center py-16 text-sm" style={{ color: C.muted }}>No contacts in this stage</p>
-        )}
-      </main>
+          {filteredContacts.length === 0 && (
+            <p className="text-center py-16 text-sm" style={{ color: C.muted }}>No contacts in this stage</p>
+          )}
+        </main>
+      )}
     </div>
   );
 }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@modelcontextprotocol/sdk": "^1.28.0",
         "@neondatabase/serverless": "^0.10.4",
         "@radix-ui/react-dialog": "^1.1.7",
@@ -370,6 +373,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@drizzle-team/brocli": {

--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,9 @@
     "test:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@neondatabase/serverless": "^0.10.4",
     "@radix-ui/react-dialog": "^1.1.7",


### PR DESCRIPTION
## Summary
- Adds toggleable Kanban board view (list/kanban icons in header)
- Desktop: full-width columns per pipeline stage with draggable contact cards
- Mobile (<768px): compact horizontal swimlane strips with pill-shaped tiles showing name + company
- Drag-and-drop between stages triggers `PUT /api/contacts/:id` with optimistic updates
- HOLD contacts excluded from Kanban view
- View preference persisted to localStorage

## New dependencies
- `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`

## Test plan
- [x] Toggle between list and kanban views via header icons
- [x] Drag a contact card to a different stage column — verify stage persists on refresh
- [x] Resize browser below 768px — verify mobile swimlane layout
- [x] Set a contact to HOLD — verify it disappears from Kanban
- [x] E2E tests: login, add note, create task, create meeting, edit date, complete task, stage change, MCP search, MCP add interaction — all pass
- [x] Screenshots captured

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)