### PR TITLE
Move Upcoming Days setting to Settings page (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-04-09
 
+### Move Upcoming Days setting to Settings page (#30)
+- Upcoming days picker moved from CRM page to Settings > Upcoming Window
+- Setting is now always accessible regardless of whether follow-ups are visible
+
 ### Add Kanban board view (#38)
 - New toggleable Kanban view alongside existing list view (icon toggle in header)
 - Desktop: full-width columns per pipeline stage with drag-and-drop contact cards

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
-import { useQuery, useMutation } from "@tanstack/react-query";
-import { apiRequest, queryClient } from "@/lib/queryClient";
+import { useQuery } from "@tanstack/react-query";
 import { useCrm } from "@/hooks/use-crm";
 import { useSSE } from "@/hooks/use-sse";
 import { useAuth } from "@/hooks/use-auth";
@@ -38,21 +37,12 @@ export default function CrmPage() {
   const { contacts, isLoading, addInteraction, updateInteraction, deleteInteraction, createFollowup, updateFollowup, deleteFollowup, completeFollowup, updateContact } = useCrm();
   const { logoutMutation } = useAuth();
   const [activeStage, setActiveStage] = useState<string>("ALL");
-  const { orgName, upcomingDays: configDays } = useConfig();
-  const [localDays, setLocalDays] = useState<number | null>(null);
-  const days = localDays ?? configDays;
+  const { orgName, upcomingDays: days } = useConfig();
   const [viewMode, setViewMode] = useState<"list" | "kanban">(() =>
     (localStorage.getItem("crm-view-mode") as "list" | "kanban") || "list",
   );
   useEffect(() => { localStorage.setItem("crm-view-mode", viewMode); }, [viewMode]);
   useSSE();
-
-  const saveDays = useMutation({
-    mutationFn: async (d: number) => {
-      await apiRequest("PUT", "/api/settings", { upcomingDays: d });
-    },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["/api/config"] }),
-  });
 
   const sortedContacts = useMemo(() => {
     const sorted = [...contacts].sort((a, b) => {
@@ -255,23 +245,8 @@ export default function CrmPage() {
           {/* Upcoming — all follow-ups and meetings in one list */}
           {allFollowups.length > 0 && (
             <div className="bg-white mb-5" style={{ border: `1px solid ${C.border}`, borderRadius: "12px", padding: "1rem 1.25rem" }}>
-              <div className="flex items-center justify-between mb-2">
+              <div className="mb-2">
                 <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: C.muted }}>Upcoming</span>
-                <div className="flex items-center gap-0.5">
-                  {[1, 2, 3, 7, 14].map((d) => (
-                    <button
-                      key={d}
-                      onClick={() => { setLocalDays(d); saveDays.mutate(d); }}
-                      className="px-1.5 py-0.5 rounded text-[10px] font-medium transition-colors"
-                      style={{
-                        backgroundColor: days === d ? C.accent : "transparent",
-                        color: days === d ? "white" : C.muted,
-                      }}
-                    >
-                      {d}d
-                    </button>
-                  ))}
-                </div>
               </div>
               <div className="space-y-1.5">
                 {allFollowups.map(({ followup: fu, contactName, briefing }) => {

--- a/app/client/src/pages/settings-page.tsx
+++ b/app/client/src/pages/settings-page.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { ArrowLeft, Copy, RefreshCw, Check } from "lucide-react";
 import { Link } from "wouter";
-import { useColors } from "@/App";
+import { useColors, useConfig } from "@/App";
 
 export default function SettingsPage() {
   const C = useColors();
@@ -19,6 +19,17 @@ export default function SettingsPage() {
   const [newPin, setNewPin] = useState("");
   const [pinMessage, setPinMessage] = useState("");
   const [copied, setCopied] = useState<string | null>(null);
+  const { upcomingDays } = useConfig();
+
+  const saveDays = useMutation({
+    mutationFn: async (d: number) => {
+      await apiRequest("PUT", "/api/settings", { upcomingDays: d });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/config"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/settings"] });
+    },
+  });
 
   // Initialize from settings
   if (settings && !orgNameDirty && orgName !== settings.orgName) {
@@ -145,6 +156,28 @@ export default function SettingsPage() {
               className="text-xs font-medium text-white px-3 py-1.5 rounded-lg disabled:opacity-40"
               style={{ backgroundColor: C.accentDark }}
             >Save</button>
+          </div>
+        </div>
+
+        {/* Upcoming Days */}
+        <div className="bg-white" style={{ border: `1px solid ${C.border}`, borderRadius: "12px", padding: "1rem 1.25rem" }}>
+          <label className="text-xs font-semibold uppercase tracking-wider" style={{ color: C.muted }}>Upcoming Window</label>
+          <p className="text-[11px] mt-0.5 mb-2" style={{ color: C.muted }}>How many days ahead to show in the Upcoming section.</p>
+          <div className="flex gap-1">
+            {[1, 2, 3, 7, 14].map((d) => (
+              <button
+                key={d}
+                onClick={() => saveDays.mutate(d)}
+                className="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+                style={{
+                  backgroundColor: upcomingDays === d ? C.accent : "transparent",
+                  color: upcomingDays === d ? "white" : C.muted,
+                  border: upcomingDays === d ? "none" : `1px solid ${C.border}`,
+                }}
+              >
+                {d}d
+              </button>
+            ))}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Moved the upcoming days picker (1d/2d/3d/7d/14d) from the Upcoming section header to the Settings page
- The setting was previously only visible when follow-ups existed in the window, making it inaccessible when all follow-ups were far out
- Now always reachable via Settings > Upcoming Window

## Test plan
- [x] Build compiles
- [x] Settings page shows Upcoming Window with day buttons
- [x] Clicking a day updates the Upcoming section on the CRM page
- [x] Upcoming section header no longer shows day picker

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)