### PR TITLE
Journal UX round 2: verbatim quotes + informal dates + scoped edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## 2026-04-19
 
+### Journal UX round 2 — verbatim quotes, informal dates, scoped edits
+Second batch of feedback from hands-on migration across three clients (~30 entries, ~15 rejections).
+
+**P0 — Verbatim blockquote escape (the one real bug)**
+Relative-phrase detection now skips lines wrapped in markdown blockquotes (lines starting with `>`). Verbatim quotes — client emails, meeting transcripts, draft scripts — preserve the original author's words including their relative dates. The agent's own prose outside the quote still enforces absolute dates. Dates INSIDE the quote still count toward the "substantive content needs an anchor" check, so a fully-quoted entry with an absolute date inside passes cleanly.
+
+**P1 — Informal date formats**
+Added: `early|mid|late YYYY`, `early|mid|late Q# YYYY`, `spring|summer|fall|autumn|winter YYYY`. Fuzzy anchors are how humans actually describe old events ("fall 2025 retrospective") and forcing Q# mapping loses nuance.
+
+**P4 — Day-of-week lookahead fix**
+"On Friday May 1, 2026" was rejected even though a full absolute date immediately followed. Lookahead now tolerates a trailing digit OR month name. "On Friday" alone still rejects — the trigger + bare day name remains caught.
+
+**P6a — `peek_last_journal_entry` returns `hash`**
+Now a valid `expectedHash` for `edit_journal` comes back in the peek response. No full re-read needed to chain peek → edit.
+
+**P6b — `edit_journal` accepts optional `section` param**
+Scopes the match to within one named section (`Key People`, `Wins / Case Study Material`, `Entries`, `Open Questions`, `Risks`, `Next Moves`). Replacements can't accidentally cross section boundaries; "oldString appears twice" resolves when the occurrences are in different sections. New rejection reason: `section_not_found`.
+
+**Docs**
+Agent guide now enumerates trigger words for day-of-week detection, lists every accepted absolute-date format, explains the blockquote escape, and notes that clients with stale tool caches should reconnect the MCP connector after a deploy (P2 workaround — server can't fix client-side caches).
+
 ### Journal UX fixes — feedback from first real use
 Based on hands-on migration of historical notes. All server-side; no schema changes.
 

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -304,7 +304,10 @@ Tasks and interactions should be SHORT reminders. The journal is where detail li
 7. If a piece of information has no known date, mark it \`[date unknown]\` rather than omitting or hedging.
 8. \`briefing\` is for the next meeting and may be overwritten freely. \`relationship_journal\` is permanent.
 9. Destructive edits require \`confirmed_with_user: true\`, set ONLY after the user has explicitly approved the change in conversation. "Destructive" = shrinks the doc ≥40% (and ≥500 chars) OR mutates an existing \`### YYYY-MM-DD:\` Entry heading. Minor cleanups don't trip it.
-10. Migrating old notes? Use \`batch_append_journal\` with per-entry \`date\` values so the timeline reflects when events actually happened, not when you typed them in.
+10. Migrating old notes? Use \`batch_append_journal\` with per-entry \`date\` values so the timeline reflects when events actually happened, not when you typed them in. If \`batch_append_journal\` doesn't appear in your tool list, your MCP client has a stale tool cache — reconnect the CRM connector in Claude's settings to refresh.
+11. Verbatim quotes (emails, transcripts, scripts) bypass the relative-phrase check when wrapped in markdown blockquotes (lines starting with \`>\`). Use this to preserve someone else's exact words without translating their relative dates. Your own prose outside the quote still enforces absolute dates.
+12. Accepted absolute date formats: \`YYYY-MM-DD\`, \`M/D/YYYY\`, \`Month DD, YYYY\`, \`Month D-D, YYYY\` (range), \`Month D – Month D, YYYY\` (cross-month range), \`YYYY-MM-DD to YYYY-MM-DD\`, \`Month YYYY\`, \`Q# YYYY\`, \`early|mid|late YYYY\`, \`early|mid|late Q# YYYY\`, \`spring|summer|fall|autumn|winter YYYY\`.
+13. Day-of-week trigger words that mark a relative use: next, this, last, by, on, until, starting, before, after, every, each, coming. "On Friday" alone is rejected; "on Friday May 1, 2026" passes because the full date immediately follows.
 10. Write dense. Every word earns its place. No filler, no throat-clearing, no hedges. Capture maximum context per character.
 
 ## Confidentiality
@@ -1088,7 +1091,7 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
 
   server.tool(
     "peek_last_journal_entry",
-    `Return just the most recent dated Entry (heading + body) from a contact's journal. Cheap confirmation of "did my last append land?" without re-reading the whole doc.`,
+    `Return just the most recent dated Entry (heading + body) from a contact's journal plus the full-doc \`hash\` — cheap confirmation of "did my last append land?" and a valid \`expectedHash\` for the next \`edit_journal\` without re-reading the whole doc.`,
     {
       contactId: z.number(),
     },
@@ -1101,7 +1104,12 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
             content: [
               {
                 type: "text" as const,
-                text: JSON.stringify({ ok: true, entry: null, message: "Journal not initialized yet." }),
+                text: JSON.stringify({
+                  ok: true,
+                  entry: null,
+                  hash: hashJournal(null),
+                  message: "Journal not initialized yet.",
+                }),
               },
             ],
           };
