### PR TITLE
fix: idempotent boot migration for memory → journal rename

### DIFF
--- a/app/server/boot-migrations.ts
+++ b/app/server/boot-migrations.ts
@@ -1,0 +1,77 @@
+// Idempotent schema fixups run at boot. Used for small, safe structural changes
+// (renames, column adds with defaults) that should apply automatically on
+// Railway deploy without requiring a manual drizzle-kit push.
+//
+// Guardrails:
+// - Every statement must be idempotent and non-destructive (IF EXISTS / IF NOT EXISTS).
+// - Never DROP, TRUNCATE, or DELETE here. Destructive changes go through a
+//   deliberate migration, not boot code.
+
+import { pool } from "./db";
+
+interface BootMigration {
+  name: string;
+  sql: string;
+}
+
+const MIGRATIONS: BootMigration[] = [
+  {
+    // 2026-04-19: rename relationship_memory → relationship_journal (PR #68 follow-up).
+    // Renames are conditional on the old column/table still existing, so this is a no-op
+    // on already-migrated databases.
+    name: "rename_memory_to_journal",
+    sql: `
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'contacts' AND column_name = 'relationship_memory'
+  ) THEN
+    ALTER TABLE contacts RENAME COLUMN relationship_memory TO relationship_journal;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_name = 'contact_memory_revisions'
+  ) THEN
+    ALTER TABLE contact_memory_revisions RENAME TO contact_journal_revisions;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE indexname = 'contact_memory_revisions_contact_created_idx'
+  ) THEN
+    ALTER INDEX contact_memory_revisions_contact_created_idx
+      RENAME TO contact_journal_revisions_contact_created_idx;
+  END IF;
+END $$;
+
+-- Ensure the journal column exists (catches a fresh Postgres where neither name is present).
+ALTER TABLE contacts ADD COLUMN IF NOT EXISTS relationship_journal TEXT;
+
+-- Ensure the journal revisions table exists.
+CREATE TABLE IF NOT EXISTS contact_journal_revisions (
+  id SERIAL PRIMARY KEY,
+  contact_id INTEGER NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  source TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS contact_journal_revisions_contact_created_idx
+  ON contact_journal_revisions (contact_id, created_at DESC);
+`,
+  },
+];
+
+export async function runBootMigrations(): Promise<void> {
+  for (const m of MIGRATIONS) {
+    try {
+      await pool.query(m.sql);
+      console.warn(`[boot-migration] ${m.name}: ok`);
+    } catch (err) {
+      console.error(`[boot-migration] ${m.name}: FAILED`, err);
+      throw err;
+    }
+  }
+}

--- a/app/server/index.ts
+++ b/app/server/index.ts
@@ -37,6 +37,9 @@ app.use((req, res, next) => {
 });
 
 (async () => {
+  const { runBootMigrations } = await import("./boot-migrations");
+  await runBootMigrations();
+
   const server = await registerRoutes(app);
 
   app.use(


### PR DESCRIPTION
## Summary
**Production hotfix.** PR #68's rename of `relationship_memory` → `relationship_journal` was applied to local dev but not to Railway's production DB, causing the rules engine to crash every 15 minutes with `column relationship_memory does not exist`.

Adds `server/boot-migrations.ts`: idempotent, non-destructive DDL that runs on startup before `registerRoutes`. It checks whether the old column / table / index still exist and renames them in place. Already-migrated databases no-op. Fresh Postgres installs get the journal schema created.

Wired into `server/index.ts` boot sequence, so Railway catches up on the next deploy — no manual `drizzle-kit push` required.

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` passes with zero warnings
- [x] Local boot logs `[boot-migration] rename_memory_to_journal: ok` and app serves on port 3000
- [x] Browser verification: CRM page renders contacts, upcoming panel, and 📓 badges without errors post-migration
- [ ] Railway redeploys → migration runs on prod DB → rules engine stops crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)