### PR TITLE
Add CRM Inbox Agent prompt; clean up README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 2026-04-19
 
+### CRM Inbox Agent reference prompt + README cleanup
+New `docs/agent-prompts/crm-inbox-agent.md` — a pastable prompt for scheduled agents (Claude Cowork, OpenClaw, etc.) that do a daily inbox scan and keep the CRM aligned. Covers read discipline (full threads, sent mail, CC/BCC), what to log vs. skip for LIVE clients, dedup, tool layering, briefing generation when a meeting is imminent, and terse reporting.
+
+README cleanup while I was there:
+- Tool count updated 16+ → 25+
+- Journal added to the Why Claw feature list (was invisible)
+- MCP Tools table updated with `peek_last_journal_entry` and `batch_append_journal`
+- Entities table gained a Journal row
+- New "Agent prompts" subsection linking to `docs/agent-prompts/`
+
 ### CRM skill — proactive mental model for Claude
 New `skills/crm/SKILL.md` — a ~3 KB always-loaded skill that orients Claude to the CRM concept (five-layer data model, data-partition rule, when to invoke) before any tool call. Progressive disclosure: skill loads first, then Claude calls `get_crm_guide` for the detailed contract (stage enums, writing validator, section structure), then individual tools on demand.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Most CRMs are built for sales teams. Claw is built for one person managing 10-50
 
 - **Notebook view** — your entire pipeline in one scrollable feed, sorted by urgency
 - **Slash commands** — `/fu 4/15 check on proposal`, `/mtg 4/3 2pm Coffee @ Verve`, `/stage PROPOSAL`
-- **AI agents write, you verify** — Claude connects via MCP and manages your CRM through 16+ tools
+- **AI agents write, you verify** — Claude connects via MCP and manages your CRM through 25+ tools
+- **Relationship journal** — a per-contact markdown document that's the durable home for the narrative of the relationship: Key People, Wins / Case Study Material, and dated Entries. Absolute-dates-only validator, full revision history with diff view, verbatim blockquote escape for preserving emails and transcripts.
 - **Rules engine** — business logic stored as data, not code. "Flag contacts with no interaction for 14 days." Agents can create, modify, and delete rules.
 - **Real-time** — SSE pushes every change to the UI instantly, whether you or an agent made it
 - **Privacy-first** — PIN-locked, teal privacy screen on window blur, no pricing or deal terms stored
@@ -78,6 +79,12 @@ Install paths:
 
 The skill assumes the MCP connector has already been registered. If tools are missing it tells Claude to prompt you to add the connector; it doesn't install anything itself.
 
+### Agent prompts
+
+Reference prompts for scheduled agents that operate on your behalf live in [`docs/agent-prompts/`](docs/agent-prompts/). Paste the prompt body into the agent's instructions (e.g. a Claude Cowork or OpenClaw scheduled agent) and point it at the relevant data source plus the CRM MCP connector.
+
+- [**CRM Inbox Agent**](docs/agent-prompts/crm-inbox-agent.md) — daily scan of your inbox (received + sent) to keep the CRM aligned. Logs new interactions, updates stages, completes stale follow-ups, builds briefings when a meeting is imminent, flags anything that needs your decision.
+
 ### MCP Tools
 
 | Tool | Description |
@@ -98,7 +105,8 @@ The skill assumes the MCP connector has already been registered. If tools are mi
 | `list_violations` | Active rule violations with contact names. |
 | `get_upcoming_meetings` / `cancel_meeting` | Meeting management. |
 | `save_briefing` / `get_briefing` | Per-contact prep notes. |
