### PR TITLE
Improve E2E testing, add grill-me skill

### DIFF
--- a/.claude/hooks/pre-pr.sh
+++ b/.claude/hooks/pre-pr.sh
@@ -21,10 +21,14 @@ if [ "$CHANGELOG_CHANGED" -eq 0 ]; then
   ERRORS="$ERRORS CHANGELOG.md not updated."
 fi
 
-# 2. Check for recent E2E test screenshots (within last 30 minutes)
-RECENT_SCREENSHOTS=$(find e2e-screenshots -name "*.png" -mmin -30 2>/dev/null | head -1)
-if [ -z "$RECENT_SCREENSHOTS" ]; then
-  ERRORS="$ERRORS No recent E2E test screenshots — run the E2E test skill first."
+# 2. Check for recent E2E run manifest (within last 30 minutes, result = pass)
+RUN_MANIFEST="e2e-screenshots/run.json"
+if [ ! -f "$RUN_MANIFEST" ]; then
+  ERRORS="$ERRORS No E2E run manifest — run the E2E test skill first."
+elif ! find "$RUN_MANIFEST" -mmin -30 2>/dev/null | grep -q .; then
+  ERRORS="$ERRORS E2E run manifest is stale (>30 min) — re-run the E2E test skill."
+elif ! python3 -c "import json; d=json.load(open('$RUN_MANIFEST')); exit(0 if d.get('result')=='pass' else 1)" 2>/dev/null; then
+  ERRORS="$ERRORS E2E run manifest shows failures — fix them before creating a PR."
 fi
 
 # 3. Check lint passes (errors only — warnings are OK)

--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -7,6 +7,36 @@ Run this skill before creating any PR. It verifies the app works end-to-end by u
 - Database seeded (`npm run db:seed` — PIN is 1234)
 - Claude-in-Chrome browser extension (primary). Playwright MCP is a fallback only.
 
+## Screenshot Protocol
+
+Before running any steps, wipe the screenshot directory and start fresh:
+```bash
+rm -rf e2e-screenshots && mkdir -p e2e-screenshots
+```
+
+Name every screenshot by step number and description:
+- `e2e-screenshots/01-crm-loaded.png`
+- `e2e-screenshots/02-note-added.png`
+- `e2e-screenshots/03-task-created.png`
+- etc.
+
+After all steps complete, write a manifest file:
+```bash
+# e2e-screenshots/run.json
+{
+  "branch": "<current git branch>",
+  "timestamp": "<ISO 8601>",
+  "steps": {
+    "01-crm-loaded": "pass",
+    "02-note-added": "pass",
+    ...
+  },
+  "result": "pass"   // or "fail"
+}
+```
+
+The pre-PR hook validates this manifest exists and is recent.
+
 ## Steps
 
 ### 1. Start dev server
@@ -21,28 +51,28 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 - Should redirect to `/auth` with "MAGNETIC ADVISORS" and "Enter PIN"
 - Enter PIN `1234`, click Unlock
 - Should see the CRM page with contacts loaded
-- **Screenshot the CRM page** → save to `e2e-screenshots/`
+- **Screenshot** → `e2e-screenshots/01-crm-loaded.png`
 
 ### 3. UI: Add a note
 - Find the first contact's input field (`placeholder*="note"`)
 - Type: `E2E test note: verified app works`
 - Press Enter
 - Verify the note appears in the contact's timeline with today's date
-- **Screenshot the contact showing the new note**
+- **Screenshot** → `e2e-screenshots/02-note-added.png`
 
 ### 4. UI: Create a task (follow-up)
 - In the same input, type: `/fu 12/31 E2E test task`
 - Verify the command hint appears ("task ready")
 - Press Enter
 - Verify a task item appears with □ checkbox, `12/31`, and the text
-- **Screenshot the task**
+- **Screenshot** → `e2e-screenshots/03-task-created.png`
 
 ### 4b. UI: Create a meeting
 - Type: `/mtg 12/25 2pm E2E test meeting @ Test Location`
 - Verify the command hint appears in blue ("meeting ready")
 - Press Enter
 - Verify a meeting item appears with 📅 icon, `12/25 2:00 PM`, content, and location
-- **Screenshot the meeting**
+- **Screenshot** → `e2e-screenshots/04-meeting-created.png`
 
 ### 4c. UI: Edit a follow-up date
 - Click on the task created in step 4 to enter edit mode
@@ -51,7 +81,7 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 - Verify the flash says "Updated"
 - **Reload the page** (navigate to `/` again)
 - After reload, find the same follow-up and verify the date is the NEW date, not the original
-- **Screenshot the follow-up showing the persisted date change**
+- **Screenshot** → `e2e-screenshots/05-date-edit-persisted.png`
 
 ### 5. UI: Complete the task
 - Click the square checkbox on the follow-up
