### PR TITLE
Ship CRM skill: proactive mental model + progressive disclosure to MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 2026-04-19
 
+### CRM skill — proactive mental model for Claude
+New `skills/crm/SKILL.md` — a ~3 KB always-loaded skill that orients Claude to the CRM concept (five-layer data model, data-partition rule, when to invoke) before any tool call. Progressive disclosure: skill loads first, then Claude calls `get_crm_guide` for the detailed contract (stage enums, writing validator, section structure), then individual tools on demand.
+
+Install paths documented in README. Claude Code: copy to `~/.claude/skills/crm/`. Claude.ai personal: paste into a Project's Custom Instructions (plugin/skill auto-install for claude.ai consumer doesn't exist yet).
+
+The skill assumes the MCP connector is already registered; if tools are missing, it surfaces a one-line prompt telling the user to add the connector.
+
 ### MCP session durability — spec-compliant 404 for stale sessions
 After every Railway redeploy, Claude clients holding an old `Mcp-Session-Id` would soft-fail: tool calls quietly returned empty or errored in a way the client couldn't recover from, forcing a manual disconnect+reconnect of the connector.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ Uses `mcp-client.ts` which calls the REST API over HTTP:
 }
 ```
 
+### Skill (optional but recommended)
+
+`skills/crm/SKILL.md` is a lightweight "when to use the CRM" guide that loads proactively — Claude sees the mental model (data-partition rule, five-layer structure) before any tool call. The detailed writing contract, stage enums, and validation rules stay in `get_crm_guide` and load on-demand.
+
+Install paths:
+
+- **Claude Code**: copy the file into your personal skills directory.
+  ```bash
+  mkdir -p ~/.claude/skills/crm && cp skills/crm/SKILL.md ~/.claude/skills/crm/
+  ```
+  Claude Code auto-loads on session start.
+- **Claude Desktop / Claude.ai personal**: open a Project → Custom Instructions → paste the SKILL.md body. (Native plugin/skill install for claude.ai consumer isn't available yet; manual paste is the current path.)
+
+The skill assumes the MCP connector has already been registered. If tools are missing it tells Claude to prompt you to add the connector; it doesn't install anything itself.
+
 ### MCP Tools
 
 | Tool | Description |

--- a/skills/crm/SKILL.md
+++ b/skills/crm/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: crm
+description: Personal CRM for relationship management. Invoke when the user mentions contacts, pipeline, prospects, clients, leads, follow-ups, meeting prep, interactions, relationship journals, briefings, or case-study material — or when they describe a new person, event, or action that could map to a CRM entity ("I met Sarah today", "follow up with Jeff Friday", "update my notes on Acme", "prep for tomorrow's call"). Assumes the CRM MCP connector is already registered in the client.
+---
+
+# Personal CRM
+
+You have access to a personal CRM exposed as an MCP connector. This skill tells you **when to use it** and the **mental model**. The connector itself exposes a `get_crm_guide` tool that returns the live, authoritative contract — call it first thing in any CRM-touching session, before writing anything.
+
+## First move
+
+```
+get_crm_guide()
+```
+
+It returns the current rule set, valid enums, stage definitions, writing contract, and a live snapshot (contact counts, overdue tasks, upcoming meetings, active rule violations). Everything below is orientation; the guide is the source of truth.
+
+## The data-partition rule — read before every write
+
+Every piece of information has exactly ONE home. **The DATE belongs to the atom. The MEANING belongs to the journal.** If you're about to write the same sentence in two places, one of them is wrong.
+
+## Five-layer mental model
+
+| Layer | What it is | Shape |
+|---|---|---|
+| **Contact fields** | Canonical facts about the person (title, email, location, company) | One-liners, edit in place |
+| **Interactions** | Past-tense atomic events — a call happened, an email went out | One sentence per row, dated |
+| **Tasks / Meetings** | Forward-looking action items with due dates | Short, verb-first, ≤10 words |
+| **Briefings** | Ephemeral prep for the **next specific** conversation | Bullets, upsert, overwritten each prep |
+| **Relationship journal** | Everlasting narrative per contact — interpretation, strategic reads, "what it means" | Long-form markdown; sections: Key People, Wins / Case Study Material, Entries |
+
+Interactions and tasks stay SHORT. The journal is where detail and meaning live. The journal is NOT a log of events — it's the interpretive layer on top of them.
+
+**Worked example — a single call with a client on a given date:**
+
+- Interaction: `<date>: 30min call with X. Discussed Q2 scope.` ← the fact, one sentence
+- Task: `Send investment memo to X` due `<future-date>` ← the next action, verb-first
+- Journal entry: dated narrative explaining *why* the call mattered, what was read between the lines, what to adjust in the next prep
+
+None of those three duplicate each other.
+
+## When to invoke this skill
+
+- User mentions any person by name in a relationship context ("Alex said", "met with Jordan", "check in with Priya")
+- User describes a future action tied to a person ("follow up", "send", "schedule", "remind me about")
+- User asks about pipeline state, overdue items, upcoming meetings, prospect status
+- User asks to prep for a meeting or review notes on a client
+- User pastes historical notes, a transcript, or context they want preserved for someone
+
+## Writing rules
+
+The server enforces strict validation — **absolute dates only, no relative phrases, dated entry headings, destructive-edit gates**. Full contract (accepted date formats, trigger words, section structure, confirmation flags) is in `get_crm_guide`. Call it once per session and operate from its output.
+
+## If the connector isn't reachable
+
+If the CRM tools don't appear in your tool list, or calls return "tool not found," tell the user in one line:
+
+> The CRM connector isn't registered in this Claude. Add it under Settings → Connectors using the MCP URL from your CRM deployment, then retry.
+
+Do not attempt to install or configure the connector yourself.
+
+## Confidentiality
+
+Never store pricing, deal terms, or cross-reference details between clients. This is a notebook, not a deal tracker.


### PR DESCRIPTION
## Summary
Adds `skills/crm/SKILL.md` — a ~3 KB always-loaded skill so Claude proactively knows what the CRM is for and WHEN to invoke it, without needing to discover the tools first.

**Progressive disclosure:**
```
SKILL.md  (~3 KB, always loaded)
  → get_crm_guide  (detailed contract, loaded on first CRM use)
    → individual MCP tools  (as needed)
