### PR TITLE
Add full-text search with server-side BM25 ranking

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -97,29 +97,50 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 - Verify the stage badge updates to PROPOSAL
 - **Screenshot** → `e2e-screenshots/07-stage-changed.png`
 
-### 7. MCP: Search contacts
+### 7. UI: Search contacts (Cmd+K)
+- Click the search icon (magnifying glass) in the header, OR press Cmd+K
+- Verify the header switches to an inline search input with a close (X) button
+- Verify the Upcoming panel is hidden
+- Type a known contact's first name (at least 2 characters)
+- Verify the contact list filters in real-time to show only matching contacts
+- **Screenshot** → `e2e-screenshots/09-search-by-name.png`
+
+### 7b. UI: Search by interaction/followup content
+- Clear the search and type a word that appears in a contact's interaction note or followup (not in any contact name)
+- Verify matching contacts appear with a teal snippet line below the contact name
+- Verify the snippet shows the field label (e.g., "Note:", "Task:") and the matched term highlighted in yellow
+- **Screenshot** → `e2e-screenshots/10-search-snippet.png`
+
+### 7c. UI: Exit search
+- Press Escape or click the X button
+- Verify the header returns to showing the org name and icons
+- Verify the Upcoming panel reappears (if there are upcoming items)
+- Verify the previous stage filter is restored
+- **Screenshot** → `e2e-screenshots/11-search-exited.png`
+
+### 8. MCP: Search contacts
 - Get the MCP token: `curl -s -b <cookie-jar> http://localhost:3000/api/settings | python3 -c "import sys,json; print(json.load(sys.stdin)['mcpToken'])"`
 - Initialize MCP session with `method: "initialize"` (must include `Accept: application/json, text/event-stream` header)
 - Call `search_contacts` with a known contact name
 - Verify response contains `results` array with contact data (name, stage, status) and `totalCount`
 
-### 8. MCP: Add interaction via agent
+### 9. MCP: Add interaction via agent
 - Call `add_interaction` via MCP with a test note
 - Navigate to the CRM page in the browser
 - Verify the agent's note appears in the contact's timeline (SSE push)
-- **Screenshot** → `e2e-screenshots/08-mcp-agent-note.png`
+- **Screenshot** → `e2e-screenshots/12-mcp-agent-note.png`
 
-### 9. MCP: Get dashboard
+### 10. MCP: Get dashboard
 - Call `get_dashboard` via MCP
 - Verify it returns `totalContacts`, `byStage`, `overdueTasks`, and `activeViolations`
 
-### 10. Cleanup
+### 11. Cleanup
 - Kill the dev server
 - Write `e2e-screenshots/run.json` manifest with branch, timestamp, and per-step results
 - Report: PASS or FAIL with details of any failures
 
 ## Success Criteria
-All 10 steps pass. Screenshots captured for visual verification. If any step fails, fix the issue before creating the PR.
+All 11 steps pass. Screenshots captured for visual verification. If any step fails, fix the issue before creating the PR.
 
 ## How to Invoke
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-04-14
+
+### Full-text search with BM25 ranking
+- Added Cmd+K search with instant contact filtering across all fields (names, notes, tasks, briefings, email, etc.)
+- Server-side MiniSearch (BM25) engine powers both the UI and MCP `search_contacts` tool
+- Weighted field ranking: name/company 5x, tasks 3x, notes 2x, metadata 1x
+- Prefix matching + fuzzy typo tolerance (edit distance ~20%)
+- Preview snippets with teal background + yellow match highlights for non-name matches
+- Search ignores active stage filter; hides Upcoming panel; auto-switches kanban to list view
+- New `GET /api/search` REST endpoint; lazy index rebuild on data mutations
+- Removed stats line from header; added search icon with ⌘K tooltip
+- Client bundle reduced ~20KB (MiniSearch moved server-side)
+- E2E test steps added for search flows
+
 ## 2026-04-12
 
 ### README rewrite for open source

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,8 @@ npm run test -- tests/auth.spec.ts  # Single test file
 
 ## Before submitting a PR
 
-1. Run the E2E test skill (`.claude/skills/e2e-test/SKILL.md`). Do not create PR if any step fails.
-2. If the PR adds a major feature, add new E2E steps covering key flows before running.
+1. **If the PR adds a major feature, add new E2E steps to `.claude/skills/e2e-test/SKILL.md` covering key flows BEFORE running tests.** This is not optional — every user-facing feature must have E2E coverage.
+2. Run the E2E test skill (`.claude/skills/e2e-test/SKILL.md`). Do not create PR if any step fails.
 3. Update README.md if architecture, tools, or workflows changed.
 4. Add a CHANGELOG.md entry.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Uses `mcp-client.ts` which calls the REST API over HTTP:
 |------|-------------|
 | `get_crm_guide` | Agent usage guide + live CRM snapshot. Recommended first call. |
 | `get_dashboard` | Contacts by stage, overdue tasks, upcoming meetings, violations. |