@@ -59,13 +89,13 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 - Type an outcome: `E2E test: follow-up completed successfully`
 - Click Done
 - Verify the follow-up disappears and the outcome appears in the timeline
-- **Screenshot the timeline showing the outcome**
+- **Screenshot** → `e2e-screenshots/06-task-completed.png`
 
 ### 6. UI: Change stage via command
 - Type `/stage PROPOSAL` in a contact's input
 - Press Enter
 - Verify the stage badge updates to PROPOSAL
-- **Screenshot the updated badge**
+- **Screenshot** → `e2e-screenshots/07-stage-changed.png`
 
 ### 7. MCP: Search contacts
 - Get the MCP token: `curl -s -b <cookie-jar> http://localhost:3000/api/settings | python3 -c "import sys,json; print(json.load(sys.stdin)['mcpToken'])"`
@@ -77,7 +107,7 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 - Call `add_interaction` via MCP with a test note
 - Navigate to the CRM page in the browser
 - Verify the agent's note appears in the contact's timeline (SSE push)
-- **Screenshot showing the agent-written note appeared in the UI**
+- **Screenshot** → `e2e-screenshots/08-mcp-agent-note.png`
 
 ### 9. MCP: Get dashboard
 - Call `get_dashboard` via MCP
@@ -85,13 +115,11 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 
 ### 10. Cleanup
 - Kill the dev server
+- Write `e2e-screenshots/run.json` manifest with branch, timestamp, and per-step results
 - Report: PASS or FAIL with details of any failures
 
 ## Success Criteria
 All 10 steps pass. Screenshots captured for visual verification. If any step fails, fix the issue before creating the PR.
-
-## Screenshot Storage
-Save screenshots to `e2e-screenshots/` in the project root. The pre-PR hook checks for recent screenshots (last 30 minutes) in `e2e-screenshots/`.
 
 ## How to Invoke
 ```

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until
+we reach a shared understanding. Walk down each branch of the design
+tree resolving dependencies between decisions one by one.
+
+If a question can be answered by exploring the codebase, explore
+the codebase instead.
+
+For each question, provide your recommended answer.
+
+Use the AskUserQuestion tool for every question so the user gets
+the structured question/answer interface in Claude Code. Ask one
+question at a time — do not batch multiple questions into a single
+prompt.

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ CLAUDE.local.md
 seed-magnetic.ts
 current-crm-data.md
 .claude/settings.local.json
+e2e-screenshots/
 # Allow PWA icons
 !app/client/icons/*.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-04-12
+
+### Improve E2E testing and add grill-me skill
+- E2E screenshots now named by step (`01-crm-loaded.png`, etc.) and wiped at start of each run
+- E2E skill writes a `run.json` manifest with branch, timestamp, and per-step results
+- Pre-PR hook validates the manifest (exists, recent, passing) instead of just checking for any recent PNG
+- `e2e-screenshots/` added to .gitignore — ephemeral proof, not committed artifacts
+- CLAUDE.md updated: after adding a major feature, update E2E skill with new steps before running it
+- New `/grill-me` skill: structured Q&A to stress-test a plan or design before implementation
+
 ## 2026-04-11
 
 ### Simplify header: filter + menu dropdowns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,9 @@ npm run test         # Playwright E2E tests
 
 ## Before submitting a PR
 1. Run the E2E test skill (`.claude/skills/e2e-test/SKILL.md`): start dev server, test UI + MCP flows, screenshot each step. Do not create PR if any step fails.
-2. Update README.md if the PR changes architecture, adds tools, or changes how things work.
-3. Add a CHANGELOG.md entry describing what changed.
+2. If the PR adds a major user-facing feature, add new steps to the E2E test skill covering the feature's key flows before running it.
+3. Update README.md if the PR changes architecture, adds tools, or changes how things work.
+4. Add a CHANGELOG.md entry describing what changed.
 
 ## Watch out for
 - Dates render in UTC (fmtDate in `lib/utils.ts`). Using `format()` from date-fns causes off-by-one timezone bugs.


### PR DESCRIPTION
## Summary
- E2E screenshot protocol: named by step, wiped per run, `run.json` manifest tracks results
- Pre-PR hook validates manifest (exists, recent, passing) instead of checking raw PNG ages
- `e2e-screenshots/` gitignored — ephemeral proof, not committed
- CLAUDE.md: new checklist item to update E2E skill when adding major features
- New `/grill-me` skill for structured design Q&A using AskUserQuestion

## Test plan
- [ ] Verify pre-PR hook blocks without valid manifest
- [ ] Run `/e2e-test` skill, confirm screenshots are named correctly and manifest is written
- [ ] Verify `/grill-me` uses AskUserQuestion interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)