### PR TITLE
Add lint + format checks to CI, enable branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build (includes typecheck)
+      - name: Lint (0 warnings allowed in CI)
+        run: npx eslint . --max-warnings 0
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Build
         run: npm run build
         env:
           NODE_OPTIONS: --max-old-space-size=4096

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-04-11
 
+### Add lint + format checks to CI, branch protection
+- CI now runs `eslint --max-warnings 0` and `prettier --check` before build/test
+- Branch protection enabled on main: requires PR, CI pass, no force push
+
 ### Clean up all lint warnings to 0
 - Typed rules-engine JSONB fields (RuleCondition, RuleException, RuleAction)
 - Typed mcp-client.ts API responses with generics

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ npm run test         # Playwright E2E tests
 ## Code quality
 - Run `npm run lint:fix` after making changes. It autofixes type imports, const/let, and equality operators.
 - Run `npm run format` if you've written new files or made large edits.
+- CI runs lint with `--max-warnings 0` — warnings that pass locally will fail the PR. Fix all warnings before pushing.
 - The pre-PR hook checks lint passes. Fix lint errors before creating a PR.
 - `@typescript-eslint/no-explicit-any` is a warning. Prefer `unknown` with type narrowing for new code, but don't refactor existing `any` unless specifically asked.
 - Prefix unused parameters with `_` (e.g., `_req`, `_err`) to satisfy no-unused-vars.

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -412,8 +412,15 @@ export default function CrmPage() {
                   }
 
                   const isMeeting = fu.type === "meeting";
-                  const meetingType = (fu.metadata as Record<string, unknown> | null)?.meetingType as string | undefined;
-                  const meetingIcons: Record<string, string> = { call: "📞", video: "📹", "in-person": "🤝", coffee: "☕" };
+                  const meetingType = (fu.metadata as Record<string, unknown> | null)?.meetingType as
+                    | string
+                    | undefined;
+                  const meetingIcons: Record<string, string> = {
+                    call: "📞",
+                    video: "📹",
+                    "in-person": "🤝",
+                    coffee: "☕",
+                  };
                   const meetingIcon = isMeeting ? (meetingType && meetingIcons[meetingType]) || "📅" : null;
                   const isTodayMeeting = isMeeting && isTodayDue;
                   const isExp = isTodayMeeting && expandedMeetingIds.has(fu.id);

