### PR TITLE
Codify schema-change discipline; CI guard + CLAUDE.md policy

### DIFF
--- a/.claude/docs/schema-changes.md
+++ b/.claude/docs/schema-changes.md
@@ -1,0 +1,52 @@
+# Schema changes
+
+Railway auto-deploys code but NOT schema. Without a migration path in the repo, the deployed code runs against a stale DB and crashes. Past incident (2026-04-19): the `relationship_memory` → `relationship_journal` rename shipped in PR #68 ran fine locally, then broke prod because Railway's Postgres still had `relationship_memory`. CI didn't catch it — CI's test DB is always freshly created with the new schema, so it never exercises the upgrade path.
+
+## The rule
+
+Every PR that modifies `app/shared/schema.ts` MUST include a matching entry in `app/server/boot-migrations.ts`. CI enforces this (see `.github/workflows/ci.yml`).
+
+The migration runs on every server start before `registerRoutes`. It must be:
+
+1. **Idempotent** — safe to run N times. Use `IF EXISTS` / `IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, `DO $$ BEGIN ... END $$` guards.
+2. **Non-destructive** — never `DROP`, `TRUNCATE`, or `DELETE` here. Destructive changes go through a deliberate PR with explicit user approval, not boot code.
+3. **Verified locally** — restart the dev server; logs should show `[boot-migration] <name>: ok` and the app should boot without errors.
+4. **Self-documenting** — the migration's `name` field prefixed with the ISO date and the PR number.
+
+## Common shapes
+
+**Add column:**
+```sql
+ALTER TABLE x ADD COLUMN IF NOT EXISTS col type;
+```
+
+**Rename column:**
+```sql
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'x' AND column_name = 'old_col'
+  ) THEN
+    ALTER TABLE x RENAME COLUMN old_col TO new_col;
+  END IF;
+END $$;
+```
+
+**Rename table:** same pattern via `information_schema.tables`.
+
+**New table:**
+```sql
+CREATE TABLE IF NOT EXISTS ... ( ... );
+```
+
+## When NOT to use a boot migration
+
+Anything destructive — dropping columns or tables, data rewrites, constraint tightening that can fail on existing rows. Those need a named migration file, explicit user approval, and a plan for rollback.
+
+## Dev-time workflow
+
+Local dev can still use `npm run db:push` for experimentation. The PR must carry the boot migration so prod catches up automatically on the next Railway deploy. Do not rely on remembering to run `db:push` against prod — we don't have prod credentials in CI, and `db:push` is interactive anyway.
+
+## Long-term direction
+
+The boot-migrations pattern is the minimum viable fix. The cleaner path is committed `drizzle-kit generate` migration files that run via `drizzle-kit migrate` on deploy. Consider when the migration list gets unwieldy or when we need destructive migrations with rollback.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,23 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Schema changes require a boot migration
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          if git diff --name-only "$BASE"...HEAD | grep -q '^app/shared/schema\.ts$'; then
+            if ! git diff --name-only "$BASE"...HEAD | grep -q '^app/server/boot-migrations\.ts$'; then
+              echo "❌ app/shared/schema.ts changed but app/server/boot-migrations.ts did not."
+              echo "   Railway does not auto-run drizzle-kit push against prod."
+              echo "   Every schema change needs a matching idempotent entry in boot-migrations.ts."
+              echo "   See CLAUDE.md → 'Schema changes'."
+              exit 1
+            fi
+            echo "✅ Schema change carries a boot-migrations.ts update."
+          fi
+        working-directory: .
 
       - uses: actions/setup-node@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-04-19
+
+### Boot migrations + CI guard for schema changes (hotfix)
+- **What went wrong**: PR #68's `relationship_memory` → `relationship_journal` rename landed in code but not on Railway's production DB. Railway auto-deploys code but does NOT run `drizzle-kit push`. The rules engine started crashing in prod every 15 minutes with `column relationship_memory does not exist`. CI passed because its test DB is always freshly created with the new schema — it never sees the upgrade path.
+- **Fix**: `app/server/boot-migrations.ts` runs idempotent DDL on startup before `registerRoutes`. Renames the column/table/index conditionally; no-ops when already migrated.
+- **Prevention**: CI now fails any PR that changes `app/shared/schema.ts` without also updating `app/server/boot-migrations.ts`. CLAUDE.md codifies the rule (idempotent, non-destructive, verified locally, dated migration entries).
+
 ## 2026-04-18
 
 ### Relationship journal — persistent per-contact narrative document (#66)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ npm run test -- tests/auth.spec.ts  # Single test file
 - MCP session recovery: stale session IDs auto-create fresh sessions. Don't error on unknown sessions.
 - Rules are data (JSONB), not code. Agents CRUD them via MCP.
 - Railway auto-deploys from main. Root directory is `app/`.
+- **Railway does NOT auto-run `drizzle-kit push`.** Code deploys; schema does not. See "Schema changes" below.
 
 ## Conventions
 
@@ -59,6 +60,27 @@ Don't assign reviewers — instead, own the PR through merge:
 2. If CI fails, read the failing job logs, fix the cause, and push again.
 3. If reviewers leave comments, read them (`gh api repos/MagneticStudio/claw-crm/pulls/<num>/comments`), respond or address, and push fixes.
 4. Once CI is green and there are no unresolved comments, merge to main (`gh pr merge <num> --squash --delete-branch`). Railway auto-deploys from main.
+
+## Schema changes (MANDATORY when touching shared/schema.ts)
+
+Railway auto-deploys code but NOT schema. Without a migration path in the repo, the deployed code runs against a stale DB and crashes. Past incident: the memory → journal rename shipped in PR #68 ran fine locally, then broke prod because Railway's Postgres still had `relationship_memory`.
+
+**The rule:** every PR that modifies `shared/schema.ts` MUST include a matching boot-time migration in `app/server/boot-migrations.ts`. The migration runs on every server start before `registerRoutes` and must be:
+
+1. **Idempotent** — safe to run N times. Use `IF EXISTS` / `IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, `DO $$ BEGIN ... END $$` guards.
+2. **Non-destructive** — never DROP, TRUNCATE, or DELETE here. Destructive changes need a deliberate PR with explicit user approval, not boot code.
+3. **Verified locally** — restart the dev server; logs should show `[boot-migration] <name>: ok` and the app should boot without errors.
+4. **Self-documenting** — the migration's `name` field should be prefixed with the ISO date and reference the PR number.
+
+Common shapes:
+- Add column: `ALTER TABLE x ADD COLUMN IF NOT EXISTS col type;`
+- Rename column: wrap in `DO $$ BEGIN IF EXISTS (SELECT 1 FROM information_schema.columns WHERE ...) THEN ALTER TABLE ... RENAME COLUMN ... END IF; END $$;`
+- Rename table: same pattern via `information_schema.tables`
+- New table: `CREATE TABLE IF NOT EXISTS ... ( ... );`
+
+Local dev can still use `npm run db:push` for experimentation, but the PR must carry the boot migration so prod catches up automatically. Do not rely on remembering to run `db:push` against prod — we don't have prod credentials in CI, and it's interactive anyway.
+
+**When NOT to use a boot migration:** anything destructive (dropping columns/tables, data rewrites, constraint tightening). Those need a named migration file, explicit user approval, and a plan for rollback.
 
 ## Gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,7 @@ npm run test -- tests/auth.spec.ts  # Single test file
 - MCP remote endpoint at `/mcp/:token` (StreamableHTTP). All MCP tools must have try/catch or they crash the session.
 - MCP session recovery: stale session IDs auto-create fresh sessions. Don't error on unknown sessions.
 - Rules are data (JSONB), not code. Agents CRUD them via MCP.