@@ -1111,7 +1119,12 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify({ ok: true, entry, totalSize: contact.relationshipJournal.length }),
+              text: JSON.stringify({
+                ok: true,
+                entry,
+                hash: hashJournal(contact.relationshipJournal),
+                totalSize: contact.relationshipJournal.length,
+              }),
             },
           ],
         };
@@ -1123,7 +1136,7 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
 
   server.tool(
     "edit_journal",
-    `Exact-string replacement on a contact's relationship_journal. Mirrors Claude's local Edit tool: oldString must occur exactly once in the current document (unless replaceAll: true). Destructive edits require confirmed_with_user: true — triggered when the edit (a) shrinks the doc ≥40% AND ≥500 chars, or (b) mutates/removes an existing \`### YYYY-MM-DD:\` Entry heading. ${JOURNAL_CONTRACT}`,
+    `Exact-string replacement on a contact's relationship_journal. Mirrors Claude's local Edit tool: oldString must occur exactly once in the current document (unless replaceAll: true). Supply \`section\` to scope the match within one named section — prevents accidental cross-section replacements and lets "oldString appears twice" resolve when the occurrences are in different sections. Destructive edits require confirmed_with_user: true — triggered when the edit (a) shrinks the doc ≥40% AND ≥500 chars, or (b) mutates/removes an existing \`### YYYY-MM-DD:\` Entry heading. ${JOURNAL_CONTRACT}`,
     {
       contactId: z.number(),
       oldString: z
@@ -1135,6 +1148,12 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
         .string()
         .describe(
           "Replacement text. Absolute dates only. Substantive content (>40 chars) must contain an absolute date. On rejection the error payload includes: field, reason, offending phrase, excerpt around the match, and position — enough to fix without guessing.",
+        ),
+      section: z
+        .enum(["Key People", "Wins / Case Study Material", "Entries", "Open Questions", "Risks", "Next Moves"])
+        .optional()
+        .describe(
+          "Scope the edit to within one named section. When set, oldString is matched only inside that section's content and the edit cannot cross section boundaries.",
         ),
       replaceAll: z
         .boolean()
@@ -1155,7 +1174,7 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
           "Set to true ONLY after the user has explicitly approved a destructive edit in conversation. Required for ≥40% shrink or mutating an existing `### YYYY-MM-DD:` Entry heading.",
         ),
     },
