### PR TITLE
Fix MCP session durability: 404 on stale session IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 2026-04-19
 
+### MCP session durability — spec-compliant 404 for stale sessions
+After every Railway redeploy, Claude clients holding an old `Mcp-Session-Id` would soft-fail: tool calls quietly returned empty or errored in a way the client couldn't recover from, forcing a manual disconnect+reconnect of the connector.
+
+Root cause: on unknown session IDs, the route handler was silently creating a fresh transport. The new transport hadn't been initialized, so the SDK returned HTTP 400 "Server not initialized" — not the HTTP 404 that MCP clients MUST auto-re-initialize on per the 2025-06-18 StreamableHTTP spec.
+
+Fix: stale session IDs now return `HTTP 404` with JSON-RPC error `-32001 Session not found`. Claude Desktop / Claude.ai auto-re-initialize on this exact signal. No user action needed after redeploy.
+
+Also tightened the handshake contract:
+- `initialize` with no session ID → mint a fresh session (correct).
+- Non-initialize call with no session ID → 404 (was permissive).
+- GET SSE stream with unknown session ID → 404 (was auto-creating a phantom transport).
+
 ### Journal UX round 2 — verbatim quotes, informal dates, scoped edits
 Second batch of feedback from hands-on migration across three clients (~30 entries, ~15 rejections).
 

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -1762,27 +1762,63 @@ setInterval(
   5 * 60 * 1000,
 );
 
+/**
+ * Spec-compliant stale-session response. Per MCP 2025-06-18 StreamableHTTP
+ * transport: a server that no longer recognizes a session MUST return HTTP 404
+ * with JSON-RPC error `-32001 Session not found`. Conformant clients (Claude
+ * Desktop, Claude.ai) then auto-re-initialize — no manual disconnect/reconnect.
+ *
+ * Previous behavior silently created a fresh transport for unknown session IDs,
+ * which then returned HTTP 400 "Server not initialized" — Claude treated that as
+ * a hard error and silently failed tool calls until the user reconnected.
+ */
+function respondSessionNotFound(res: Response, requestId: unknown) {
+  res.status(404).json({
+    jsonrpc: "2.0",
+    error: { code: -32001, message: "Session not found" },
+    id: requestId ?? null,
+  });
+}
+
+function isInitializeRequest(body: unknown): boolean {
+  if (!body || typeof body !== "object") return false;
+  const obj = body as Record<string, unknown>;
+  return obj.method === "initialize";
+}
+
 export function registerMcpRoutes(app: Express) {
-  // Handle POST /mcp/:token
-  // If session ID is unknown (e.g. after redeploy), auto-create a new session
-  // so Claude doesn't need manual reconnection
+  // POST /mcp/:token — JSON-RPC requests.
+  //  - Known session ID → route to its transport.
+  //  - `initialize` without a session ID → mint a fresh session.
+  //  - Stale session ID (after redeploy or TTL expiry) → HTTP 404 with
+  //    -32001, which triggers the MUST-re-initialize path on the client.
   app.post("/mcp/:token", async (req: Request, res: Response) => {
     if (!(await checkToken(req, res))) return;
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
+    const body = req.body as { id?: unknown; method?: unknown } | undefined;
 
     if (sessionId && transports.has(sessionId)) {
       touchSession(sessionId);
       const transport = transports.get(sessionId)!;
-      await transport.handleRequest(req, res, req.body);
+      await transport.handleRequest(req, res, body);
       return;
     }
 
-    // New session OR stale session after redeploy — create fresh
-    const transport = createTransportAndServer();
-    await transport.handleRequest(req, res, req.body);
+    if (isInitializeRequest(body) && !sessionId) {
+      const transport = createTransportAndServer();
+      await transport.handleRequest(req, res, body);
+      return;
+    }
+
+    // Either a stale session ID the server no longer knows, or a non-initialize
+    // call with no session at all. Both map to 404 per spec — the client will
+    // re-initialize automatically.
+    respondSessionNotFound(res, body?.id);
   });
 
-  // Handle GET /mcp/:token - SSE stream
+  // GET /mcp/:token — SSE stream for server-initiated notifications.
+  // Requires an established session; never auto-creates one here (the spec's
+  // init handshake is POST-only).
   app.get("/mcp/:token", async (req: Request, res: Response) => {
     if (!(await checkToken(req, res))) return;
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
@@ -1794,9 +1830,7 @@ export function registerMcpRoutes(app: Express) {
       return;
     }
 
-    // Stale or missing session — create new one
-    const transport = createTransportAndServer();
-    await transport.handleRequest(req, res);
+    respondSessionNotFound(res, null);
   });
 
   // Handle DELETE /mcp/:token - session cleanup


### PR DESCRIPTION
## Why this exists
Every Railway redeploy killed Claude's MCP connection. Tool calls would soft-fail — empty responses or opaque errors — and the user had to manually disconnect and reconnect the CRM connector in Claude's settings to recover. This happened after every PR that shipped.

## Root cause
The route handler silently created a fresh `StreamableHTTPServerTransport` for any unknown session ID. That transport hadn't run `initialize`, so the SDK's `validateSession` returned HTTP 400 "Server not initialized" — which clients don't treat as a re-init signal.

## The spec (MCP 2025-06-18 StreamableHTTP transport)
> "When a client receives HTTP 404 in response to a request containing an `Mcp-Session-Id`, it MUST start a new session by sending a new InitializeRequest without a session ID attached."

So: the correct response for an unrecognized session is **HTTP 404 with JSON-RPC error `-32001 Session not found`**. Claude Desktop and Claude.ai auto-re-initialize on exactly that.

## Changes
- **Stale `Mcp-Session-Id`** → `404` + `{"error": {"code": -32001, "message": "Session not found"}}`
- **`initialize` with no session ID** → mint fresh session (unchanged, correct)
- **Non-initialize call with no session ID** → `404` (was permissive, creating phantom transports)
- **GET `/mcp/:token` with unknown session** → `404` (was creating a phantom SSE stream that would fail downstream)

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] curl against local dev verifies all three cases:
  - Stale session → `404` + `{"code":-32001,"message":"Session not found","id":<req-id>}`
  - Fresh `initialize` → `200` + `mcp-session-id: <uuid>` response header
  - Non-init without session → `404` + same error envelope
- [ ] After merge: trigger a Railway redeploy, then issue a tool call from an already-connected Claude session — should work without disconnect/reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)