### PR TITLE
Truncate long interaction notes with more/less toggle

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -60,6 +60,14 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 - Verify the note appears in the contact's timeline with today's date
 - **Screenshot** → `e2e-screenshots/02-note-added.png`
 
+### 3b. UI: Long note truncation with more/less toggle
+- In the same contact's input, paste a long note (>280 chars), e.g. repeat a sentence until it exceeds 280 characters: `E2E long note test. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.`
+- Press Enter
+- Verify the rendered note ends in `…` followed by a `more...` button (teal link)
+- Click `more...` — verify the full note is revealed and the button now reads `less`
+- Click `less` — verify the note collapses back to the truncated form
+- **Screenshot** → `e2e-screenshots/02b-note-truncation.png`
+
 ### 4. UI: Create a task (follow-up)
 - In the same input, type: `/fu 12/31 E2E test task`
 - Verify the command hint appears ("task ready")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-04-16
+
+### Truncate long interaction notes
+- Individual notes over 280 characters now collapse with a `more...` / `less` toggle so one long note can't fill the page
+- Auto-expands when a search term matches inside the note, so matches stay visible
+
 ## 2026-04-15
 
 ### Snooze follow-ups by 1/7/14 days

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -583,7 +583,9 @@ export function ContactBlock({
                     searchTerms.some((t) => interaction.content.toLowerCase().includes(t.toLowerCase()));
                   const isExpanded = expandedInteractions.has(interaction.id) || hasSearchMatch;
                   const displayText =
-                    tooLong && !isExpanded ? interaction.content.slice(0, MAX_CHARS).trimEnd() + "…" : interaction.content;
+                    tooLong && !isExpanded
+                      ? interaction.content.slice(0, MAX_CHARS).trimEnd() + "…"
+                      : interaction.content;
                   return (
                     <div
                       key={interaction.id}

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -121,6 +121,7 @@ export function ContactBlock({
   const isInactive = contact.status !== "ACTIVE";
   const [showDetails, setShowDetails] = useState(false);
   const [showAllInteractions, setShowAllInteractions] = useState(false);
+  const [expandedInteractions, setExpandedInteractions] = useState<Set<number>>(new Set());
   const [newNote, setNewNote] = useState("");
   const [showStageMenu, setShowStageMenu] = useState(false);
   const [showStatusMenu, setShowStatusMenu] = useState(false);
@@ -575,6 +576,14 @@ export function ContactBlock({
                       </div>
                     );
                   }
+                  const MAX_CHARS = 280;
+                  const tooLong = interaction.content.length > MAX_CHARS;
+                  const hasSearchMatch =
+                    !!searchTerms?.length &&
+                    searchTerms.some((t) => interaction.content.toLowerCase().includes(t.toLowerCase()));
+                  const isExpanded = expandedInteractions.has(interaction.id) || hasSearchMatch;
+                  const displayText =
+                    tooLong && !isExpanded ? interaction.content.slice(0, MAX_CHARS).trimEnd() + "…" : interaction.content;
                   return (
                     <div
                       key={interaction.id}
@@ -591,7 +600,24 @@ export function ContactBlock({
                         className="group-hover/line:bg-[#e6f7f6] rounded px-0.5 -mx-0.5 transition-colors"
                         style={{ color: C.text }}
                       >
-                        <HighlightedText text={interaction.content} terms={searchTerms} />
+                        <HighlightedText text={displayText} terms={searchTerms} />
+                        {tooLong && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setExpandedInteractions((prev) => {
+                                const next = new Set(prev);
+                                if (next.has(interaction.id)) next.delete(interaction.id);
+                                else next.add(interaction.id);
+                                return next;
+                              });
+                            }}
+                            className="ml-1 transition-colors hover:opacity-70"
+                            style={{ color: C.accentDark }}
+                          >
+                            {isExpanded ? "less" : "more..."}
+                          </button>
+                        )}
                       </span>
                     </div>
                   );


### PR DESCRIPTION
## Summary
- Notes over 280 chars now collapse with an inline `more...` / `less` toggle so a single long note can't fill the contact card
- Auto-expands when a search term matches inside the note, keeping matches visible
- Adds E2E step 3b covering the new truncation flow

## Test plan
- [x] E2E suite: full 11-step run passes (screenshots in `e2e-screenshots/`, manifest marked pass)
- [x] Step 3b (new): long note truncates to 280 chars + `…`, `more...` button reveals full text, `less` collapses back
- [x] Step 7b (existing, extended): searching for a term inside a long note auto-expands it with yellow highlight
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)