-    async ({ contactId, oldString, newString, replaceAll, expectedHash, confirmed_with_user }) => {
+    async ({ contactId, oldString, newString, section, replaceAll, expectedHash, confirmed_with_user }) => {
       try {
         const contact = await storage.getContact(contactId);
         if (!contact) return notFoundError("Contact", contactId, "search_contacts");
@@ -1184,7 +1203,48 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
         }
 
         const current = contact.relationshipJournal;
-        const occurrences = current.split(oldString).length - 1;
+
+        // Determine the haystack: either the full doc, or the scoped section.
+        let sectionContent: string | null = null;
+        let sectionStart = -1;
+        if (section) {
+          sectionContent = readJournalSection(current, section);
+          if (sectionContent === null) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    ok: false,
+                    reason: "section_not_found",
+                    section,
+                    message: `Section "${section}" not present in this journal.`,
+                  }),
+                },
+              ],
+              isError: true,
+            };
+          }
+          sectionStart = current.indexOf(sectionContent);
+          if (sectionStart < 0) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    ok: false,
+                    reason: "section_boundary_lost",
+                    message: `Internal: could not locate section "${section}" in the doc. Re-read and retry.`,
+                  }),
+                },
+              ],
+              isError: true,
+            };
+          }
+        }
+
+        const haystack = sectionContent ?? current;
+        const occurrences = haystack.split(oldString).length - 1;
         if (occurrences === 0) {
           return {
             content: [
@@ -1193,7 +1253,9 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
                 text: JSON.stringify({
                   ok: false,
                   reason: "no_match",
-                  message: "oldString not found in current document. Re-read the journal and try again.",
+                  message: section
+                    ? `oldString not found in section "${section}". Re-read the journal and try again (or drop the section scope).`
+                    : "oldString not found in current document. Re-read the journal and try again.",
                 }),
               },
             ],
@@ -1208,7 +1270,7 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
                 text: JSON.stringify({
                   ok: false,
                   reason: "multiple_matches",
-                  message: `oldString appears ${occurrences} times. Provide more surrounding context for uniqueness, or set replaceAll: true.`,
+                  message: `oldString appears ${occurrences} times${section ? ` in section "${section}"` : ""}. Provide more surrounding context for uniqueness, or set replaceAll: true.`,
                 }),
               },
             ],
@@ -1216,7 +1278,15 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
           };
         }
 