-- Railway auto-deploys from main. Root directory is `app/`.
-- **Railway does NOT auto-run `drizzle-kit push`.** Code deploys; schema does not. See "Schema changes" below.
+- Railway auto-deploys from main. Root directory is `app/`. Schema is NOT auto-migrated — see "Schema changes" below.
 
 ## Conventions
 
@@ -61,26 +60,9 @@ Don't assign reviewers — instead, own the PR through merge:
 3. If reviewers leave comments, read them (`gh api repos/MagneticStudio/claw-crm/pulls/<num>/comments`), respond or address, and push fixes.
 4. Once CI is green and there are no unresolved comments, merge to main (`gh pr merge <num> --squash --delete-branch`). Railway auto-deploys from main.
 
-## Schema changes (MANDATORY when touching shared/schema.ts)
+## Schema changes
 
-Railway auto-deploys code but NOT schema. Without a migration path in the repo, the deployed code runs against a stale DB and crashes. Past incident: the memory → journal rename shipped in PR #68 ran fine locally, then broke prod because Railway's Postgres still had `relationship_memory`.
-
-**The rule:** every PR that modifies `shared/schema.ts` MUST include a matching boot-time migration in `app/server/boot-migrations.ts`. The migration runs on every server start before `registerRoutes` and must be:
-
-1. **Idempotent** — safe to run N times. Use `IF EXISTS` / `IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, `DO $$ BEGIN ... END $$` guards.
-2. **Non-destructive** — never DROP, TRUNCATE, or DELETE here. Destructive changes need a deliberate PR with explicit user approval, not boot code.
-3. **Verified locally** — restart the dev server; logs should show `[boot-migration] <name>: ok` and the app should boot without errors.
-4. **Self-documenting** — the migration's `name` field should be prefixed with the ISO date and reference the PR number.
-
-Common shapes:
-- Add column: `ALTER TABLE x ADD COLUMN IF NOT EXISTS col type;`
-- Rename column: wrap in `DO $$ BEGIN IF EXISTS (SELECT 1 FROM information_schema.columns WHERE ...) THEN ALTER TABLE ... RENAME COLUMN ... END IF; END $$;`
-- Rename table: same pattern via `information_schema.tables`
-- New table: `CREATE TABLE IF NOT EXISTS ... ( ... );`
-
-Local dev can still use `npm run db:push` for experimentation, but the PR must carry the boot migration so prod catches up automatically. Do not rely on remembering to run `db:push` against prod — we don't have prod credentials in CI, and it's interactive anyway.
-
-**When NOT to use a boot migration:** anything destructive (dropping columns/tables, data rewrites, constraint tightening). Those need a named migration file, explicit user approval, and a plan for rollback.
+Every PR that modifies `app/shared/schema.ts` MUST also update `app/server/boot-migrations.ts` (CI enforces this). Railway does NOT auto-run `drizzle-kit push`. See @.claude/docs/schema-changes.md.
 
 ## Gotchas
 

--- a/app/server/boot-migrations.ts
+++ b/app/server/boot-migrations.ts
@@ -1,0 +1,77 @@
+// Idempotent schema fixups run at boot. Used for small, safe structural changes
+// (renames, column adds with defaults) that should apply automatically on
+// Railway deploy without requiring a manual drizzle-kit push.
+//
+// Guardrails:
+// - Every statement must be idempotent and non-destructive (IF EXISTS / IF NOT EXISTS).
+// - Never DROP, TRUNCATE, or DELETE here. Destructive changes go through a
+//   deliberate migration, not boot code.
+
+import { pool } from "./db";
+
+interface BootMigration {
+  name: string;
+  sql: string;
+}
+
+const MIGRATIONS: BootMigration[] = [
+  {
+    // 2026-04-19: rename relationship_memory → relationship_journal (PR #68 follow-up).
+    // Renames are conditional on the old column/table still existing, so this is a no-op
+    // on already-migrated databases.
+    name: "rename_memory_to_journal",
+    sql: `
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'contacts' AND column_name = 'relationship_memory'
+  ) THEN
+    ALTER TABLE contacts RENAME COLUMN relationship_memory TO relationship_journal;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_name = 'contact_memory_revisions'
+  ) THEN
+    ALTER TABLE contact_memory_revisions RENAME TO contact_journal_revisions;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE indexname = 'contact_memory_revisions_contact_created_idx'
+  ) THEN
+    ALTER INDEX contact_memory_revisions_contact_created_idx
+      RENAME TO contact_journal_revisions_contact_created_idx;
+  END IF;
+END $$;
+
+-- Ensure the journal column exists (catches a fresh Postgres where neither name is present).
+ALTER TABLE contacts ADD COLUMN IF NOT EXISTS relationship_journal TEXT;
+
+-- Ensure the journal revisions table exists.
+CREATE TABLE IF NOT EXISTS contact_journal_revisions (
+  id SERIAL PRIMARY KEY,
+  contact_id INTEGER NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  source TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS contact_journal_revisions_contact_created_idx
+  ON contact_journal_revisions (contact_id, created_at DESC);
+`,
+  },
+];
+
+export async function runBootMigrations(): Promise<void> {
+  for (const m of MIGRATIONS) {
+    try {
+      await pool.query(m.sql);
+      console.warn(`[boot-migration] ${m.name}: ok`);
+    } catch (err) {
+      console.error(`[boot-migration] ${m.name}: FAILED`, err);
+      throw err;
+    }
+  }
+}

--- a/app/server/index.ts
+++ b/app/server/index.ts
@@ -37,6 +37,9 @@ app.use((req, res, next) => {
 });
 
 (async () => {
+  const { runBootMigrations } = await import("./boot-migrations");
+  await runBootMigrations();
+
   const server = await registerRoutes(app);
 
   app.use(


### PR DESCRIPTION
Post-incident follow-up to PR #68 / #69.

## Summary
- **CI guard**: any PR that modifies `app/shared/schema.ts` without also modifying `app/server/boot-migrations.ts` now fails with a pointer to the policy docs. Catches the exact class of bug that took prod down earlier today.
- **CLAUDE.md "Schema changes" section**: codifies the rule. Every schema change ships an idempotent, non-destructive, dated boot migration. Local `db:push` is fine for experimentation, but the PR must carry the migration so Railway catches up automatically on next deploy.
- **CHANGELOG** entry explaining what went wrong, what we did, how we'll prevent it.

## Context
PR #68's rename landed in code but not in production Postgres. Railway auto-deploys code; it does NOT run `drizzle-kit push`. CI's ephemeral Postgres starts fresh every run with the new schema, so it never exercises the upgrade path — making rename/drop bugs invisible until they hit prod.

The boot-migrations approach (added in #69) is the minimum viable fix. Longer-term, committed `drizzle-kit generate` migration files would be cleaner, but that's a bigger lift.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] CI guard: simulated `git diff` showing `schema.ts` change without `boot-migrations.ts` change would fail the new step
- [ ] CI runs and passes this PR (no schema change → guard is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)