### PR TITLE
Open source prep: secrets, license, relative seed dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules/
 dist/
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,6 @@
 - MCP server with 20+ tools
 - Rules engine: reactive + scheduled evaluation
 - SSE real-time updates
-- Seeded with 11 contacts from Magnetic Advisors pipeline
-- Deployed to Railway at crm.magneticadvisors.ai
+- Seeded with demo contacts and pipeline data
+- Deployed to Railway
 - PWA for iOS + Pake Mac desktop app

--- a/app/.env.example
+++ b/app/.env.example
@@ -6,3 +6,7 @@ SESSION_SECRET=change-this-to-a-random-string
 
 # Optional: MCP token override (if not set, uses token from DB settings)
 # MCP_TOKEN=your-secret-token
+
+# MCP Client (for local stdio mode — see README)
+# CRM_URL=http://localhost:3000
+# CRM_API_KEY=your-api-key-from-settings

--- a/app/client/sw.js
+++ b/app/client/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'magnetic-crm-v1';
+const CACHE_NAME = 'claw-crm-v1';
 const SHELL_ASSETS = ['/'];
 
 // Cache the app shell on install

--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "claw-crm",
   "version": "1.0.0",
   "type": "module",
-  "license": "MIT",
+  "license": "AGPL-3.0-or-later",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",

--- a/app/server/mcp-client.ts
+++ b/app/server/mcp-client.ts
@@ -4,9 +4,13 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import type { ContactWithRelations, RuleViolation, Rule, Interaction, Followup } from "@shared/schema";
 
-const CRM_URL = process.env.CRM_URL || "https://crm.magneticadvisors.ai";
+const CRM_URL = process.env.CRM_URL;
 const API_KEY = process.env.CRM_API_KEY || "";
 