-| `search_contacts` | Find by name, company, stage, or status. Paginated. |
+| `search_contacts` | BM25 full-text search across all contact data (names, notes, tasks, briefings). Ranked, paginated. |
 | `get_contact` | Full contact with all related data. |
 | `create_contact` | Add a new contact. |
 | `update_contact` | Modify contact fields. |

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -52,6 +52,38 @@ function SnippetText({ text, matchRanges }: { text: string; matchRanges: Array<[
   );
 }
 
+function findInlineMatchRanges(text: string, terms: string[]): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  const lower = text.toLowerCase();
+  for (const term of terms) {
+    const tLower = term.toLowerCase();
+    let pos = 0;
+    while (pos < lower.length) {
+      const idx = lower.indexOf(tLower, pos);
+      if (idx === -1) break;
+      ranges.push([idx, idx + tLower.length]);
+      pos = idx + 1;
+    }
+  }
+  ranges.sort((a, b) => a[0] - b[0]);
+  const merged: Array<[number, number]> = [];
+  for (const r of ranges) {
+    if (merged.length > 0 && r[0] <= merged[merged.length - 1][1]) {
+      merged[merged.length - 1][1] = Math.max(merged[merged.length - 1][1], r[1]);
+    } else {
+      merged.push([...r]);
+    }
+  }
+  return merged;
+}
+
+function HighlightedText({ text, terms }: { text: string; terms?: string[] }) {
+  if (!terms || terms.length === 0) return <>{text}</>;
+  const ranges = findInlineMatchRanges(text, terms);
+  if (ranges.length === 0) return <>{text}</>;
+  return <SnippetText text={text} matchRanges={ranges} />;
+}
+
 interface ContactBlockProps {
   contact: ContactWithRelations;
   accentColor: string;
@@ -68,6 +100,7 @@ interface ContactBlockProps {
   onCompleteFollowup: (id: number, outcome?: string) => void;
   onUpdateContact: (data: Record<string, unknown>) => void;
   searchSnippet?: SearchSnippet | null;
+  searchTerms?: string[];
 }
 
 export function ContactBlock({
@@ -82,6 +115,7 @@ export function ContactBlock({
   onCompleteFollowup,
   onUpdateContact,
   searchSnippet,
+  searchTerms,
 }: ContactBlockProps) {
   const C = useColors();
   const isInactive = contact.status !== "ACTIVE";
@@ -515,7 +549,7 @@ export function ContactBlock({
                         className="group-hover/line:bg-[#e6f7f6] rounded px-0.5 -mx-0.5 transition-colors"
                         style={{ color: C.text }}
                       >
-                        {interaction.content}
+                        <HighlightedText text={interaction.content} terms={searchTerms} />
                       </span>
                     </div>
                   );
@@ -685,7 +719,9 @@ export function ContactBlock({
                       {fmtDate(due)}
                       {fu.time ? ` ${fu.time}` : ""}
                     </span>
-                    <span style={{ color: isOverdue ? C.red : C.text }}> {truncated}</span>
+                    <span style={{ color: isOverdue ? C.red : C.text }}>
+                      {" "}<HighlightedText text={truncated} terms={searchTerms} />
+                    </span>
                     {isOverdue && (
                       <span className="font-semibold" style={{ color: C.red }}>
                         {" "}

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { isPast, isToday, differenceInDays } from "date-fns";
 import { Square, AlertTriangle, Trash2 } from "lucide-react";
 import type { ContactWithRelations } from "@shared/schema";
+import type { SearchSnippet } from "@/hooks/use-contact-search";
 import { fmtDate, fmtDateInput } from "@/lib/utils";
 import { useColors, BADGES } from "@/App";
 
@@ -26,6 +27,31 @@ function detectCommand(text: string): { type: "fu" | "mtg" | "stage" | "status" 
 
 const COMMAND_COLORS: Record<string, string> = { fu: "#1a9e96", mtg: "#2563eb", stage: "#2e7d32", status: "#d4880f" };
 
+function SnippetText({ text, matchRanges }: { text: string; matchRanges: Array<[number, number]> }) {
+  if (matchRanges.length === 0) return <span>{text}</span>;
+  const parts: Array<{ text: string; highlight: boolean }> = [];
+  let pos = 0;
+  for (const [start, end] of matchRanges) {
+    if (start > pos) parts.push({ text: text.slice(pos, start), highlight: false });
+    parts.push({ text: text.slice(start, end), highlight: true });
+    pos = end;
+  }
+  if (pos < text.length) parts.push({ text: text.slice(pos), highlight: false });
+  return (
+    <span>
+      {parts.map((p, i) =>
+        p.highlight ? (
+          <mark key={i} style={{ backgroundColor: "#fef08a", color: "inherit", borderRadius: 2, padding: "0 1px" }}>
+            {p.text}
+          </mark>
+        ) : (
+          <span key={i}>{p.text}</span>
+        ),
+      )}
+    </span>
+  );
+}
+
 interface ContactBlockProps {
   contact: ContactWithRelations;
   accentColor: string;
@@ -41,6 +67,7 @@ interface ContactBlockProps {
   onDeleteFollowup: (id: number) => void;
   onCompleteFollowup: (id: number, outcome?: string) => void;
   onUpdateContact: (data: Record<string, unknown>) => void;
+  searchSnippet?: SearchSnippet | null;
 }
 
 export function ContactBlock({
@@ -54,6 +81,7 @@ export function ContactBlock({
   onDeleteFollowup,
   onCompleteFollowup,
   onUpdateContact,
+  searchSnippet,
 }: ContactBlockProps) {
   const C = useColors();
   const isInactive = contact.status !== "ACTIVE";
@@ -302,6 +330,19 @@ export function ContactBlock({
           ) : null,
         )}
       </div>
+
+      {/* Search snippet */}
+      {searchSnippet && (
+        <div
+          className="mt-1.5 rounded-md px-2.5 py-1.5 text-[11px] truncate"
+          style={{ backgroundColor: C.accentLight, color: C.text }}
+        >
+          <span className="font-semibold mr-1" style={{ color: C.muted }}>
+            {searchSnippet.fieldLabel}:
+          </span>
+          <SnippetText text={searchSnippet.text} matchRanges={searchSnippet.matchRanges} />
+        </div>
+      )}
 
       {/* Details preview — first two lines, then "more..." */}
       {hasDetails &&

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -123,11 +123,6 @@ export function ContactBlock({
     setBackgroundText(derivedBackground);
   }, [derivedBackground]);
 
-  // Auto-expand interactions when search finds a match in a hidden note
-  useEffect(() => {
-    setShowAllInteractions(!!searchSnippet);
-  }, [searchSnippet]);
-
   const showFlash = useCallback((msg: string) => {
     setFlash(msg);
     setTimeout(() => setFlash(null), 2000);
@@ -441,15 +436,23 @@ export function ContactBlock({
               ? contact.interactions
               : contact.interactions.slice(-VISIBLE_COUNT);
 
+            // Check if the search match is in a hidden interaction
+            const hasHiddenMatch =
+              showToggle &&
+              searchSnippet?.fieldLabel === "Note" &&
+              contact.interactions
+                .slice(0, -VISIBLE_COUNT)
+                .some((i) => i.content.toLowerCase().includes(searchSnippet.text.replace(/^\u2026|\u2026$/g, "").trim().slice(0, 20).toLowerCase()));
+
             return (
               <div className="space-y-0.5 mb-2">
                 {showToggle && (
                   <button
                     onClick={() => setShowAllInteractions(true)}
                     className="text-[11px] font-medium mb-0.5 transition-colors hover:opacity-70"
-                    style={{ color: C.accentDark }}
+                    style={{ color: hasHiddenMatch ? C.accent : C.accentDark, fontWeight: hasHiddenMatch ? 600 : 500 }}
                   >
-                    Show {hiddenCount} earlier...
+                    Show {hiddenCount} earlier...{hasHiddenMatch ? " (match inside)" : ""}
                   </button>
                 )}
                 {showAllInteractions && total > VISIBLE_COUNT && (

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -123,6 +123,11 @@ export function ContactBlock({
     setBackgroundText(derivedBackground);
   }, [derivedBackground]);
 
+  // Auto-expand interactions when search finds a match in a hidden note
+  useEffect(() => {
+    setShowAllInteractions(!!searchSnippet);
+  }, [searchSnippet]);
+
   const showFlash = useCallback((msg: string) => {
     setFlash(msg);
     setTimeout(() => setFlash(null), 2000);

--- a/app/client/src/hooks/use-contact-search.ts
+++ b/app/client/src/hooks/use-contact-search.ts
@@ -1,0 +1,64 @@
+import { useState, useEffect, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { ContactWithRelations } from "@shared/schema";
+
+export interface SearchSnippet {
+  text: string;
+  matchRanges: Array<[number, number]>;
+  fieldLabel: string;
+}
+
+export interface SearchResult {
+  contact: ContactWithRelations;
+  snippet: SearchSnippet | null;
+}
+
+interface ServerSearchResult {
+  contactId: number;
+  score: number;
+  snippet: SearchSnippet | null;
+}
+
+interface ServerSearchResponse {
+  results: ServerSearchResult[];
+  totalCount: number;
+  hasMore: boolean;
+}
+
+function useDebouncedValue(value: string, delayMs: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+  return debounced;
+}
+
+export function useContactSearch(contacts: ContactWithRelations[], query: string): SearchResult[] {
+  const debouncedQuery = useDebouncedValue(query, 150);
+
+  const contactMap = useMemo(() => {
+    const map = new Map<number, ContactWithRelations>();
+    for (const c of contacts) map.set(c.id, c);
+    return map;
+  }, [contacts]);
+
+  const searchUrl = `/api/search?q=${encodeURIComponent(debouncedQuery)}`;
+
+  const { data } = useQuery<ServerSearchResponse>({
+    queryKey: [searchUrl],
+    enabled: debouncedQuery.length >= 2,
+    staleTime: 10_000,
+  });
+
+  return useMemo(() => {
+    if (!data || debouncedQuery.length < 2) return [];
+    return data.results
+      .map((r) => {
+        const contact = contactMap.get(r.contactId);
+        if (!contact) return null;
+        return { contact, snippet: r.snippet } satisfies SearchResult;
+      })
+      .filter((r): r is SearchResult => r !== null);
+  }, [data, contactMap, debouncedQuery]);
+}

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useCrm } from "@/hooks/use-crm";
 import { useSSE } from "@/hooks/use-sse";
@@ -18,6 +18,7 @@ import {
   SlidersHorizontal,
   Menu,
   Check,
+  Search,
 } from "lucide-react";
 import { KanbanBoard } from "@/components/kanban/kanban-board";
 import { Link } from "wouter";
@@ -25,6 +26,7 @@ import { format, isPast, isToday, differenceInDays } from "date-fns";
 import type { Followup, ActivityLogEntry, Briefing } from "@shared/schema";
 import { fmtDate } from "@/lib/utils";
 import { useConfig, useColors } from "@/App";
+import { useContactSearch } from "@/hooks/use-contact-search";
 
 // Pipeline order (funnel flow, top to bottom)
 const STAGES = ["ALL", "LEAD", "MEETING", "PROPOSAL", "NEGOTIATION", "LIVE", "RELATIONSHIP", "PASS"] as const;
@@ -75,7 +77,47 @@ export default function CrmPage() {
   }, [viewMode]);
   const [showFilter, setShowFilter] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
+  const [isSearchMode, setIsSearchMode] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [, setPreSearchViewMode] = useState<"list" | "kanban" | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   useSSE();
+
+  const searchResults = useContactSearch(contacts, isSearchMode ? searchQuery : "");
+
+  const enterSearch = useCallback(() => {
+    setViewMode((v) => {
+      if (v === "kanban") setPreSearchViewMode("kanban");
+      return v === "kanban" ? "list" : v;
+    });
+    setIsSearchMode(true);
+    setSearchQuery("");
+    setTimeout(() => searchInputRef.current?.focus(), 0);
+  }, []);
+
+  const exitSearch = useCallback(() => {
+    setIsSearchMode(false);
+    setSearchQuery("");
+    setPreSearchViewMode((prev) => {
+      if (prev) setViewMode(prev);
+      return null;
+    });
+  }, []);
+
+  // Cmd+K / Ctrl+K shortcut
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        enterSearch();
+      }
+      if (e.key === "Escape") {
+        exitSearch();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [enterSearch, exitSearch]);
 
   const sortedContacts = useMemo(() => {
     const sorted = [...contacts].sort((a, b) => {
@@ -163,18 +205,11 @@ export default function CrmPage() {
     });
   };
 
-  // Today's meetings count for header
-  const todayMeetingCount = useMemo(() => {
-    return allFollowups.filter(({ followup: fu }) => fu.type === "meeting" && isToday(new Date(fu.dueDate))).length;
-  }, [allFollowups]);
-
   // Activity log
   const { data: activityLog = [] } = useQuery<ActivityLogEntry[]>({
     queryKey: ["/api/activity"],
     staleTime: 30_000,
   });
-
-  const activeCount = contacts.filter((c) => c.status === "ACTIVE").length;
 
   if (isLoading) {
     return (
@@ -189,176 +224,194 @@ export default function CrmPage() {
       {/* Header */}
       <header className="sticky top-0 z-50 bg-white" style={{ borderBottom: `1px solid ${C.border}` }}>
         <div className="max-w-[640px] mx-auto px-4 py-3 flex items-center justify-between">
-          <div>
-            <h1 className="text-[13px] font-semibold tracking-[0.2em] uppercase" style={{ color: C.text }}>
-              {orgName}
-            </h1>
-            <p className="text-[11px] font-mono mt-0.5" style={{ color: C.muted }}>
-              {activeCount} active
-              {todayMeetingCount > 0 && ` · ${todayMeetingCount} meeting${todayMeetingCount !== 1 ? "s" : ""} today`}
-              {allFollowups.length > 0 && ` · ${allFollowups.length} follow-up${allFollowups.length !== 1 ? "s" : ""}`}
-            </p>
-          </div>
-          <div className="flex items-center gap-0.5 relative">
-            {/* Filter button */}
-            <button
-              onClick={() => {
-                setShowFilter(!showFilter);
-                setShowMenu(false);
-              }}
-              className="p-2 transition-colors"
-              style={{ color: activeStage !== "ALL" ? C.accent : C.muted }}
-              title="Filter by stage"
-            >
-              <SlidersHorizontal className="h-4 w-4" />
-            </button>
+          {isSearchMode ? (
+            <div className="flex items-center gap-2 flex-1 mr-2">
+              <Search className="h-4 w-4 flex-shrink-0" style={{ color: C.muted }} />
+              <input
+                ref={searchInputRef}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search contacts..."
+                className="flex-1 text-sm bg-transparent outline-none"
+                style={{ color: C.text }}
+                autoFocus
+              />
+              <button onClick={exitSearch} className="p-1 flex-shrink-0" style={{ color: C.muted }}>
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          ) : (
+            <>
+              <h1 className="text-[13px] font-semibold tracking-[0.2em] uppercase" style={{ color: C.text }}>
+                {orgName}
+              </h1>
+              <div className="flex items-center gap-0.5 relative">
+                {/* Search button */}
+                <button onClick={enterSearch} className="p-2 transition-colors" style={{ color: C.muted }} title="⌘K">
+                  <Search className="h-4 w-4" />
+                </button>
 
-            {/* Menu button */}
-            <button
-              onClick={() => {
-                setShowMenu(!showMenu);
-                setShowFilter(false);
-              }}
-              className="p-2 transition-colors"
-              style={{ color: C.muted }}
-              title="Menu"
-            >
-              <Menu className="h-4 w-4" />
-            </button>
-
-            {/* Filter dropdown */}
-            {showFilter && (
-              <>
-                <div className="fixed inset-0 z-[59]" onClick={() => setShowFilter(false)} />
-                <div
-                  className="absolute right-8 top-10 z-[60] py-1"
-                  style={{
-                    backgroundColor: "#fff",
-                    border: `1px solid ${C.border}`,
-                    borderRadius: 12,
-                    boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
-                    minWidth: 180,
+                {/* Filter button */}
+                <button
+                  onClick={() => {
+                    setShowFilter(!showFilter);
+                    setShowMenu(false);
                   }}
+                  className="p-2 transition-colors"
+                  style={{ color: activeStage !== "ALL" ? C.accent : C.muted }}
+                  title="Filter by stage"
                 >
-                  {STAGES.map((stage) => {
-                    const count = stageCounts[stage] || 0;
-                    const isActive = activeStage === stage;
-                    const label = stage === "ALL" ? "All" : stage.charAt(0) + stage.slice(1).toLowerCase();
-                    return (
-                      <button
-                        key={stage}
-                        onClick={() => {
-                          setActiveStage(isActive && stage !== "ALL" ? "ALL" : stage);
-                          setShowFilter(false);
-                        }}
-                        className="w-full flex items-center justify-between px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
-                        style={{
-                          color: stage !== "ALL" && count === 0 ? `${C.muted}80` : isActive ? C.accent : C.text,
-                          fontWeight: isActive ? 600 : 400,
-                        }}
-                      >
-                        <span>{label}</span>
-                        <span className="flex items-center gap-2">
-                          {stage !== "ALL" && (
-                            <span className="text-[11px]" style={{ color: C.muted }}>
-                              {count}
+                  <SlidersHorizontal className="h-4 w-4" />
+                </button>
+
+                {/* Menu button */}
+                <button
+                  onClick={() => {
+                    setShowMenu(!showMenu);
+                    setShowFilter(false);
+                  }}
+                  className="p-2 transition-colors"
+                  style={{ color: C.muted }}
+                  title="Menu"
+                >
+                  <Menu className="h-4 w-4" />
+                </button>
+
+                {/* Filter dropdown */}
+                {showFilter && (
+                  <>
+                    <div className="fixed inset-0 z-[59]" onClick={() => setShowFilter(false)} />
+                    <div
+                      className="absolute right-8 top-10 z-[60] py-1"
+                      style={{
+                        backgroundColor: "#fff",
+                        border: `1px solid ${C.border}`,
+                        borderRadius: 12,
+                        boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
+                        minWidth: 180,
+                      }}
+                    >
+                      {STAGES.map((stage) => {
+                        const count = stageCounts[stage] || 0;
+                        const isActive = activeStage === stage;
+                        const label = stage === "ALL" ? "All" : stage.charAt(0) + stage.slice(1).toLowerCase();
+                        return (
+                          <button
+                            key={stage}
+                            onClick={() => {
+                              setActiveStage(isActive && stage !== "ALL" ? "ALL" : stage);
+                              setShowFilter(false);
+                            }}
+                            className="w-full flex items-center justify-between px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
+                            style={{
+                              color: stage !== "ALL" && count === 0 ? `${C.muted}80` : isActive ? C.accent : C.text,
+                              fontWeight: isActive ? 600 : 400,
+                            }}
+                          >
+                            <span>{label}</span>
+                            <span className="flex items-center gap-2">
+                              {stage !== "ALL" && (
+                                <span className="text-[11px]" style={{ color: C.muted }}>
+                                  {count}
+                                </span>
+                              )}
+                              {isActive && <Check className="h-3.5 w-3.5" style={{ color: C.accent }} />}
                             </span>
-                          )}
-                          {isActive && <Check className="h-3.5 w-3.5" style={{ color: C.accent }} />}
-                        </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </>
+                )}
+
+                {/* Menu dropdown */}
+                {showMenu && (
+                  <>
+                    <div className="fixed inset-0 z-[59]" onClick={() => setShowMenu(false)} />
+                    <div
+                      className="absolute right-0 top-10 z-[60] py-1"
+                      style={{
+                        backgroundColor: "#fff",
+                        border: `1px solid ${C.border}`,
+                        borderRadius: 12,
+                        boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
+                        minWidth: 200,
+                      }}
+                    >
+                      {/* View toggle */}
+                      <button
+                        onClick={() => {
+                          setViewMode("list");
+                          setShowMenu(false);
+                        }}
+                        className="w-full flex items-center gap-3 px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
+                        style={{ color: viewMode === "list" ? C.accent : C.text }}
+                      >
+                        <LayoutList className="h-4 w-4" style={{ color: viewMode === "list" ? C.accent : C.muted }} />
+                        <span style={{ fontWeight: viewMode === "list" ? 600 : 400 }}>List view</span>
+                        {viewMode === "list" && <Check className="h-3.5 w-3.5 ml-auto" style={{ color: C.accent }} />}
                       </button>
-                    );
-                  })}
-                </div>
-              </>
-            )}
+                      <button
+                        onClick={() => {
+                          setViewMode("kanban");
+                          setShowMenu(false);
+                        }}
+                        className="w-full flex items-center gap-3 px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
+                        style={{ color: viewMode === "kanban" ? C.accent : C.text }}
+                      >
+                        <Kanban className="h-4 w-4" style={{ color: viewMode === "kanban" ? C.accent : C.muted }} />
+                        <span style={{ fontWeight: viewMode === "kanban" ? 600 : 400 }}>Kanban view</span>
+                        {viewMode === "kanban" && <Check className="h-3.5 w-3.5 ml-auto" style={{ color: C.accent }} />}
+                      </button>
 
-            {/* Menu dropdown */}
-            {showMenu && (
-              <>
-                <div className="fixed inset-0 z-[59]" onClick={() => setShowMenu(false)} />
-                <div
-                  className="absolute right-0 top-10 z-[60] py-1"
-                  style={{
-                    backgroundColor: "#fff",
-                    border: `1px solid ${C.border}`,
-                    borderRadius: 12,
-                    boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
-                    minWidth: 200,
-                  }}
-                >
-                  {/* View toggle */}
-                  <button
-                    onClick={() => {
-                      setViewMode("list");
-                      setShowMenu(false);
-                    }}
-                    className="w-full flex items-center gap-3 px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
-                    style={{ color: viewMode === "list" ? C.accent : C.text }}
-                  >
-                    <LayoutList className="h-4 w-4" style={{ color: viewMode === "list" ? C.accent : C.muted }} />
-                    <span style={{ fontWeight: viewMode === "list" ? 600 : 400 }}>List view</span>
-                    {viewMode === "list" && <Check className="h-3.5 w-3.5 ml-auto" style={{ color: C.accent }} />}
-                  </button>
-                  <button
-                    onClick={() => {
-                      setViewMode("kanban");
-                      setShowMenu(false);
-                    }}
-                    className="w-full flex items-center gap-3 px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
-                    style={{ color: viewMode === "kanban" ? C.accent : C.text }}
-                  >
-                    <Kanban className="h-4 w-4" style={{ color: viewMode === "kanban" ? C.accent : C.muted }} />
-                    <span style={{ fontWeight: viewMode === "kanban" ? 600 : 400 }}>Kanban view</span>
-                    {viewMode === "kanban" && <Check className="h-3.5 w-3.5 ml-auto" style={{ color: C.accent }} />}
-                  </button>
+                      <div className="my-1" style={{ borderTop: `1px solid ${C.border}` }} />
 
-                  <div className="my-1" style={{ borderTop: `1px solid ${C.border}` }} />
+                      <Link
+                        href="/rules"
+                        onClick={() => setShowMenu(false)}
+                        className="w-full flex items-center gap-3 px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
+                        style={{ color: C.text }}
+                      >
+                        <Zap className="h-4 w-4" style={{ color: C.muted }} />
+                        <span>Rules</span>
+                      </Link>
+                      <Link
+                        href="/settings"
+                        onClick={() => setShowMenu(false)}
+                        className="w-full flex items-center gap-3 px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
+                        style={{ color: C.text }}
+                      >
+                        <Settings className="h-4 w-4" style={{ color: C.muted }} />
+                        <span>Settings</span>
+                      </Link>
+                      <button
+                        onClick={() => {
+                          setShowActivityDrawer(!showActivityDrawer);
+                          setShowMenu(false);
+                        }}
+                        className="w-full flex items-center gap-3 px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
+                        style={{ color: C.text }}
+                      >
+                        <Activity className="h-4 w-4" style={{ color: C.muted }} />
+                        <span>Activity Log</span>
+                      </button>
 
-                  <Link
-                    href="/rules"
-                    onClick={() => setShowMenu(false)}
-                    className="w-full flex items-center gap-3 px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
-                    style={{ color: C.text }}
-                  >
-                    <Zap className="h-4 w-4" style={{ color: C.muted }} />
-                    <span>Rules</span>
-                  </Link>
-                  <Link
-                    href="/settings"
-                    onClick={() => setShowMenu(false)}
-                    className="w-full flex items-center gap-3 px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
-                    style={{ color: C.text }}
-                  >
-                    <Settings className="h-4 w-4" style={{ color: C.muted }} />
-                    <span>Settings</span>
-                  </Link>
-                  <button
-                    onClick={() => {
-                      setShowActivityDrawer(!showActivityDrawer);
-                      setShowMenu(false);
-                    }}
-                    className="w-full flex items-center gap-3 px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
-                    style={{ color: C.text }}
-                  >
-                    <Activity className="h-4 w-4" style={{ color: C.muted }} />
-                    <span>Activity Log</span>
-                  </button>
+                      <div className="my-1" style={{ borderTop: `1px solid ${C.border}` }} />
 
-                  <div className="my-1" style={{ borderTop: `1px solid ${C.border}` }} />
-
-                  <button
-                    onClick={() => logoutMutation.mutate()}
-                    className="w-full flex items-center gap-3 px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
-                    style={{ color: C.text }}
-                  >
-                    <LogOut className="h-4 w-4" style={{ color: C.muted }} />
-                    <span>Log out</span>
-                  </button>
-                </div>
-              </>
-            )}
-          </div>
+                      <button
+                        onClick={() => logoutMutation.mutate()}
+                        className="w-full flex items-center gap-3 px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
+                        style={{ color: C.text }}
+                      >
+                        <LogOut className="h-4 w-4" style={{ color: C.muted }} />
+                        <span>Log out</span>
+                      </button>
+                    </div>
+                  </>
+                )}
+              </div>
+            </>
+          )}
         </div>
       </header>
 
@@ -433,7 +486,7 @@ export default function CrmPage() {
       ) : (
         <main className="max-w-[640px] mx-auto px-4 py-5">
           {/* Upcoming — all follow-ups and meetings in one list */}
-          {allFollowups.length > 0 && (
+          {!isSearchMode && allFollowups.length > 0 && (
             <div
               className="bg-white mb-5"
               style={{ border: `1px solid ${C.border}`, borderRadius: "12px", padding: "1rem 1.25rem" }}
@@ -609,30 +662,61 @@ export default function CrmPage() {
           )}
 
           {/* Contact cards */}
-          {filteredContacts.map((contact) => (
-            <ContactBlock
-              key={contact.id}
-              contact={contact}
-              accentColor={STAGE_ACCENT[contact.stage] || "#5a7a7a"}
-              onAddInteraction={(content, date, type) =>
-                addInteraction.mutate({ contactId: contact.id, content, date, type })
-              }
-              onUpdateInteraction={(id, data) => updateInteraction.mutate({ id, ...data })}
-              onDeleteInteraction={(id) => deleteInteraction.mutate(id)}
-              onCreateFollowup={(content, dueDate, opts) =>
-                createFollowup.mutate({ contactId: contact.id, content, dueDate, ...opts })
-              }
-              onUpdateFollowup={(id, data) => updateFollowup.mutate({ id, ...data })}
-              onDeleteFollowup={(id) => deleteFollowup.mutate(id)}
-              onCompleteFollowup={(id, outcome) => completeFollowup.mutate({ id, outcome })}
-              onUpdateContact={(data) => updateContact.mutate({ id: contact.id, ...data })}
-            />
-          ))}
-
-          {filteredContacts.length === 0 && (
-            <p className="text-center py-16 text-sm" style={{ color: C.muted }}>
-              No contacts in this stage
-            </p>
+          {isSearchMode && searchQuery.length >= 2 ? (
+            <>
+              {searchResults.map(({ contact, snippet }) => (
+                <ContactBlock
+                  key={contact.id}
+                  contact={contact}
+                  accentColor={STAGE_ACCENT[contact.stage] || "#5a7a7a"}
+                  searchSnippet={snippet}
+                  onAddInteraction={(content, date, type) =>
+                    addInteraction.mutate({ contactId: contact.id, content, date, type })
+                  }
+                  onUpdateInteraction={(id, data) => updateInteraction.mutate({ id, ...data })}
+                  onDeleteInteraction={(id) => deleteInteraction.mutate(id)}
+                  onCreateFollowup={(content, dueDate, opts) =>
+                    createFollowup.mutate({ contactId: contact.id, content, dueDate, ...opts })
+                  }
+                  onUpdateFollowup={(id, data) => updateFollowup.mutate({ id, ...data })}
+                  onDeleteFollowup={(id) => deleteFollowup.mutate(id)}
+                  onCompleteFollowup={(id, outcome) => completeFollowup.mutate({ id, outcome })}
+                  onUpdateContact={(data) => updateContact.mutate({ id: contact.id, ...data })}
+                />
+              ))}
+              {searchResults.length === 0 && (
+                <p className="text-center py-16 text-sm" style={{ color: C.muted }}>
+                  No results
+                </p>
+              )}
+            </>
+          ) : (
+            <>
+              {(isSearchMode ? sortedContacts : filteredContacts).map((contact) => (
+                <ContactBlock
+                  key={contact.id}
+                  contact={contact}
+                  accentColor={STAGE_ACCENT[contact.stage] || "#5a7a7a"}
+                  onAddInteraction={(content, date, type) =>
+                    addInteraction.mutate({ contactId: contact.id, content, date, type })
+                  }
+                  onUpdateInteraction={(id, data) => updateInteraction.mutate({ id, ...data })}
+                  onDeleteInteraction={(id) => deleteInteraction.mutate(id)}
+                  onCreateFollowup={(content, dueDate, opts) =>
+                    createFollowup.mutate({ contactId: contact.id, content, dueDate, ...opts })
+                  }
+                  onUpdateFollowup={(id, data) => updateFollowup.mutate({ id, ...data })}
+                  onDeleteFollowup={(id) => deleteFollowup.mutate(id)}
+                  onCompleteFollowup={(id, outcome) => completeFollowup.mutate({ id, outcome })}
+                  onUpdateContact={(data) => updateContact.mutate({ id: contact.id, ...data })}
+                />
+              ))}
+              {filteredContacts.length === 0 && !isSearchMode && (
+                <p className="text-center py-16 text-sm" style={{ color: C.muted }}>
+                  No contacts in this stage
+                </p>
+              )}
+            </>
           )}
         </main>
       )}

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -670,6 +670,7 @@ export default function CrmPage() {
                   contact={contact}
                   accentColor={STAGE_ACCENT[contact.stage] || "#5a7a7a"}
                   searchSnippet={snippet}
+                  searchTerms={searchQuery.trim().split(/\s+/).filter(Boolean)}
                   onAddInteraction={(content, date, type) =>
                     addInteraction.mutate({ contactId: contact.id, content, date, type })
                   }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "claw-crm",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -45,6 +45,7 @@
         "express": "^4.21.2",
         "express-session": "^1.18.1",
         "lucide-react": "^0.453.0",
+        "minisearch": "^7.2.0",
         "pg": "^8.20.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -7673,6 +7674,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
     },
     "node_modules/mitt": {
       "version": "3.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -55,6 +55,7 @@
     "express": "^4.21.2",
     "express-session": "^1.18.1",
     "lucide-react": "^0.453.0",
+    "minisearch": "^7.2.0",
     "pg": "^8.20.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -21,6 +21,7 @@ import type { InsertContact } from "@shared/schema";
 import { db } from "./db";
 import { eq, and, isNull, gte, lte, asc, sql } from "drizzle-orm";
 import { sseManager } from "./sse";
+import { searchService } from "./search";
 import type { Express, Request, Response } from "express";
 import { randomUUID } from "crypto";
 
@@ -341,9 +342,12 @@ Good for: talking points, recent news, open items before a meeting.
   // --- Read Tools ---
   server.tool(
     "search_contacts",
-    "Search contacts by name, company, stage, or status. Returns a summary list with pagination.",
+    "Full-text search across all contact data including notes, tasks, and briefings. Returns a ranked summary list with pagination.",
     {
-      query: z.string().optional().describe("Search term (matches name, company, or email)"),
+      query: z
+        .string()
+        .optional()
+        .describe("Search term (full-text search across name, company, notes, tasks, briefings, email, and more)"),
       stage: stageEnum.optional().describe(`Filter by stage: ${STAGES.join(", ")}`),
       status: statusEnum.optional().describe(`Filter by status: ${STATUSES.join(", ")}`),
       limit: z.number().optional().describe("Max results to return (default 25)"),
@@ -351,6 +355,50 @@ Good for: talking points, recent news, open items before a meeting.
     },
     async ({ query, stage, status, limit, offset }) => {
       try {
+        const l = limit || 25;
+        const o = offset || 0;
+
+        // Use BM25 search when query is provided
+        if (query && query.length >= 2) {
+          const searchResult = await searchService.search(query, { stage, status, limit: l, offset: o });
+          const summary = searchResult.results
+            .map((r) => {
+              const c = searchService.getContact(r.contactId);
+              if (!c) return null;
+              return {
+                id: c.id,
+                name: `${c.firstName} ${c.lastName}`,
+                company: c.company?.name,
+                stage: c.stage,
+                status: c.status,
+                email: c.email,
+                lastInteraction:
+                  c.interactions.length > 0
+                    ? {
+                        date: c.interactions[c.interactions.length - 1].date,
+                        content: c.interactions[c.interactions.length - 1].content,
+                      }
+                    : null,
+                activeFollowups: c.followups.filter((f) => !f.completed).length,
+                violations: c.violations.length,
+              };
+            })
+            .filter(Boolean);
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  { results: summary, totalCount: searchResult.totalCount, hasMore: searchResult.hasMore },
+                  null,
+                  2,
+                ),
+              },
+            ],
+          };
+        }
+
+        // No query or too short — fall back to listing with optional filters
         let results = await storage.getContactsWithRelations();
         if (query) {
           const q = query.toLowerCase();
@@ -364,7 +412,7 @@ Good for: talking points, recent news, open items before a meeting.
         if (stage) results = results.filter((c) => c.stage === stage);
         if (status) results = results.filter((c) => c.status === status);
 
-        const { items, totalCount, hasMore } = paginate(results, limit || 25, offset || 0);
+        const { items, totalCount, hasMore } = paginate(results, l, o);
 
         const summary = items.map((c) => ({
           id: c.id,

--- a/app/server/mcp-server.ts
+++ b/app/server/mcp-server.ts
@@ -12,6 +12,7 @@ import {
   CONDITION_TYPES,
   EXCEPTION_TYPES,
 } from "@shared/schema";
+import { searchService } from "./search";
 
 // Zod enums from shared constants
 const stageEnum = z.enum(STAGES);
@@ -30,23 +31,69 @@ const server = new McpServer({
 
 server.tool(
   "search_contacts",
-  "Search contacts by name, company, stage, or status. Returns a paginated summary list.",
+  "Full-text search across all contact data including notes, tasks, and briefings. Returns a ranked summary list with pagination.",
   {
-    query: z.string().optional().describe("Search term (matches name, company, or email)"),
+    query: z
+      .string()
+      .optional()
+      .describe("Search term (full-text search across name, company, notes, tasks, briefings, email, and more)"),
     stage: stageEnum.optional().describe(`Filter by stage: ${STAGES.join(", ")}`),
     status: statusEnum.optional().describe(`Filter by status: ${STATUSES.join(", ")}`),
     limit: z.number().optional().describe("Max results to return (default 25)"),
     offset: z.number().optional().describe("Skip this many results (default 0)"),
   },
   async ({ query, stage, status, limit, offset }) => {
-    let contacts = await storage.getContactsWithRelations();
+    const l = limit || 25;
+    const o = offset || 0;
 
+    // Use BM25 search when query is provided and long enough
+    if (query && query.length >= 2) {
+      const searchResult = await searchService.search(query, { stage, status, limit: l, offset: o });
+      const summary = searchResult.results
+        .map((r) => {
+          const c = searchService.getContact(r.contactId);
+          if (!c) return null;
+          return {
+            id: c.id,
+            name: `${c.firstName} ${c.lastName}`,
+            company: c.company?.name,
+            stage: c.stage,
+            status: c.status,
+            email: c.email,
+            lastInteraction:
+              c.interactions.length > 0
+                ? {
+                    date: c.interactions[c.interactions.length - 1].date,
+                    content: c.interactions[c.interactions.length - 1].content,
+                  }
+                : null,
+            activeFollowups: c.followups.filter((f) => !f.completed).length,
+            violations: c.violations.length,
+          };
+        })
+        .filter(Boolean);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              { results: summary, totalCount: searchResult.totalCount, hasMore: searchResult.hasMore },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    }
+
+    // No query or too short — fall back to listing with optional filters
+    let contacts = await storage.getContactsWithRelations();
     if (query) {
       const q = query.toLowerCase();
       contacts = contacts.filter(
         (c) =>
           `${c.firstName} ${c.lastName}`.toLowerCase().includes(q) ||
-          c.company?.name.toLowerCase().includes(q) ||
+          c.company?.name?.toLowerCase().includes(q) ||
           c.email?.toLowerCase().includes(q),
       );
     }
@@ -54,8 +101,6 @@ server.tool(
     if (status) contacts = contacts.filter((c) => c.status === status);
 
     const total = contacts.length;
-    const l = limit || 25;
-    const o = offset || 0;
     const sliced = contacts.slice(o, o + l);
 
     const summary = sliced.map((c) => ({

--- a/app/server/routes.ts
+++ b/app/server/routes.ts
@@ -1,6 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
+import { searchService } from "./search";
 import { setupAuth, requireAuth } from "./auth";
 import { sseManager } from "./sse";
 import {
@@ -150,6 +151,19 @@ export async function registerRoutes(app: Express): Promise<Server> {
       await storage.updateContact(id, { sortOrder });
     }
     res.json({ ok: true });
+  });
+
+  // --- Search ---
+  app.get("/api/search", requireAuth, async (req, res) => {
+    const q = (req.query.q as string) || "";
+    if (q.length < 2) return res.json({ results: [], totalCount: 0, hasMore: false });
+    const result = await searchService.search(q, {
+      stage: req.query.stage as string | undefined,
+      status: req.query.status as string | undefined,
+      limit: req.query.limit ? parseInt(req.query.limit as string) : undefined,
+      offset: req.query.offset ? parseInt(req.query.offset as string) : undefined,
+    });
+    res.json(result);
   });
 
   // --- Companies ---
@@ -365,6 +379,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
     sseManager.broadcast({ type: "briefing_updated", contactId });
     storage.logActivity("briefing.saved", `Briefing updated (${content.length} chars)`, { contactId, source: "agent" });
+    searchService.invalidate();
     res.json(result);
   });
 
@@ -375,6 +390,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       .returning();
     if (result.length === 0) return res.status(404).json({ message: "Briefing not found" });
     sseManager.broadcast({ type: "briefing_deleted", contactId: parseInt(req.params.contactId) });
+    searchService.invalidate();
     res.status(204).send();
   });
 

--- a/app/server/search.ts
+++ b/app/server/search.ts
@@ -1,0 +1,319 @@
+import MiniSearch from "minisearch";
+import type { ContactWithRelations } from "@shared/schema";
+import { storage } from "./storage";
+
+// --- Types ---
+
+export interface SearchSnippet {
+  text: string;
+  matchRanges: Array<[number, number]>;
+  fieldLabel: string;
+}
+
+export interface ServerSearchResult {
+  contactId: number;
+  score: number;
+  snippet: SearchSnippet | null;
+}
+
+export interface SearchResponse {
+  results: ServerSearchResult[];
+  totalCount: number;
+  hasMore: boolean;
+}
+
+interface SearchDoc {
+  id: number;
+  firstName: string;
+  lastName: string;
+  companyName: string;
+  title: string;
+  email: string;
+  phone: string;
+  background: string;
+  location: string;
+  source: string;
+  interactionText: string;
+  followupText: string;
+  briefingText: string;
+}
+
+// --- Constants ---
+
+const FIELDS: Array<keyof SearchDoc> = [
+  "firstName",
+  "lastName",
+  "companyName",
+  "followupText",
+  "interactionText",
+  "title",
+  "email",
+  "phone",
+  "background",
+  "location",
+  "source",
+  "briefingText",
+];
+
+const BOOST: Partial<Record<keyof SearchDoc, number>> = {
+  firstName: 5,
+  lastName: 5,
+  companyName: 5,
+  followupText: 3,
+  interactionText: 2,
+};
+
+const NAME_FIELDS = new Set(["firstName", "lastName", "companyName"]);
+
+const FIELD_LABELS: Partial<Record<string, string>> = {
+  interactionText: "Note",
+  followupText: "Task",
+  briefingText: "Briefing",
+  title: "Title",
+  email: "Email",
+  phone: "Phone",
+  background: "Background",
+  location: "Location",
+  source: "Source",
+};
+
+const FIELD_PRIORITY = [
+  "followupText",
+  "interactionText",
+  "briefingText",
+  "title",
+  "email",
+  "background",
+  "phone",
+  "location",
+  "source",
+];
+
+// --- Pure helpers (ported from client) ---
+
+function contactToDoc(c: ContactWithRelations): SearchDoc {
+  return {
+    id: c.id,
+    firstName: c.firstName,
+    lastName: c.lastName,
+    companyName: c.company?.name || "",
+    title: c.title || "",
+    email: c.email || "",
+    phone: c.phone || "",
+    background: c.background || "",
+    location: c.location || "",
+    source: c.source || "",
+    interactionText: c.interactions.map((i) => i.content).join("\n"),
+    followupText: c.followups.map((f) => f.content).join("\n"),
+    briefingText: c.briefing?.content || "",
+  };
+}
+
+function findMatchRanges(text: string, terms: string[]): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  const lower = text.toLowerCase();
+  for (const term of terms) {
+    const tLower = term.toLowerCase();
+    let pos = 0;
+    while (pos < lower.length) {
+      const idx = lower.indexOf(tLower, pos);
+      if (idx === -1) break;
+      ranges.push([idx, idx + tLower.length]);
+      pos = idx + 1;
+    }
+  }
+  ranges.sort((a, b) => a[0] - b[0]);
+  const merged: Array<[number, number]> = [];
+  for (const r of ranges) {
+    if (merged.length > 0 && r[0] <= merged[merged.length - 1][1]) {
+      merged[merged.length - 1][1] = Math.max(merged[merged.length - 1][1], r[1]);
+    } else {
+      merged.push([...r]);
+    }
+  }
+  return merged;
+}
+
+function extractSnippet(fieldValue: string, terms: string[], fieldKey: string): SearchSnippet | null {
+  if (!fieldValue) return null;
+  const lower = fieldValue.toLowerCase();
+
+  const lines = fieldValue.split("\n").filter((l) => l.trim());
+  let bestLine = fieldValue;
+  let bestScore = 0;
+
+  for (const line of lines) {
+    const lineLower = line.toLowerCase();
+    let score = 0;
+    for (const term of terms) {
+      if (lineLower.includes(term.toLowerCase())) score++;
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      bestLine = line;
+    }
+  }
+
+  if (bestScore === 0) {
+    let hasMatch = false;
+    for (const term of terms) {
+      if (lower.includes(term.toLowerCase())) {
+        hasMatch = true;
+        break;
+      }
+    }
+    if (!hasMatch) return null;
+  }
+
+  const source = bestLine;
+  const sourceLower = source.toLowerCase();
+  let firstMatchIdx = 0;
+  for (const term of terms) {
+    const idx = sourceLower.indexOf(term.toLowerCase());
+    if (idx !== -1) {
+      firstMatchIdx = idx;
+      break;
+    }
+  }
+
+  const WINDOW = 80;
+  let start = Math.max(0, firstMatchIdx - Math.floor(WINDOW / 3));
+  const end = Math.min(source.length, start + WINDOW);
+  if (end - start < WINDOW) start = Math.max(0, end - WINDOW);
+
+  let text = source.slice(start, end).trim();
+  if (start > 0) text = "\u2026" + text;
+  if (end < source.length) text = text + "\u2026";
+
+  const matchRanges = findMatchRanges(text, terms);
+  const label = FIELD_LABELS[fieldKey] || fieldKey;
+
+  return { text, matchRanges, fieldLabel: label };
+}
+
+// --- SearchService ---
+
+class SearchService {
+  private index: MiniSearch<SearchDoc> | null = null;
+  private contactCache = new Map<number, ContactWithRelations>();
+  private dirty = true;
+  private buildPromise: Promise<void> | null = null;
+
+  /** Mark the index as stale. Cheap — no async work. */
+  invalidate(): void {
+    this.dirty = true;
+  }
+
+  /** Ensure the index is fresh before searching. Deduplicates concurrent rebuilds. */
+  private async ensureIndex(): Promise<void> {
+    if (!this.dirty && this.index) return;
+    if (this.buildPromise) {
+      await this.buildPromise;
+      return;
+    }
+    this.buildPromise = this.rebuild();
+    try {
+      await this.buildPromise;
+    } finally {
+      this.buildPromise = null;
+    }
+  }
+
+  private async rebuild(): Promise<void> {
+    const contacts = await storage.getContactsWithRelations();
+    const ms = new MiniSearch<SearchDoc>({
+      fields: FIELDS as unknown as string[],
+      storeFields: ["id"],
+      searchOptions: {
+        boost: BOOST as Record<string, number>,
+        prefix: true,
+        fuzzy: 0.2,
+        combineWith: "AND",
+      },
+    });
+
+    const cache = new Map<number, ContactWithRelations>();
+    const docs: SearchDoc[] = [];
+    for (const c of contacts) {
+      cache.set(c.id, c);
+      docs.push(contactToDoc(c));
+    }
+    ms.addAll(docs);
+
+    this.index = ms;
+    this.contactCache = cache;
+    this.dirty = false;
+  }
+
+  /** Get a cached contact by ID (available after ensureIndex). */
+  getContact(id: number): ContactWithRelations | undefined {
+    return this.contactCache.get(id);
+  }
+
+  /** Get all cached contacts (available after ensureIndex). */
+  getAllContacts(): ContactWithRelations[] {
+    return [...this.contactCache.values()];
+  }
+
+  async search(
+    query: string,
+    opts?: { stage?: string; status?: string; limit?: number; offset?: number },
+  ): Promise<SearchResponse> {
+    await this.ensureIndex();
+    if (!this.index || query.length < 2) {
+      return { results: [], totalCount: 0, hasMore: false };
+    }
+
+    const rawResults = this.index.search(query);
+    const terms = query
+      .trim()
+      .split(/\s+/)
+      .filter((t) => t.length > 0);
+
+    let results: ServerSearchResult[] = [];
+
+    for (const result of rawResults) {
+      const contact = this.contactCache.get(result.id as number);
+      if (!contact) continue;
+
+      // Apply optional stage/status filters
+      if (opts?.stage && contact.stage !== opts.stage) continue;
+      if (opts?.status && contact.status !== opts.status) continue;
+
+      // Extract snippet — only when the match is NOT on name/company fields
+      let snippet: SearchSnippet | null = null;
+      const allMatchedFields = new Set<string>();
+      for (const fields of Object.values(result.match)) {
+        for (const f of fields) allMatchedFields.add(f);
+      }
+      const hasNameMatch = [...allMatchedFields].some((f) => NAME_FIELDS.has(f));
+      const nonNameFields = [...allMatchedFields].filter((f) => !NAME_FIELDS.has(f));
+
+      // If name/company matched, skip snippet — the name is already visible in the card
+      if (!hasNameMatch && nonNameFields.length > 0) {
+        const doc = contactToDoc(contact);
+        for (const field of FIELD_PRIORITY) {
+          if (nonNameFields.includes(field)) {
+            const value = doc[field as keyof SearchDoc] as string;
+            const s = extractSnippet(value, terms, field);
+            if (s) {
+              snippet = s;
+              break;
+            }
+          }
+        }
+      }
+
+      results.push({ contactId: contact.id, score: result.score, snippet });
+    }
+
+    const totalCount = results.length;
+    const limit = opts?.limit || 25;
+    const offset = opts?.offset || 0;
+    results = results.slice(offset, offset + limit);
+
+    return { results, totalCount, hasMore: offset + limit < totalCount };
+  }
+}
+
+export const searchService = new SearchService();

--- a/app/server/storage.ts
+++ b/app/server/storage.ts
@@ -40,6 +40,19 @@ async function triggerRulesEvaluation(contactId: number) {
   evaluateRulesForContact(contactId).catch((err) => console.error("Reactive rules evaluation failed:", err));
 }
 
+// Lazy import for search index invalidation
+let _searchInvalidate: (() => void) | null = null;
+function invalidateSearch() {
+  if (!_searchInvalidate) {
+    import("./search").then((m) => {
+      _searchInvalidate = m.searchService.invalidate.bind(m.searchService);
+      _searchInvalidate();
+    });
+  } else {
+    _searchInvalidate();
+  }
+}
+
 const PostgresSessionStore = connectPg(session);
 
 export class Storage {
@@ -179,6 +192,7 @@ export class Storage {
       contactId: contact.id,
       source: "agent",
     });
+    invalidateSearch();
     return contact;
   }
 
@@ -197,6 +211,7 @@ export class Storage {
         source: "agent",
         metadata: data as Record<string, unknown>,
       });
+      invalidateSearch();
     }
     return contact;
   }
@@ -211,6 +226,7 @@ export class Storage {
           contactId: id,
           source: "agent",
         });
+      invalidateSearch();
     }
     return result.length > 0;
   }
@@ -232,6 +248,7 @@ export class Storage {
       `Added ${data.type || "note"} for ${name}: ${(data.content as string).slice(0, 80)}`,
       { contactId: data.contactId },
     );
+    invalidateSearch();
     return interaction;
   }
 
@@ -240,6 +257,7 @@ export class Storage {
     if (interaction) {
       sseManager.broadcast({ type: "interaction_updated", contactId: interaction.contactId });
       this.logActivity("interaction.updated", `Edited interaction ${id}`, { contactId: interaction.contactId });
+      invalidateSearch();
     }
     return interaction;
   }
@@ -249,6 +267,7 @@ export class Storage {
     if (deleted) {
       sseManager.broadcast({ type: "interaction_deleted", contactId: deleted.contactId });
       this.logActivity("interaction.deleted", `Deleted interaction ${id}`, { contactId: deleted.contactId });
+      invalidateSearch();
     }
     return !!deleted;
   }
@@ -283,6 +302,7 @@ export class Storage {
       `Created ${data.type || "task"} for ${name}: ${(data.content as string).slice(0, 80)}`,
       { contactId: data.contactId },
     );
+    invalidateSearch();
     return followup;
   }
 
@@ -294,6 +314,7 @@ export class Storage {
       this.logActivity("followup.updated", `Updated ${followup.type || "task"} ${id}: ${changes}`, {
         contactId: followup.contactId,
       });
+      invalidateSearch();
     }
     return followup;
   }
@@ -314,6 +335,7 @@ export class Storage {
         `Completed ${followup.type || "task"} for ${name}: ${followup.content.slice(0, 80)}`,
         { contactId: followup.contactId },
       );
+      invalidateSearch();
     }
     return followup;
   }
@@ -325,6 +347,7 @@ export class Storage {
       this.logActivity("followup.deleted", `Deleted ${deleted.type || "task"}: ${deleted.content.slice(0, 80)}`, {
         contactId: deleted.contactId,
       });
+      invalidateSearch();
     }
     return !!deleted;
   }
@@ -386,6 +409,7 @@ export class Storage {
       source: `rule:${data.ruleId}`,
       metadata: { ruleId: data.ruleId, severity: data.severity },
     });
+    invalidateSearch();
     return violation;
   }
 
@@ -395,7 +419,10 @@ export class Storage {
       .set({ resolvedAt: new Date() })
       .where(eq(ruleViolations.id, id))
       .returning();
-    if (violation) sseManager.broadcast({ type: "violation_resolved", contactId: violation.contactId });
+    if (violation) {
+      sseManager.broadcast({ type: "violation_resolved", contactId: violation.contactId });
+      invalidateSearch();
+    }
     return violation;
   }
 
@@ -410,6 +437,7 @@ export class Storage {
           isNull(ruleViolations.resolvedAt),
         ),
       );
+    invalidateSearch();
   }
 
   async hasActiveViolation(ruleId: number, contactId: number): Promise<boolean> {


### PR DESCRIPTION
## Summary
- **Server-side BM25 search** via MiniSearch — unified engine powering both the Cmd+K UI search and MCP `search_contacts` tool
- Searches across all contact fields (names, notes, tasks, briefings, email, title, background) with weighted ranking (name 5x, tasks 3x, notes 2x)
- Fuzzy matching + prefix search with lazy index rebuild on data mutations
- New `GET /api/search` REST endpoint; client hook rewritten as thin debounced API caller
- Header redesign: removed stats line, added search icon with ⌘K shortcut
- Snippet previews with teal background + yellow match highlights for non-name matches
- Client bundle reduced ~20KB (MiniSearch moved server-side)
- E2E test steps added for search flows

## Test plan
- [x] UI: Cmd+K opens inline search, ESC closes
- [x] UI: Type 2+ chars → contacts filter in real-time with BM25 ranking
- [x] UI: Name search → no snippet; note/task search → teal snippet with yellow highlights
- [x] UI: Upcoming panel hidden during search; restored on exit
- [x] API: `GET /api/search?q=advisory` returns ranked results with snippets
- [x] MCP: `search_contacts` with query searches notes/tasks/briefings
- [x] MCP: `get_dashboard` returns expected data
- [x] MCP: `add_interaction` creates note visible via SSE
- [x] Full E2E pass (13 steps, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)