### PR TITLE
Add global search with MiniSearch (BM25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-04-14
+
+### Global search (Issue #55)
+- Added client-side full-text search using MiniSearch (BM25) across contacts, interactions, follow-ups, and more
+- Search icon in header + Cmd+K / Ctrl+K keyboard shortcut to toggle
+- Inline header expansion: search input replaces title area, Escape to dismiss
+- Matches highlighted in yellow across contact name, company, interactions, follow-ups, and details
+- Interactions auto-expand when they contain matching text
+- Search bypasses stage filter; clearing search restores previous view
+- Removed stats line from header for cleaner layout
+
 ## 2026-04-12
 
 ### README rewrite for open source

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, type ReactNode } from "react";
 import { isPast, isToday, differenceInDays } from "date-fns";
 import { Square, AlertTriangle, Trash2 } from "lucide-react";
 import type { ContactWithRelations } from "@shared/schema";
@@ -26,6 +26,22 @@ function detectCommand(text: string): { type: "fu" | "mtg" | "stage" | "status" 
 
 const COMMAND_COLORS: Record<string, string> = { fu: "#1a9e96", mtg: "#2563eb", stage: "#2e7d32", status: "#d4880f" };
 
+function HighlightText({ text, terms }: { text: string; terms?: string[] }): ReactNode {
+  if (!terms || terms.length === 0) return text;
+  const escaped = terms.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const regex = new RegExp(`(${escaped.join("|")})`, "gi");
+  const parts = text.split(regex);
+  return parts.map((part, i) =>
+    regex.test(part) ? (
+      <mark key={i} style={{ backgroundColor: "#fef08a", borderRadius: 2, padding: "0 1px" }}>
+        {part}
+      </mark>
+    ) : (
+      part
+    ),
+  );
+}
+
 interface ContactBlockProps {
   contact: ContactWithRelations;
   accentColor: string;
@@ -41,6 +57,7 @@ interface ContactBlockProps {
   onDeleteFollowup: (id: number) => void;
   onCompleteFollowup: (id: number, outcome?: string) => void;
   onUpdateContact: (data: Record<string, unknown>) => void;
+  searchTerms?: string[];
 }
 
 export function ContactBlock({
@@ -54,6 +71,7 @@ export function ContactBlock({
   onDeleteFollowup,
   onCompleteFollowup,
   onUpdateContact,
+  searchTerms,
 }: ContactBlockProps) {
   const C = useColors();
   const isInactive = contact.status !== "ACTIVE";
@@ -94,6 +112,15 @@ export function ContactBlock({
   useEffect(() => {
     setBackgroundText(derivedBackground);
   }, [derivedBackground]);
+
+  useEffect(() => {
+    if (searchTerms && searchTerms.length > 0) {
+      const hasInteractionMatch = contact.interactions.some((i) =>
+        searchTerms.some((t) => i.content.toLowerCase().includes(t.toLowerCase())),
+      );
+      if (hasInteractionMatch) setShowAllInteractions(true);
+    }
+  }, [searchTerms, contact.interactions]);
 
   const showFlash = useCallback((msg: string) => {
     setFlash(msg);
@@ -224,12 +251,12 @@ export function ContactBlock({
       {/* Header */}
       <div className="flex items-center gap-1.5">
         <h2 className="text-sm font-bold leading-tight" style={{ color: C.text }}>
-          {contact.firstName} {contact.lastName}
+          <HighlightText text={`${contact.firstName} ${contact.lastName}`} terms={searchTerms} />
         </h2>
 
         {companyName && (
           <span className="text-xs" style={{ color: C.muted }}>
-            {companyName}
+            <HighlightText text={companyName} terms={searchTerms} />
           </span>
         )}
 
@@ -320,7 +347,7 @@ export function ContactBlock({
             <div className="mt-1 text-[11px]" style={{ color: C.muted }}>
               {!showDetails ? (
                 <div>
-                  {previewLines.join(" · ")}
+                  <HighlightText text={previewLines.join(" · ")} terms={searchTerms} />
                   {hasMore && (
                     <button
                       onClick={() => setShowDetails(true)}
@@ -335,15 +362,29 @@ export function ContactBlock({
                 <div className="leading-relaxed space-y-0.5 pl-3" style={{ borderLeft: `2px solid ${C.border}` }}>
                   {contact.title && (
                     <div>
-                      {contact.title}
-                      {contact.location ? ` · ${contact.location}` : ""}
+                      <HighlightText
+                        text={contact.title + (contact.location ? ` · ${contact.location}` : "")}
+                        terms={searchTerms}
+                      />
                     </div>
                   )}
-                  {!contact.title && contact.location && <div>{contact.location}</div>}
-                  {contact.email && <div>{contact.email}</div>}
+                  {!contact.title && contact.location && (
+                    <div>
+                      <HighlightText text={contact.location} terms={searchTerms} />
+                    </div>
+                  )}
+                  {contact.email && (
+                    <div>
+                      <HighlightText text={contact.email} terms={searchTerms} />
+                    </div>
+                  )}
                   {contact.phone && <div>{contact.phone}</div>}
                   {contact.website && <div>{contact.website}</div>}
-                  {contact.source && <div>Via {contact.source}</div>}
+                  {contact.source && (
+                    <div>
+                      Via <HighlightText text={contact.source} terms={searchTerms} />
+                    </div>
+                  )}
                   {contact.additionalContacts && <div className="italic">{contact.additionalContacts}</div>}
                   {contact.cadence && <div className="font-medium">{contact.cadence}</div>}
                   {editingBackground ? (
@@ -366,7 +407,7 @@ export function ContactBlock({
                       onClick={() => setEditingBackground(true)}
                       className="cursor-text rounded px-1 -mx-1 py-0.5 transition-colors hover:bg-[#e6f7f6] mt-0.5"
                     >
-                      {contact.background}
+                      <HighlightText text={contact.background} terms={searchTerms} />
                     </div>
                   ) : null}
                   <button
@@ -466,7 +507,7 @@ export function ContactBlock({
                         className="group-hover/line:bg-[#e6f7f6] rounded px-0.5 -mx-0.5 transition-colors"
                         style={{ color: C.text }}
                       >
-                        {interaction.content}
+                        <HighlightText text={interaction.content} terms={searchTerms} />
                       </span>
                     </div>
                   );
@@ -636,7 +677,10 @@ export function ContactBlock({
                       {fmtDate(due)}
                       {fu.time ? ` ${fu.time}` : ""}
                     </span>
-                    <span style={{ color: isOverdue ? C.red : C.text }}> {truncated}</span>
+                    <span style={{ color: isOverdue ? C.red : C.text }}>
+                      {" "}
+                      <HighlightText text={truncated} terms={searchTerms} />
+                    </span>
                     {isOverdue && (
                       <span className="font-semibold" style={{ color: C.red }}>
                         {" "}

--- a/app/client/src/hooks/use-mini-search.ts
+++ b/app/client/src/hooks/use-mini-search.ts
@@ -1,0 +1,80 @@
+import { useMemo, useCallback } from "react";
+import MiniSearch from "minisearch";
+import type { ContactWithRelations } from "@shared/schema";
+
+interface SearchDoc {
+  id: number;
+  name: string;
+  title: string;
+  companyName: string;
+  background: string;
+  location: string;
+  source: string;
+  email: string;
+  interactionContent: string;
+  followupContent: string;
+}
+
+function buildDoc(c: ContactWithRelations): SearchDoc {
+  return {
+    id: c.id,
+    name: `${c.firstName} ${c.lastName}`,
+    title: c.title || "",
+    companyName: c.company?.name || "",
+    background: c.background || "",
+    location: c.location || "",
+    source: c.source || "",
+    email: c.email || "",
+    interactionContent: c.interactions.map((i) => i.content).join(" "),
+    followupContent: c.followups.map((f) => f.content).join(" "),
+  };
+}
+
+const FIELDS: (keyof SearchDoc)[] = [
+  "name",
+  "title",
+  "companyName",
+  "background",
+  "location",
+  "source",
+  "email",
+  "interactionContent",
+  "followupContent",
+];
+
+export function useMiniSearch(contacts: ContactWithRelations[]) {
+  const ms = useMemo(() => {
+    const instance = new MiniSearch<SearchDoc>({
+      fields: FIELDS as string[],
+      storeFields: [],
+      searchOptions: {
+        prefix: true,
+        fuzzy: 0.2,
+        boost: { name: 3, companyName: 2, title: 1.5 },
+      },
+    });
+    instance.addAll(contacts.map(buildDoc));
+    return instance;
+  }, [contacts]);
+
+  const search = useCallback(
+    (query: string) => {
+      if (!query.trim()) return [];
+      return ms.search(query);
+    },
+    [ms],
+  );
+
+  const getMatchTerms = useCallback(
+    (contactId: number, query: string): string[] => {
+      if (!query.trim()) return [];
+      const results = ms.search(query);
+      const match = results.find((r) => r.id === contactId);
+      if (!match) return [];
+      return [...match.terms];
+    },
+    [ms],
+  );
+
+  return { search, getMatchTerms };
+}

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useCrm } from "@/hooks/use-crm";
 import { useSSE } from "@/hooks/use-sse";
@@ -18,6 +18,7 @@ import {
   SlidersHorizontal,
   Menu,
   Check,
+  Search,
 } from "lucide-react";
 import { KanbanBoard } from "@/components/kanban/kanban-board";
 import { Link } from "wouter";
@@ -25,6 +26,7 @@ import { format, isPast, isToday, differenceInDays } from "date-fns";
 import type { Followup, ActivityLogEntry, Briefing } from "@shared/schema";
 import { fmtDate } from "@/lib/utils";
 import { useConfig, useColors } from "@/App";
+import { useMiniSearch } from "@/hooks/use-mini-search";
 
 // Pipeline order (funnel flow, top to bottom)
 const STAGES = ["ALL", "LEAD", "MEETING", "PROPOSAL", "NEGOTIATION", "LIVE", "RELATIONSHIP", "PASS"] as const;
@@ -75,6 +77,9 @@ export default function CrmPage() {
   }, [viewMode]);
   const [showFilter, setShowFilter] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
+  const [searchActive, setSearchActive] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const searchInputRef = useRef<HTMLInputElement>(null);
   useSSE();
 
   const sortedContacts = useMemo(() => {
@@ -106,10 +111,19 @@ export default function CrmPage() {
     return sorted;
   }, [contacts]);
 
+  const { search, getMatchTerms } = useMiniSearch(contacts);
+  const searchResultIds = useMemo(() => {
+    if (!searchActive || !searchQuery.trim()) return null;
+    return new Set(search(searchQuery).map((r) => r.id));
+  }, [searchActive, searchQuery, search]);
+
   const filteredContacts = useMemo(() => {
+    if (searchResultIds) {
+      return sortedContacts.filter((c) => searchResultIds.has(c.id));
+    }
     if (activeStage === "ALL") return sortedContacts;
     return sortedContacts.filter((c) => c.stage === activeStage);
-  }, [sortedContacts, activeStage]);
+  }, [sortedContacts, activeStage, searchResultIds]);
 
   const stageCounts = useMemo(() => {
     const counts: Record<string, number> = { ALL: contacts.length };
@@ -163,18 +177,30 @@ export default function CrmPage() {
     });
   };
 
-  // Today's meetings count for header
-  const todayMeetingCount = useMemo(() => {
-    return allFollowups.filter(({ followup: fu }) => fu.type === "meeting" && isToday(new Date(fu.dueDate))).length;
-  }, [allFollowups]);
-
   // Activity log
   const { data: activityLog = [] } = useQuery<ActivityLogEntry[]>({
     queryKey: ["/api/activity"],
     staleTime: 30_000,
   });
 
-  const activeCount = contacts.filter((c) => c.status === "ACTIVE").length;
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        if (searchActive) {
+          setSearchActive(false);
+          setSearchQuery("");
+        } else {
+          setSearchActive(true);
+          setShowFilter(false);
+          setShowMenu(false);
+          requestAnimationFrame(() => searchInputRef.current?.focus());
+        }
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [searchActive]);
 
   if (isLoading) {
     return (
@@ -189,17 +215,63 @@ export default function CrmPage() {
       {/* Header */}
       <header className="sticky top-0 z-50 bg-white" style={{ borderBottom: `1px solid ${C.border}` }}>
         <div className="max-w-[640px] mx-auto px-4 py-3 flex items-center justify-between">
-          <div>
-            <h1 className="text-[13px] font-semibold tracking-[0.2em] uppercase" style={{ color: C.text }}>
-              {orgName}
-            </h1>
-            <p className="text-[11px] font-mono mt-0.5" style={{ color: C.muted }}>
-              {activeCount} active
-              {todayMeetingCount > 0 && ` · ${todayMeetingCount} meeting${todayMeetingCount !== 1 ? "s" : ""} today`}
-              {allFollowups.length > 0 && ` · ${allFollowups.length} follow-up${allFollowups.length !== 1 ? "s" : ""}`}
-            </p>
-          </div>
+          {searchActive ? (
+            <div className="flex items-center gap-2 flex-1 mr-2">
+              <Search className="h-4 w-4 flex-shrink-0" style={{ color: C.muted }} />
+              <input
+                ref={searchInputRef}
+                autoFocus
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    setSearchActive(false);
+                    setSearchQuery("");
+                  }
+                }}
+                placeholder="Search contacts..."
+                className="flex-1 text-sm bg-transparent border-none outline-none"
+                style={{ color: C.text }}
+              />
+              {searchQuery && (
+                <button
+                  onClick={() => setSearchQuery("")}
+                  className="p-1 transition-colors hover:opacity-70"
+                  style={{ color: C.muted }}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </div>
+          ) : (
+            <div>
+              <h1 className="text-[13px] font-semibold tracking-[0.2em] uppercase" style={{ color: C.text }}>
+                {orgName}
+              </h1>
+            </div>
+          )}
           <div className="flex items-center gap-0.5 relative">
+            {/* Search button */}
+            <button
+              onClick={() => {
+                if (searchActive) {
+                  setSearchActive(false);
+                  setSearchQuery("");
+                } else {
+                  setSearchActive(true);
+                  setShowFilter(false);
+                  setShowMenu(false);
+                  requestAnimationFrame(() => searchInputRef.current?.focus());
+                }
+              }}
+              className="p-2 transition-colors"
+              style={{ color: searchActive ? C.accent : C.muted }}
+              title="Search (⌘K)"
+            >
+              <Search className="h-4 w-4" />
+            </button>
+
             {/* Filter button */}
             <button
               onClick={() => {
@@ -433,7 +505,7 @@ export default function CrmPage() {
       ) : (
         <main className="max-w-[640px] mx-auto px-4 py-5">
           {/* Upcoming — all follow-ups and meetings in one list */}
-          {allFollowups.length > 0 && (
+          {!searchActive && allFollowups.length > 0 && (
             <div
               className="bg-white mb-5"
               style={{ border: `1px solid ${C.border}`, borderRadius: "12px", padding: "1rem 1.25rem" }}
@@ -614,6 +686,7 @@ export default function CrmPage() {
               key={contact.id}
               contact={contact}
               accentColor={STAGE_ACCENT[contact.stage] || "#5a7a7a"}
+              searchTerms={searchActive ? getMatchTerms(contact.id, searchQuery) : undefined}
               onAddInteraction={(content, date, type) =>
                 addInteraction.mutate({ contactId: contact.id, content, date, type })
               }
@@ -631,7 +704,7 @@ export default function CrmPage() {
 
           {filteredContacts.length === 0 && (
             <p className="text-center py-16 text-sm" style={{ color: C.muted }}>
-              No contacts in this stage
+              {searchActive ? "No contacts match your search" : "No contacts in this stage"}
             </p>
           )}
         </main>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "claw-crm",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -45,6 +45,7 @@
         "express": "^4.21.2",
         "express-session": "^1.18.1",
         "lucide-react": "^0.453.0",
+        "minisearch": "^7.2.0",
         "pg": "^8.20.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -7673,6 +7674,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
     },
     "node_modules/mitt": {
       "version": "3.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -55,6 +55,7 @@
     "express": "^4.21.2",
     "express-session": "^1.18.1",
     "lucide-react": "^0.453.0",
+    "minisearch": "^7.2.0",
     "pg": "^8.20.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
## Summary
- Client-side full-text search using [MiniSearch](https://github.com/lucaong/minisearch) (BM25) across contacts, interactions, follow-ups, and contact details
- Search icon in header + **Cmd+K** / **Ctrl+K** keyboard shortcut to toggle search
- Inline header expansion replaces title with search input; Escape to dismiss
- Yellow match highlighting across contact name, company, interactions, follow-ups, and detail fields
- Interactions auto-expand when they contain matching text
- Search bypasses stage filter; clearing restores previous view
- Removed stats line from header for cleaner layout

Closes #55

## Test plan
- [x] Click search icon — input appears, title hides, Upcoming section hides
- [x] Type a contact name — list filters instantly to matching contacts
- [x] Type an interaction keyword — matching contacts appear with highlighted text
- [x] Cmd+K toggles search on/off
- [x] Escape closes search and restores full view + Upcoming section
- [x] Stage filter is bypassed during search, restored after clearing
- [x] X button clears search query
- [x] No results shows "No contacts match your search"
- [x] `npm run build` passes
- [x] `npm run lint:fix` passes with 0 warnings
- [x] E2E tests pass (all 9 steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)