### PR TITLE
PR workflow: Claude owns PRs end-to-end

### DIFF
--- a/.claude/hooks/pre-pr.sh
+++ b/.claude/hooks/pre-pr.sh
@@ -40,11 +40,6 @@ if [ "$LINT_EXIT" -ne 0 ]; then
   ERRORS="$ERRORS Lint errors found — run 'npm run lint:fix' in app/ first."
 fi
 
-# 4. Check PR is assigned to Parker
-if ! echo "$COMMAND" | grep -q "parkervoss"; then
-  ERRORS="$ERRORS PR must be assigned to parkervoss (add --assignee parkervoss)."
-fi
-
 if [ -n "$ERRORS" ]; then
   cat <<EOF
 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-04-16
+
+### PR workflow: Claude owns PRs end-to-end
+- Pre-PR hook no longer requires `--assignee parkervoss`
+- CLAUDE.md documents the post-create flow: monitor CI, address comments, merge when green (Railway auto-deploys from main)
+
 ## 2026-04-15
 
 ### Snooze follow-ups by 1/7/14 days

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,15 @@ npm run test -- tests/auth.spec.ts  # Single test file
 3. Update README.md if architecture, tools, or workflows changed.
 4. Add a CHANGELOG.md entry.
 
+## After creating a PR
+
+Don't assign reviewers — instead, own the PR through merge:
+
+1. Monitor CI (`gh pr checks <num> --watch` or poll with `gh pr checks <num>`).
+2. If CI fails, read the failing job logs, fix the cause, and push again.
+3. If reviewers leave comments, read them (`gh api repos/MagneticStudio/claw-crm/pulls/<num>/comments`), respond or address, and push fixes.
+4. Once CI is green and there are no unresolved comments, merge to main (`gh pr merge <num> --squash --delete-branch`). Railway auto-deploys from main.
+
 ## Gotchas
 
 - Dates: use `fmtDate` from `lib/utils.ts`. Using `format()` from date-fns causes off-by-one timezone bugs.


### PR DESCRIPTION
## Summary
- Pre-PR hook no longer requires `--assignee parkervoss` — Claude now owns PRs through merge instead of routing to a reviewer
- CLAUDE.md adds an "After creating a PR" section: monitor CI, address review comments, merge when green (Railway auto-deploys from main)

## Test plan
- [x] `gh pr create` without `--assignee` will now pass the pre-pr hook (this PR is the test)
- [x] CHANGELOG entry added
- [x] Other hook checks (CHANGELOG, E2E manifest, lint) still enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)