### PR TITLE
Accept date ranges in journal validator

### DIFF
--- a/app/shared/journal.ts
+++ b/app/shared/journal.ts
@@ -49,10 +49,21 @@ const RELATIVE_DAY_OF_WEEK =
 // date" check. Order doesn't matter; any match is enough.
 const ABSOLUTE_DATE_PATTERNS: Array<{ label: string; re: RegExp }> = [
   { label: "YYYY-MM-DD", re: /\b\d{4}-\d{2}-\d{2}\b/ },
+  { label: "YYYY-MM-DD to YYYY-MM-DD", re: /\b\d{4}-\d{2}-\d{2}\s*(?:to|–|—|-)\s*\d{4}-\d{2}-\d{2}\b/ },
   { label: "M/D/YYYY", re: /\b\d{1,2}\/\d{1,2}\/\d{4}\b/ },
   {
     label: "Month DD, YYYY",
     re: /\b(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{1,2},?\s+\d{4}\b/i,
+  },
+  {
+    // "April 7-8, 2026" — same-month day range, common in meeting/trip titles.
+    label: "Month D-D, YYYY",
+    re: /\b(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{1,2}\s*(?:–|—|-)\s*\d{1,2},?\s+\d{4}\b/i,
+  },
+  {
+    // "April 30 – May 2, 2026" — cross-month day range.
+    label: "Month D – Month D, YYYY",
+    re: /\b(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{1,2}\s*(?:–|—|-|to)\s*(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{1,2},?\s+\d{4}\b/i,
   },
   {
     // "August 2025" — year-only precision, common for historical summaries.


### PR DESCRIPTION
## Summary
"April 7-8, 2026" (and similar range formats in titles) was getting rejected as not matching any absolute-date format. Ranges are common in entry titles — onsites, trips, multi-day events, sprint arcs — and forcing users to pad with a standalone ISO date just to satisfy the validator is friction with no upside.

Four new accepted formats added to `ABSOLUTE_DATE_PATTERNS`:

| Format | Example |
|---|---|
| `Month D-D, YYYY` | `April 7-8, 2026`, `July 10–12, 2025` |
| `Month D – Month D, YYYY` | `April 30 - May 2, 2026` |
| `YYYY-MM-DD to YYYY-MM-DD` | `2025-07-01 to 2025-08-22` |

Hyphen, en-dash, em-dash, and the literal word `to` are all accepted as separators.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] 5 MCP scenarios verified end-to-end against local dev (contact 10, Marcus Webb):
  - `April 7-8, 2026` in title → accepted
  - `July 10–12, 2025` (em-dash) → accepted
  - `April 30 - May 2, 2026` (cross-month) → accepted
  - `2025-07-01 to 2025-08-22` → accepted
  - `April 2-3` without year → still correctly rejected as `no_absolute_date`

🤖 Generated with [Claude Code](https://claude.com/claude-code)