-| `read_journal` / `edit_journal` / `append_journal` | Per-contact `relationship_journal` — persistent markdown doc for the full living narrative of the relationship. Absolute-dates-only validator; destructive edits gated behind `confirmed_with_user`. Full revision history in the UI. |
+| `read_journal` / `peek_last_journal_entry` | Read the full `relationship_journal` (optional `section` scope) or just the most recent dated Entry + doc hash. |
+| `edit_journal` / `append_journal` / `batch_append_journal` | Modify the journal. Absolute-dates-only validator, verbatim blockquote escape, destructive edits gated behind `confirmed_with_user`. `batch_append_journal` writes many dated entries transactionally — the bulk-migration path. |
 
 Tools follow [Anthropic's best practices](https://www.anthropic.com/engineering/writing-tools-for-agents): enum validation, actionable errors, pagination, enriched responses.
 
@@ -152,6 +160,7 @@ Exceptions: `has_future_followup`, `stage_in` (exclude specific stages from rule
 | **Follow-ups** | Action items with due dates. |
 | **Meetings** | Future scheduled events. |
 | **Briefings** | Per-contact prep notes (upsert). |
+| **Journal** | Per-contact markdown narrative — Key People, Wins / Case Study Material, dated Entries. Full revision history. |
 | **Rules** | Business logic — conditions + actions as JSONB. |
 | **Violations** | Alerts created by rules, auto-cleared when resolved. |
 

--- a/docs/agent-prompts/crm-inbox-agent.md
+++ b/docs/agent-prompts/crm-inbox-agent.md
@@ -1,0 +1,104 @@
+---
+name: crm-management
+description: Scheduled run that keeps the CRM aligned with the user's inbox.
+---
+
+# CRM Inbox Agent
+
+A reference prompt for users who want a scheduled agent (e.g. a Claude Cowork or OpenClaw agent) to do a **daily scan of their inbox and update the CRM**. Paste this into the agent's instructions and point it at the inbox + the CRM MCP connector.
+
+The prompt assumes:
+
+- The CRM MCP connector is already registered in the agent's client (`Settings → Connectors`).
+- The agent has access to the user's inbox (received and sent mail).
+- The `crm` skill from this repo is installed, OR the agent has equivalent proactive knowledge of the data-partition rule.
+
+---
+
+## Mission
+
+Keep the CRM fully accurate so the user always walks into their pipeline with ground truth. This is one of the highest-leverage jobs in their workflow: the CRM is the source of truth for every relationship and deal, and it only stays true if every material email is reflected in it.
+
+Goals, in order:
+
+1. No deal movement is missed.
+2. Every CRM-relevant email from the last day is reflected in the CRM.
+3. The user is surfaced anything that needs their attention or decision.
+4. No duplicates, no hallucinated contacts, no silent failures.
+
+If there's ever a tradeoff between being slightly noisy and missing a real deal signal, prefer catching the signal.
+
+## Setup (every run)
+
+1. Invoke the **`crm` skill** first. It carries the mental model, data-partition rule, and writing contract.
+2. Call `get_crm_guide` (exposed by the CRM MCP connector) for the live rule set, valid enums, and current state snapshot.
+3. Pull the dashboard. Note recent activity, upcoming meetings, and active violations.
+4. Search the inbox — **both received and sent mail** — for threads touched in the last 1–2 days.
+
+If the `crm` skill or the MCP connector isn't available, stop and tell the user in one line. Don't improvise storage.
+
+## How to read email
+
+- Read **every thread in full, chronologically.** Don't skim the newest message. Don't filter by sender.
+- **Include sent mail.** The user's own replies, proposals, and scheduling confirmations are often the most important CRM events in a thread.
+- **Include forwarded threads.** A forward from the user to themselves or to a teammate usually signals intent for the CRM to catch up.
+- **Include threads where the user is CC'd or BCC'd.** A new stakeholder entering a deal often shows up there first.
+- Typed text beats voice transcription when reconciling.
+
+## What to log
+
+Anything that moves the relationship or deal:
+
+- new prospect replies, proposal responses, acknowledgments
+- scheduling confirmed, changed, or cancelled
+- stage changes
+- signals of interest, hesitation, or delay
+- new stakeholders entering a deal
+- forwarded client emails from the user
+
+## What NOT to log (LIVE clients)
+
+Skip routine delivery chatter: session rescheduling, minor logistics, invoice confirmations, one-line "thanks." Bar: will this matter in six months? If no, skip.
+
+For LIVE clients, log only: wins, relationship moments, friction, scope or pricing changes, new stakeholders, strategic shifts.
+
+## Dedup
+
+Before every write, check whether the same fact is already on the contact for the same date. Skip silently if so. Re-runs must not double-log.
+
+## Tool discipline
+
+Use the layers the `crm` skill defines:
+
+- **Interactions** — past-tense facts, one sentence.
+- **Tasks** — prep work or nudges with a due date.
+- **Meetings** — confirmed calendar events logged on the meeting date, not as follow-ups.
+- **Journal** — interpretation, strategic reads, "what this means" for that contact.
+- **Stage** — update explicitly when reality has moved (LEAD → MEETING → PROPOSAL → NEGOTIATION → LIVE, or PASS/HOLD).
+- **Follow-ups** — complete or delete stale ones; don't let the queue rot.
+
+Date belongs to the atom. Meaning belongs to the journal. Don't write the same sentence twice.
+
+## Contacts
+
+Do not create new contacts unless the task explicitly authorizes it. If someone in the inbox looks worth adding, flag them in the summary and let the user decide.
+
+## Briefings
+
+If the CRM surfaces a "meeting tomorrow" alert and no briefing exists on that contact, build one from email history, CRM interactions, and light public research. Keep it practical: who, role, history, why now, likely goals, open questions, talking points, risks. Save via the briefing tool and verify.
+
+Don't pre-build briefings without an alert.
+
+## Verify
+
+Every write must be confirmed. An email is not "processed" until the CRM reflects it and the write is verified. If a write fails or is uncertain, surface it — don't silently move on.
+
+## Reporting
+
+Short and direct. One line per contact that moved. Examples:
+
+- "Proposal accepted. Stage → NEGOTIATION. Follow-up Friday."
+- "Jeff confirmed May 5, 9–11 AM in Torrance. Meeting logged."
+- "Prospect pushed timing two weeks. Follow-up moved."
+
+Call out: anything needing the user's action, anyone who might warrant a new contact, any live deal at risk of slipping.


### PR DESCRIPTION
## Summary
- New `docs/agent-prompts/crm-inbox-agent.md` — a pastable prompt for users who want a scheduled agent (e.g. Claude Cowork or OpenClaw) to do a daily scan of their inbox and keep the CRM aligned with reality.
- README cleanup: stale bits caught while I was there.

## What the prompt covers
- **Mission + priority** — catch deal movement, reflect material emails, surface anything needing a decision; prefer noise over missed signal.
- **Read discipline** — full threads in chronological order, **both received AND sent mail** (the user's own replies, proposals, confirmations are often the most load-bearing events), forwards, CC/BCC.
- **What to log vs. what to skip** — LIVE clients get a higher bar: wins / friction / strategic shifts / new stakeholders only; no routine delivery chatter.
- **Dedup** — re-runs must not double-log; check for same fact on same date before writing.
- **Tool discipline** mirrors the `crm` skill's data-partition rule.
- **Briefings** built only when the CRM surfaces a "meeting tomorrow" alert.
- **Reporting** — one line per contact that moved.

## README staleness fixes
- Tool count `16+` → `25+`
- New `Journal` bullet in "Why Claw" — the flagship recent feature wasn't pitched
- MCP Tools table gained `peek_last_journal_entry` and `batch_append_journal`
- Entities table gained a `Journal` row
- New "Agent prompts" section linking to `docs/agent-prompts/`

## Test plan
- [x] Docs render correctly (GitHub markdown)
- [x] Link in README resolves to `docs/agent-prompts/crm-inbox-agent.md`
- [x] No code/schema/behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)