-        const updated = replaceAll ? current.split(oldString).join(newString) : current.replace(oldString, newString);
+        let updated: string;
+        if (section && sectionContent !== null) {
+          const newSection = replaceAll
+            ? sectionContent.split(oldString).join(newString)
+            : sectionContent.replace(oldString, newString);
+          updated = current.slice(0, sectionStart) + newSection + current.slice(sectionStart + sectionContent.length);
+        } else {
+          updated = replaceAll ? current.split(oldString).join(newString) : current.replace(oldString, newString);
+        }
 
         const result = await storage.updateRelationshipJournal(contactId, updated, {
           source: "agent",

--- a/app/shared/journal.ts
+++ b/app/shared/journal.ts
@@ -39,11 +39,34 @@ export const RELATIVE_TIME_PHRASES = [
   "later this year",
 ];
 
-// A day-of-week used relatively means "next Tuesday", "by Friday", etc. — a
-// TRIGGER word appears before the day name. Generic usage like "Monday through
-// Friday" or "Mon/Wed/Fri cadence" must pass.
-const RELATIVE_DAY_OF_WEEK =
-  /\b(?:next|this|last|by|on|until|starting|before|after|every|each|coming)\s+(?:mon|tues|wednes|thurs|fri|satur|sun)day(?!\s*[,.-]?\s*\d)\b/i;
+// Trigger words that, when placed before a day name, mark a relative date.
+// Exposed so the agent guide and error messages can enumerate them.
+export const DAY_OF_WEEK_TRIGGER_WORDS = [
+  "next",
+  "this",
+  "last",
+  "by",
+  "on",
+  "until",
+  "starting",
+  "before",
+  "after",
+  "every",
+  "each",
+  "coming",
+] as const;
+
+// A day-of-week used relatively means "next Tuesday", "by Friday", etc. Generic
+// usage ("Mon/Wed/Fri cadence", "Monday through Friday") passes. The negative
+// lookahead allows "on Friday May 1, 2026" and similar by tolerating a digit OR
+// month name following the day.
+const RELATIVE_DAY_OF_WEEK = new RegExp(
+  `\\b(?:${DAY_OF_WEEK_TRIGGER_WORDS.join("|")})\\s+` +
+    `(?:mon|tues|wednes|thurs|fri|satur|sun)day` +
+    `(?!\\s*[,.-]?\\s*(?:\\d|(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)))` +
+    `\\b`,
+  "i",
+);
 
 // Patterns that qualify as absolute dates for the "substantive content needs a
 // date" check. Order doesn't matter; any match is enough.
@@ -74,6 +97,21 @@ const ABSOLUTE_DATE_PATTERNS: Array<{ label: string; re: RegExp }> = [
     // "Q3 2025" — useful for quarterly retrospectives.
     label: "Q# YYYY",
     re: /\bQ[1-4]\s+\d{4}\b/i,
+  },
+  {
+    // "early Q3 2025", "late Q1 2026" — fuzzy quarter anchors.
+    label: "early|mid|late Q# YYYY",
+    re: /\b(?:early|mid|late)\s+Q[1-4]\s+\d{4}\b/i,
+  },
+  {
+    // "early 2025", "mid 2025", "late 2026" — year with rough-phase qualifier.
+    label: "early|mid|late YYYY",
+    re: /\b(?:early|mid|late)\s+\d{4}\b/i,
+  },
+  {
+    // "fall 2025", "summer 2026" — seasons anchor ~3-month windows.
+    label: "Season YYYY",
+    re: /\b(?:spring|summer|fall|autumn|winter)\s+\d{4}\b/i,
   },
 ];
 
@@ -139,13 +177,29 @@ function excerptAround(text: string, position: number, length: number, window = 
 }
 
 /**
- * Reject content containing relative time phrases. Returns the exact matched
- * phrase, its position, and a surrounding excerpt so the caller can debug.
+ * Strip markdown blockquote lines (lines starting with `>`, allowing leading
+ * whitespace) while preserving their char positions via blank replacement.
+ * Quoted text is verbatim archival material (someone else's words) and is
+ * exempt from the relative-phrase rules that apply to the agent's own prose.
+ */
+function maskBlockquotes(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => (/^\s*>/.test(line) ? " ".repeat(line.length) : line))
+    .join("\n");
+}
+
+/**
+ * Reject content containing relative time phrases. Blockquoted lines (`>`) are
+ * skipped — verbatim quotes preserve the original author's words. Returns the
+ * exact matched phrase, its position in the ORIGINAL text, and a surrounding
+ * excerpt so the caller can debug.
  */
 export function validateAbsoluteDates(text: string, field: ValidationField = "content"): ValidationResult {
+  const masked = maskBlockquotes(text);
   for (const phrase of RELATIVE_TIME_PHRASES) {
     const re = new RegExp(`\\b${phrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "i");
-    const m = re.exec(text);
+    const m = re.exec(masked);
     if (m && m.index !== undefined) {
       return {
         ok: false,
@@ -154,11 +208,11 @@ export function validateAbsoluteDates(text: string, field: ValidationField = "co
         offending: m[0],
         position: m.index,
         excerpt: excerptAround(text, m.index, m[0].length),
-        message: `Rejected ${field}: relative phrase "${m[0]}" at position ${m.index}. Rewrite with an absolute date (e.g. "2026-04-18" or "August 2025"). Relative phrases lose meaning over time.`,
+        message: `Rejected ${field}: relative phrase "${m[0]}" at position ${m.index}. Rewrite with an absolute date (e.g. "2026-04-18" or "August 2025"). Relative phrases lose meaning over time. To preserve verbatim text (quoted emails, transcripts, scripts), wrap in a markdown blockquote — lines starting with \`>\` are exempt.`,
       };
     }
   }