+if (!CRM_URL) {
+  console.error("CRM_URL is required — set it in your environment or Claude Desktop config");
+  process.exit(1);
+}
 if (!API_KEY) {
   console.error("CRM_API_KEY is required");
   process.exit(1);

--- a/app/server/seed.ts
+++ b/app/server/seed.ts
@@ -17,7 +17,8 @@ async function seed() {
   await db.insert(users).values({ pin, apiKey, mcpToken, orgName: "Claw CRM" }).returning();
   console.log(`Created user — PIN: 1234, API key: ${apiKey}, MCP token: ${mcpToken}`);
 
-  const d = (m: number, day: number) => toNoonUTC(new Date(2026, m - 1, day));
+  /** Days from today → noon UTC. Negative = past, positive = future. */
+  const d = (daysFromToday: number) => toNoonUTC(new Date(Date.now() + daysFromToday * 86_400_000));
 
   // Companies
   const companyData = [
@@ -60,32 +61,32 @@ async function seed() {
   await db.insert(interactions).values([
     {
       contactId: sarah.id,
-      date: d(1, 15),
+      date: d(-87),
       content: "Intro call. Sarah interested in AI advisory for portfolio companies.",
       type: "meeting",
     },
     {
       contactId: sarah.id,
-      date: d(2, 1),
+      date: d(-70),
       content: "Proposal sent. 3-month engagement, 4 portfolio companies.",
       type: "email",
     },
     {
       contactId: sarah.id,
-      date: d(2, 10),
+      date: d(-61),
       content: "Sarah signed. Kicking off with first portfolio company next week.",
       type: "note",
     },
     {
       contactId: sarah.id,
-      date: d(3, 15),
+      date: d(-28),
       content: "Monthly check-in. Two companies showing strong AI adoption progress.",
       type: "meeting",
     },
   ]);
   await db.insert(followups).values({
     contactId: sarah.id,
-    dueDate: d(4, 1),
+    dueDate: d(2),
     content: "Prep Q2 portfolio review deck",
     type: "task",
     completed: false,
@@ -112,21 +113,21 @@ async function seed() {
   await db.insert(interactions).values([
     {
       contactId: marcus.id,
-      date: d(3, 5),
+      date: d(-38),
       content: "Intro via Sarah Chen. Marcus wants AI enablement for engineering team.",
       type: "note",
     },
     {
       contactId: marcus.id,
-      date: d(3, 12),
+      date: d(-31),
       content: "Discovery call. 45 min. Team of 30 engineers, mostly Python. Want to integrate LLMs into QA pipeline.",
       type: "meeting",
     },
-    { contactId: marcus.id, date: d(3, 20), content: "Proposal sent. 6-week sprint, $25K.", type: "email" },
+    { contactId: marcus.id, date: d(-23), content: "Proposal sent. 6-week sprint, $25K.", type: "email" },
   ]);
   await db.insert(followups).values({
     contactId: marcus.id,
-    dueDate: d(4, 3),
+    dueDate: d(5),
     content: "Follow up on proposal — Marcus said he'd review over weekend",
     type: "task",
     completed: false,
@@ -154,20 +155,20 @@ async function seed() {
   await db.insert(interactions).values([
     {
       contactId: elena.id,
-      date: d(3, 1),
+      date: d(-42),
       content: "Cold outreach via LinkedIn. Elena responded same day — interested.",
       type: "email",
     },
     {
       contactId: elena.id,
-      date: d(3, 10),
+      date: d(-33),
       content:
         "First call. 30 min. Elena described maintenance challenges across 500 sites. AI could predict panel failures.",
       type: "meeting",
     },
     {
       contactId: elena.id,
-      date: d(3, 22),
+      date: d(-21),
       content: "Elena introduced Mike Torres (CTO). Scheduling a technical deep-dive.",
       type: "email",
     },
@@ -175,14 +176,14 @@ async function seed() {
   await db.insert(followups).values([
     {
       contactId: elena.id,
-      dueDate: d(4, 2),
+      dueDate: d(3),
       content: "Schedule technical call with Mike Torres",
       type: "task",
       completed: false,
     },
     {
       contactId: elena.id,
-      dueDate: d(4, 8),
+      dueDate: d(9),
       content: "Coffee with Elena",
       type: "meeting",
       time: "10:00 AM",
@@ -212,39 +213,39 @@ async function seed() {
   await db.insert(interactions).values([
     {
       contactId: james.id,
-      date: d(2, 15),
+      date: d(-56),
       content: "David Kim intro'd. James looking for AI strategy consultant across their portfolio.",
       type: "note",
     },
     {
       contactId: james.id,
-      date: d(2, 25),
+      date: d(-46),
       content: "Zoom call. James outlined 12-company portfolio. Wants phased approach starting with 3 companies.",
       type: "meeting",
     },
     {
       contactId: james.id,
-      date: d(3, 5),
+      date: d(-38),
       content: "Proposal sent. $75K for Phase 1 (3 companies, 12 weeks).",
       type: "email",
     },
     {
       contactId: james.id,
-      date: d(3, 18),
-      content: "James: 'Proposal looks good. Need to run it by our investment committee. They meet April 5.'",
+      date: d(-25),
+      content: "James: 'Proposal looks good. Need to run it by our investment committee.'",
       type: "email",
     },
     {
       contactId: james.id,
-      date: d(3, 25),
+      date: d(-18),
       content: "Followed up. James confirmed committee meeting is on track.",
       type: "email",
     },
   ]);
   await db.insert(followups).values({
     contactId: james.id,
-    dueDate: d(4, 7),
-    content: "Check in after investment committee meeting (April 5)",
+    dueDate: d(8),
+    content: "Check in after investment committee meeting",
     type: "task",
     completed: false,
   });
@@ -269,15 +270,15 @@ async function seed() {
   await db.insert(interactions).values([
     {
       contactId: priya.id,
-      date: d(3, 20),
+      date: d(-23),
       content: "Met at YC Demo Day. Priya interested in AI ops advisory.",
       type: "meeting",
     },
-    { contactId: priya.id, date: d(3, 22), content: "Sent follow-up email with case study.", type: "email" },
+    { contactId: priya.id, date: d(-21), content: "Sent follow-up email with case study.", type: "email" },
   ]);
   await db
     .insert(followups)
-    .values({ contactId: priya.id, dueDate: d(4, 5), content: "Schedule intro call", type: "task", completed: false });
+    .values({ contactId: priya.id, dueDate: d(6), content: "Schedule intro call", type: "task", completed: false });
 
   // --- David Kim — Pacific Ventures (MEETING, HOLD) ---
   const [david] = await db
@@ -299,14 +300,14 @@ async function seed() {
   await db.insert(interactions).values([
     {
       contactId: david.id,
-      date: d(2, 10),
+      date: d(-61),
       content:
         "Caught up at climate tech conference. David not ready for advisory engagement but referred Northbridge.",
       type: "meeting",
     },
     {
       contactId: david.id,
-      date: d(3, 1),
+      date: d(-42),
       content: "Moved to HOLD. Good relationship, not a current prospect.",
       type: "note",
     },
@@ -332,20 +333,20 @@ async function seed() {
   await db.insert(interactions).values([
     {
       contactId: rachel.id,
-      date: d(2, 14),
+      date: d(-57),
       content: "Caught up over lunch. Rachel's company is growing fast.",
       type: "meeting",
     },
     {
       contactId: rachel.id,
-      date: d(3, 10),
+      date: d(-33),
       content: "Shared an article on AI in media. Rachel replied: 'Great read, thanks!'",
       type: "email",
     },
   ]);
   await db
     .insert(followups)
-    .values({ contactId: rachel.id, dueDate: d(4, 15), content: "Coffee catch-up", type: "task", completed: false });
+    .values({ contactId: rachel.id, dueDate: d(16), content: "Coffee catch-up", type: "task", completed: false });
 
   // --- Tom Nakamura — Sterling Advisors (PASS) ---
   const [tom] = await db
@@ -367,19 +368,19 @@ async function seed() {
   await db.insert(interactions).values([
     {
       contactId: tom.id,
-      date: d(2, 5),
+      date: d(-66),
       content: "Cold email. Tom replied, interested in AI for due diligence.",
       type: "email",
     },
     {
       contactId: tom.id,
-      date: d(2, 15),
+      date: d(-56),
       content: "Call. Realized they want a full-time AI hire, not advisory. Not a fit.",
       type: "meeting",
     },
     {
       contactId: tom.id,
-      date: d(2, 16),
+      date: d(-55),
       content: "Moved to PASS. Offered to help with job spec if needed.",
       type: "note",
     },


### PR DESCRIPTION
## Summary
- Seed dates are now relative to today (`d(-87)` through `d(+16)`) so demo data always looks fresh regardless of when someone runs `db:seed`
- Removed hardcoded production URL from `mcp-client.ts` — `CRM_URL` is now a required env var (matches existing `CRM_API_KEY` pattern)
- Aligned `package.json` license to `AGPL-3.0-or-later` (was MIT, LICENSE file was already AGPL)
- Renamed service worker cache from `magnetic-crm-v1` to `claw-crm-v1`
- Added `.DS_Store` to `.gitignore`
- Sanitized CHANGELOG (removed production domain reference)

## Audit
- No secrets found in git history (`.env` never committed, `seed-magnetic.ts` never committed)
- Zero references to `magneticadvisors` remain in tracked source files
- Build passes, lint clean

## Test plan
- [x] `npm run build` passes
- [x] `npm run db:seed` — dates are relative to today
- [x] `grep -r "magneticadvisors" app/` returns nothing
- [x] MCP client fails with clear error when `CRM_URL` is unset
- [x] E2E tests pass (all 10 steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)