--- a/app/client/src/pages/rules-page.tsx
+++ b/app/client/src/pages/rules-page.tsx
@@ -140,7 +140,8 @@ export default function RulesPage() {
                           Exceptions:{" "}
                           {condition.exceptions
                             .map((e: { type: string; params?: Record<string, unknown> }) => {
-                              if (e.type === "stage_in") return `${e.type}(${(e.params?.stages as string[])?.join(", ")})`;
+                              if (e.type === "stage_in")
+                                return `${e.type}(${(e.params?.stages as string[])?.join(", ")})`;
                               return e.type;
                             })
                             .join(", ")}

--- a/app/server/index.ts
+++ b/app/server/index.ts
@@ -39,12 +39,14 @@ app.use((req, res, next) => {
 (async () => {
   const server = await registerRoutes(app);
 
-  app.use((err: Error & { status?: number; statusCode?: number }, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
-    res.status(status).json({ message });
-    throw err;
-  });
+  app.use(
+    (err: Error & { status?: number; statusCode?: number }, _req: Request, res: Response, _next: NextFunction) => {
+      const status = err.status || err.statusCode || 500;
+      const message = err.message || "Internal Server Error";
+      res.status(status).json({ message });
+      throw err;
+    },
+  );
 
   if (app.get("env") === "development") {
     await setupVite(app, server);

--- a/app/server/mcp-server.ts
+++ b/app/server/mcp-server.ts
@@ -180,7 +180,15 @@ server.tool(
         ],
       };
     } catch (err: unknown) {
-      return { content: [{ type: "text" as const, text: `Error creating contact: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error creating contact: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ],
+        isError: true,
+      };
     }
   },
 );
@@ -220,7 +228,15 @@ server.tool(
         content: [{ type: "text" as const, text: `Updated contact: ${contact.firstName} ${contact.lastName}` }],
       };
     } catch (err: unknown) {
-      return { content: [{ type: "text" as const, text: `Error updating contact: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error updating contact: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ],
+        isError: true,
+      };
     }
   },
 );
@@ -247,7 +263,15 @@ server.tool(
       });
       return { content: [{ type: "text" as const, text: `Logged ${interaction.type} for contact ${contactId}` }] };
     } catch (err: unknown) {
-      return { content: [{ type: "text" as const, text: `Error logging interaction: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error logging interaction: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ],
+        isError: true,
+      };
     }
   },
 );
@@ -304,7 +328,12 @@ For meetings (type "meeting"): scheduled events with optional time/location.`,
         ],
       };
     } catch (err: unknown) {
-      return { content: [{ type: "text" as const, text: `Error creating task: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+      return {
+        content: [
+          { type: "text" as const, text: `Error creating task: ${err instanceof Error ? err.message : String(err)}` },
+        ],
+        isError: true,
+      };
     }
   },
 );
@@ -343,7 +372,12 @@ server.tool(
       return { content: [{ type: "text" as const, text: `Completed: "${followup.content}"` }] };
     } catch (err: unknown) {
       return {
-        content: [{ type: "text" as const, text: `Error completing follow-up: ${err instanceof Error ? err.message : String(err)}` }],
+        content: [
+          {
+            type: "text" as const,
+            text: `Error completing follow-up: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ],
         isError: true,
       };
     }
@@ -413,7 +447,12 @@ server.tool(
       });
       return { content: [{ type: "text" as const, text: `Created rule: "${rule.name}" (ID: ${rule.id})` }] };
     } catch (err: unknown) {
-      return { content: [{ type: "text" as const, text: `Error creating rule: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+      return {
+        content: [
+          { type: "text" as const, text: `Error creating rule: ${err instanceof Error ? err.message : String(err)}` },
+        ],
+        isError: true,
+      };
     }
   },
 );
@@ -440,7 +479,12 @@ server.tool(
         };
       return { content: [{ type: "text" as const, text: `Updated rule: "${rule.name}"` }] };
     } catch (err: unknown) {
-      return { content: [{ type: "text" as const, text: `Error updating rule: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+      return {
+        content: [
+          { type: "text" as const, text: `Error updating rule: ${err instanceof Error ? err.message : String(err)}` },
+        ],
+        isError: true,
+      };
     }
   },
 );
@@ -455,7 +499,12 @@ server.tool("delete_rule", "Delete a business rule", { ruleId: z.number().descri
       };
     return { content: [{ type: "text" as const, text: `Deleted rule ${ruleId}` }] };
   } catch (err: unknown) {
-    return { content: [{ type: "text" as const, text: `Error deleting rule: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+    return {
+      content: [
+        { type: "text" as const, text: `Error deleting rule: ${err instanceof Error ? err.message : String(err)}` },
+      ],
+      isError: true,
+    };
   }
 });
 

--- a/app/server/rules-engine.ts
+++ b/app/server/rules-engine.ts
@@ -148,11 +148,7 @@ function checkCondition(
   return violated;
 }
 
-function checkException(
-  exception: RuleException,
-  contact: Contact,
-  contactFollowups: Followup[],
-): boolean {
+function checkException(exception: RuleException, contact: Contact, contactFollowups: Followup[]): boolean {
   switch (exception.type) {
     case "has_future_followup":
       return contactFollowups.some((f) => !f.completed && new Date(f.dueDate) >= new Date());


### PR DESCRIPTION
## Summary
- CI now runs `eslint --max-warnings 0` and `prettier --check` before build/test
- Branch protection enabled on main: requires CI status check, no force pushes

## Test plan
- [x] Lint and format pass locally
- [x] Branch protection verified via gh api
- [ ] CI will validate lint + format on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)