-  const dayMatch = RELATIVE_DAY_OF_WEEK.exec(text);
+  const dayMatch = RELATIVE_DAY_OF_WEEK.exec(masked);
   if (dayMatch && dayMatch.index !== undefined) {
     return {
       ok: false,
@@ -167,7 +221,7 @@ export function validateAbsoluteDates(text: string, field: ValidationField = "co
       offending: dayMatch[0],
       position: dayMatch.index,
       excerpt: excerptAround(text, dayMatch.index, dayMatch[0].length),
-      message: `Rejected ${field}: day-of-week used relatively — "${dayMatch[0]}" at position ${dayMatch.index}. Translate to an absolute date (e.g. "2026-04-21"). Generic usage like "Mon/Wed/Fri cadence" or "Monday through Friday" is fine — only trigger words like "next/this/last/by/on" before a day name are rejected.`,
+      message: `Rejected ${field}: day-of-week preceded by trigger word — "${dayMatch[0]}" at position ${dayMatch.index}. Trigger words: ${DAY_OF_WEEK_TRIGGER_WORDS.join(", ")}. Either translate to an absolute date, append a full \`Month DD, YYYY\` right after the day name (e.g. "on Friday May 1, 2026"), or quote the line with a leading \`>\` to mark it verbatim.`,
     };
   }
   return { ok: true };
@@ -175,7 +229,8 @@ export function validateAbsoluteDates(text: string, field: ValidationField = "co
 
 /**
  * Substantive content (> SUBSTANTIVE_LENGTH chars) must include at least one
- * absolute date pattern. Short annotations are exempt.
+ * absolute date pattern. Short annotations are exempt. Dates INSIDE blockquotes
+ * count — a quoted passage that anchors its own time is fine.
  */
 export function requiresAbsoluteDate(text: string): boolean {
   if (text.length <= SUBSTANTIVE_LENGTH) return false;
@@ -192,7 +247,7 @@ export function validateJournalContent(text: string, field: ValidationField = "c
       field,
       acceptedFormats: ACCEPTED_DATE_FORMATS,
       excerpt: excerptAround(text, 0, Math.min(text.length, 80)),
-      message: `Rejected ${field}: substantive content (>${SUBSTANTIVE_LENGTH} chars) must include at least one absolute date. Accepted formats: ${ACCEPTED_DATE_FORMATS.join(", ")}. If the date is genuinely unknown, write "[date unknown]".`,
+      message: `Rejected ${field}: substantive content (>${SUBSTANTIVE_LENGTH} chars) must include at least one absolute date. Accepted formats: ${ACCEPTED_DATE_FORMATS.join(", ")}. Dates inside blockquotes count. If the date is genuinely unknown, write "[date unknown]".`,
     };
   }
   return { ok: true };


### PR DESCRIPTION
Response to 3-client migration feedback. All server-side.

## Changes
| Priority | Fix |
|---|---|
| **P0** | Markdown blockquotes (`>`) bypass relative-phrase detection. Verbatim quotes preserve original wording. |
| **P1** | New accepted date formats: `early\|mid\|late YYYY`, `early\|mid\|late Q# YYYY`, `Season YYYY` (spring/summer/fall/autumn/winter). |
| **P4** | "On Friday May 1, 2026" now accepted — lookahead tolerates trailing month names, not just digits. |
| **P6a** | `peek_last_journal_entry` returns `hash` so peek → edit chains without a re-read. |
| **P6b** | `edit_journal` accepts optional `section` param. Scopes match within one named section; new `section_not_found` reason. |

**P2** (client-side tool cache) can't be fixed server-side, but the agent guide now tells users to reconnect the MCP connector if `batch_append_journal` is missing from their tool list.

**P3 and P5** (title/body ranges) were already handled by PR #72; verified with fresh tests in this PR.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] 11 MCP scenarios verified end-to-end against local dev (contact 10, Marcus Webb):
  - Blockquote with "next month" in verbatim email → accepted
  - Blockquote with "on Friday" / "next week" → accepted
  - Relative phrase OUTSIDE blockquote → still rejected
  - `early 2025`, `mid 2025`, `fall 2025`, `late Q3 2025`, `summer 2026` → all accepted
  - `on Friday May 1, 2026` → accepted
  - `on Friday` alone → still rejected
  - `peek_last_journal_entry` returns a 64-char hash
  - Scoped `edit_journal` with `section: "Key People"` succeeds
  - Scoped edit with missing section → `section_not_found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)