### PR TITLE
Add snooze buttons to follow-ups (+1d, +7d, +14d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2026-04-15
 
+### Snooze follow-ups by 1/7/14 days
+- Hover over any follow-up to reveal snooze buttons (+1d, +7d, +14d)
+- Works in both the Upcoming panel and per-contact follow-up lists
+- Snooze updates the due date immediately via the existing API (fixes #40)
+
 ### Contact card UI polish
 - Flash notifications no longer overlap stage/status badges — now inline in the header row (fixes #42)
 - Status badge (ACTIVE/HOLD) is always visible and clickable to toggle — no more slash commands needed (fixes #39)

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { isPast, isToday, differenceInDays } from "date-fns";
-import { Square, AlertTriangle, Trash2 } from "lucide-react";
+import { Square, AlertTriangle, Trash2, Clock } from "lucide-react";
 import type { ContactWithRelations } from "@shared/schema";
 import type { SearchSnippet } from "@/hooks/use-contact-search";
 import { fmtDate, fmtDateInput } from "@/lib/utils";
@@ -702,57 +702,83 @@ export function ContactBlock({
               const fullText = fu.content + (fu.location ? ` — ${fu.location}` : "");
               const truncated = fullText.length > maxLen ? fullText.slice(0, maxLen) + "..." : fullText;
 
+              const handleSnooze = (days: number) => {
+                const newDate = new Date(due);
+                newDate.setDate(newDate.getDate() + days);
+                onUpdateFollowup(fu.id, { dueDate: newDate.toISOString() });
+                showFlash(`Snoozed to ${fmtDate(newDate)}`);
+              };
+
               return (
-                <div key={fu.id} className="flex items-start gap-1 text-xs">
-                  {isMeeting ? (
-                    <span className="flex-shrink-0 text-sm mt-px" title="Meeting">
-                      {icon}
-                    </span>
-                  ) : (
-                    <button
+                <div key={fu.id} className="group/fu">
+                  <div className="flex items-start gap-1 text-xs">
+                    {isMeeting ? (
+                      <span className="flex-shrink-0 text-sm mt-px" title="Meeting">
+                        {icon}
+                      </span>
+                    ) : (
+                      <button
+                        onClick={() => {
+                          setCompletingFollowupId(fu.id);
+                          setCompletingFollowupText(fu.content);
+                        }}
+                        className="flex-shrink-0 hover:opacity-70 mt-px"
+                        title="Complete"
+                        style={{ color: fuColor }}
+                      >
+                        <Square className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                    <span
+                      className="cursor-pointer hover:underline decoration-dotted underline-offset-2 min-w-0"
                       onClick={() => {
-                        setCompletingFollowupId(fu.id);
-                        setCompletingFollowupText(fu.content);
+                        setEditingFollowupId(fu.id);
+                        setEditingFollowupText(fu.content);
+                        setEditingFollowupDate(fmtDateInput(due));
                       }}
-                      className="flex-shrink-0 hover:opacity-70 mt-px"
-                      title="Complete"
-                      style={{ color: fuColor }}
                     >
-                      <Square className="h-3.5 w-3.5" />
-                    </button>
-                  )}
-                  <span
-                    className="cursor-pointer hover:underline decoration-dotted underline-offset-2 min-w-0"
-                    onClick={() => {
-                      setEditingFollowupId(fu.id);
-                      setEditingFollowupText(fu.content);
-                      setEditingFollowupDate(fmtDateInput(due));
-                    }}
-                  >
-                    <span className="font-semibold" style={{ color: fuColor }}>
-                      {fmtDate(due)}
-                      {fu.time ? ` ${fu.time}` : ""}
-                    </span>
-                    <span style={{ color: isOverdue ? C.red : C.text }}>
-                      {" "}
-                      <HighlightedText text={truncated} terms={searchTerms} />
-                    </span>
-                    {isOverdue && (
-                      <span className="font-semibold" style={{ color: C.red }}>
-                        {" "}
-                        OVERDUE
+                      <span className="font-semibold" style={{ color: fuColor }}>
+                        {fmtDate(due)}
+                        {fu.time ? ` ${fu.time}` : ""}
                       </span>
-                    )}
-                    {isTodayDue && (
-                      <span className="font-semibold" style={{ color: C.stale }}>
+                      <span style={{ color: isOverdue ? C.red : C.text }}>
                         {" "}
-                        TODAY
+                        <HighlightedText text={truncated} terms={searchTerms} />
                       </span>
-                    )}
-                    {!isOverdue && !isTodayDue && daysUntil <= 7 && (
-                      <span style={{ color: C.muted }}> {daysUntil}d</span>
-                    )}
-                  </span>
+                      {isOverdue && (
+                        <span className="font-semibold" style={{ color: C.red }}>
+                          {" "}
+                          OVERDUE
+                        </span>
+                      )}
+                      {isTodayDue && (
+                        <span className="font-semibold" style={{ color: C.stale }}>
+                          {" "}
+                          TODAY
+                        </span>
+                      )}
+                      {!isOverdue && !isTodayDue && daysUntil <= 7 && (
+                        <span style={{ color: C.muted }}> {daysUntil}d</span>
+                      )}
+                    </span>
+                    <span className="hidden group-hover/fu:inline-flex items-center gap-1 ml-auto flex-shrink-0">
+                      <Clock className="h-3 w-3" style={{ color: C.muted }} />
+                      {[1, 7, 14].map((d) => (
+                        <button
+                          key={d}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleSnooze(d);
+                          }}
+                          className="text-[10px] px-1.5 py-0.5 rounded-full transition-colors hover:opacity-80"
+                          style={{ backgroundColor: C.accentLight, color: C.accentDark }}
+                          title={`Snooze ${d} day${d > 1 ? "s" : ""}`}
+                        >
+                          +{d}d
+                        </button>
+                      ))}
+                    </span>
+                  </div>
                 </div>
               );
             })}

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -19,6 +19,7 @@ import {
   Menu,
   Check,
   Search,
+  Clock,
 } from "lucide-react";
 import { KanbanBoard } from "@/components/kanban/kanban-board";
 import { Link } from "wouter";
@@ -579,8 +580,14 @@ export default function CrmPage() {
                   const isTodayMeeting = isMeeting && isTodayDue;
                   const isExp = isTodayMeeting && expandedMeetingIds.has(fu.id);
 
+                  const handleUpcomingSnooze = (days: number) => {
+                    const newDate = new Date(due);
+                    newDate.setDate(newDate.getDate() + days);
+                    updateFollowup.mutate({ id: fu.id, dueDate: newDate.toISOString() });
+                  };
+
                   return (
-                    <div key={fu.id}>
+                    <div key={fu.id} className="group/upcoming">
                       <div className="flex items-center gap-2 text-sm">
                         {isMeeting ? (
                           <span
@@ -627,6 +634,23 @@ export default function CrmPage() {
                             {daysUntil}d
                           </span>
                         )}
+                        <span className="hidden group-hover/upcoming:inline-flex items-center gap-1 flex-shrink-0">
+                          <Clock className="h-3 w-3" style={{ color: C.muted }} />
+                          {[1, 7, 14].map((d) => (
+                            <button
+                              key={d}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleUpcomingSnooze(d);
+                              }}
+                              className="text-[10px] px-1.5 py-0.5 rounded-full transition-colors hover:opacity-80"
+                              style={{ backgroundColor: C.accentLight, color: C.accentDark }}
+                              title={`Snooze ${d} day${d > 1 ? "s" : ""}`}
+                            >
+                              +{d}d
+                            </button>
+                          ))}
+                        </span>
                         {isTodayMeeting && (
                           <ChevronDown
                             className={`h-3 w-3 flex-shrink-0 transition-transform cursor-pointer ${isExp ? "rotate-180" : ""}`}


### PR DESCRIPTION
## Summary
- Hover over any follow-up to reveal snooze pill buttons: **+1d**, **+7d**, **+14d**
- Works in both the **Upcoming panel** and **per-contact follow-up lists**
- Snooze updates the due date immediately via existing `PUT /api/followups/:id` endpoint
- Shows flash confirmation with the new date (fixes #40)

## Test plan
- [x] Hover over a task in Upcoming → snooze buttons appear (clock icon + 3 pills)
- [x] Click +7d → date moves forward 7 days, item re-sorts in Upcoming
- [x] Hover over a task in a contact card → same snooze buttons appear
- [x] Flash shows "Snoozed to X/X" confirmation
- [x] Build + lint + format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)