```

The skill covers *when* and the mental model. The guide covers *how* — writing contract, stage enums, validation rules. No duplication between them.

## What the skill delivers
- **Trigger phrases for auto-invocation** in the description ("I met X today", "follow up with Y Friday", "prep for the call", etc.) — the user mentions a person or a CRM-shaped event, the skill fires.
- **Data-partition rule** baked in as a one-liner: *the DATE belongs to the atom, the MEANING belongs to the journal*. Prevents duplication across interactions / tasks / journal even before the detailed guide loads.
- **Five-layer mental model** (fields / interactions / tasks / briefings / journal) in a compact table.
- **Worked example** showing a single call writes to three entities (interaction + task + journal) without any duplication.
- **Connection check**: if tools are missing, surface a one-line "add connector" prompt to the user. Doesn't try to install anything.
- **Defers to `get_crm_guide`** for details — explicit instruction to call it first thing in any CRM session.

## Install
- **Claude Code**: `mkdir -p ~/.claude/skills/crm && cp skills/crm/SKILL.md ~/.claude/skills/crm/`
- **Claude.ai / Desktop personal**: paste the SKILL.md body into a Project's Custom Instructions (native skill install for claude.ai consumer doesn't exist yet).

## What this isn't
- **Not** a Claude Code plugin (`.claude-plugin/plugin.json` + marketplace). Plugins bundle skill + MCP and auto-register connectors, but that's Claude Code CLI only. The user uses Claude.ai personal where plugins aren't a thing yet.
- **Not** a server change. No new endpoints, no schema change.
- **Not** a MCP connector auto-installer. The skill assumes the user has already registered the connector via Settings → Connectors.

## Content generalization
Everything in the skill reads as a neutral personal-CRM product. No references to Magnetic Advisors or solo-advisor framing.

## Test plan
- [x] Skill file exists at `skills/crm/SKILL.md`, frontmatter is valid YAML with `name` and `description`
- [x] Body ~3.5 KB — dense but scannable, within the always-loaded budget
- [x] Description contains trigger phrases (contacts, pipeline, follow-ups, journal, briefings + natural-language examples)
- [x] Skill installed to `~/.claude/skills/crm/SKILL.md` locally — verified it loads into this Claude Code session's available-skills listing with the CRM description
- [x] README section added under "AI Agent Integration" describing install paths
- [x] CHANGELOG entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)