### PR TITLE
Contact header: text links for Briefing/Journal, left-edge status bar

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -102,8 +102,19 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 ### 6. UI: Change stage via command
 - Type `/stage PROPOSAL` in a contact's input
 - Press Enter
-- Verify the stage badge updates to PROPOSAL
+- Verify the flash "Stage → PROPOSAL" appears on the contact's card (briefly)
+- Switch the top stage filter to `PROPOSAL` and verify the contact now appears in that list
 - **Screenshot** → `e2e-screenshots/07-stage-changed.png`
+
+### 6b. UI: Briefing/Journal text links and status bar
+- On the contact list, verify each contact card has:
+  - A 3px colored bar on its left edge (teal for ACTIVE, violet for HOLD)
+  - A `Journal` text link on the right of the header row — teal if the relationship journal is populated, muted gray if empty
+  - A `Briefing` text link on the right of the header row **only when a briefing exists** for that contact
+- Click the `Journal` link for a contact — verify it navigates to `/journal/<id>`
+- Navigate back; click the `Briefing` link for a contact that has one — verify it navigates to `/briefings/<id>`
+- Verify **no** stage pill, status pill, or emoji badges appear on the header row
+- **Screenshot** → `e2e-screenshots/07b-header-links.png`
 
 ### 7. UI: Search contacts (Cmd+K)
 - Click the search icon (magnifying glass) in the header, OR press Cmd+K
@@ -148,10 +159,10 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 - Call `append_journal` again with `body: "follow up next week"` (intentionally relative). Verify `ok: false` and `reason: "relative_date"` naming the phrase `next week`.
 - Call `edit_journal` with a stale `expectedHash` (e.g. `"0"`). Verify `ok: false`, `reason: "hash_conflict"`.
 - Call `edit_journal` to mutate an existing `### YYYY-MM-DD:` heading without `confirmed_with_user`. Verify `ok: false`, `reason: "destructive_edit"`. Retry with `confirmed_with_user: true` — verify it succeeds.
-- **Screenshot** → `e2e-screenshots/13-mcp-journal.png` (the CRM page showing the journal badge 📓 on the contact)
+- **Screenshot** → `e2e-screenshots/13-mcp-journal.png` (the CRM page showing the teal `Journal` link on the contact)
 
 ### 10c. UI: View, edit, and restore journal
-- From the CRM page, click the 📓 badge next to a contact (dim if empty, full opacity if populated). Should navigate to `/journal/<id>`.
+- From the CRM page, click the `Journal` text link next to a contact (muted gray if empty, teal if populated). Should navigate to `/journal/<id>`.
 - Verify the journal renders as formatted text (no `**`, `#`, or `[` visible in the rendered view).
 - Click Edit → the Tiptap editor appears. Make a small change (add a bold phrase via toolbar or add a sentence).
 - Click Save → confirm content persists (reload page, change still visible).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-04-20
+
+### Contact header: text links for Briefing/Journal, quieter status
+Emoji badges (📋 / 📓) are gone. Briefing and Journal now appear as plain teal text links on the right of the contact card header, matching the existing `more…` / `Show N earlier` link style already used inside the card. Much better tap targets on mobile, and consistent visual language across the row.
+
+Stage/status pills are also gone from the header row — they took real estate for values rarely touched in the list view. Status moved to a 3px colored left-edge bar on each card: teal for `ACTIVE`, violet for `HOLD`. Stage remains changeable via the existing `/stage XXX` slash command in the note input (and drag-drop on the kanban). Status still responds to `/status ACTIVE` / `/status HOLD`.
+
+Also removed the stale/violations warning triangle from the header — it was redundant with the violation rows rendered below the contact card and the red `OVERDUE` marker on tasks.
+
 ## 2026-04-19
 
 ### CRM Inbox Agent reference prompt + README cleanup

--- a/app/client/src/App.tsx
+++ b/app/client/src/App.tsx
@@ -15,18 +15,6 @@ import JournalPage from "@/pages/journal-page";
 import SetupPage from "@/pages/setup-page";
 import NotFound from "@/pages/not-found";
 
-// Badge definitions — hardcoded, no plugin indirection
-export const BADGES = [
-  { dataKey: "briefing", icon: "📋", route: "/briefings/:contactId", tooltip: "View briefing", alwaysShow: false },
-  {
-    dataKey: "relationshipJournal",
-    icon: "📓",
-    route: "/journal/:contactId",
-    tooltip: "Relationship journal",
-    alwaysShow: true,
-  },
-];
-
 // App config context — org name from DB
 // Derive color variants from a hex primary color
 function deriveColors(hex: string) {

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -4,7 +4,9 @@ import { Square, AlertTriangle, Trash2, Clock } from "lucide-react";
 import type { ContactWithRelations } from "@shared/schema";
 import type { SearchSnippet } from "@/hooks/use-contact-search";
 import { fmtDate, fmtDateInput } from "@/lib/utils";
-import { useColors, BADGES } from "@/App";
+import { useColors } from "@/App";
+
+const HOLD_COLOR = "#6c5ce7";
 
 const STAGE_OPTIONS = ["LEAD", "MEETING", "PROPOSAL", "NEGOTIATION", "LIVE", "PASS", "RELATIONSHIP"] as const;
 
@@ -86,7 +88,6 @@ function HighlightedText({ text, terms }: { text: string; terms?: string[] }) {
 
 interface ContactBlockProps {
   contact: ContactWithRelations;
-  accentColor: string;
   onAddInteraction: (content: string, date: string, type?: string) => void;
   onUpdateInteraction: (id: number, data: { content?: string; type?: string }) => void;
   onDeleteInteraction: (id: number) => void;
@@ -105,7 +106,6 @@ interface ContactBlockProps {
 
 export function ContactBlock({
   contact,
-  accentColor,
   onAddInteraction,
   onUpdateInteraction,
   onDeleteInteraction,
@@ -123,8 +123,6 @@ export function ContactBlock({
   const [showAllInteractions, setShowAllInteractions] = useState(false);
   const [expandedInteractions, setExpandedInteractions] = useState<Set<number>>(new Set());
   const [newNote, setNewNote] = useState("");
-  const [showStageMenu, setShowStageMenu] = useState(false);
-  const [showStatusMenu, setShowStatusMenu] = useState(false);
   const [flash, setFlash] = useState<string | null>(null);
   const [editingInteractionId, setEditingInteractionId] = useState<number | null>(null);
   const [editingInteractionText, setEditingInteractionText] = useState("");
@@ -137,12 +135,7 @@ export function ContactBlock({
   const [completingFollowupText, setCompletingFollowupText] = useState("");
 
   const companyName = contact.company?.name || "";
-  const hasViolations = contact.violations.length > 0;
   const activeFollowups = contact.followups.filter((f) => !f.completed);
-  const lastInteraction =
-    contact.interactions.length > 0 ? contact.interactions[contact.interactions.length - 1] : null;
-  const daysSinceLastTouch = lastInteraction ? differenceInDays(new Date(), new Date(lastInteraction.date)) : null;
-  const isStale = daysSinceLastTouch !== null && daysSinceLastTouch > 14 && contact.status === "ACTIVE";
   const hasDetails = !!(
     contact.background ||
     contact.source ||
@@ -236,11 +229,6 @@ export function ContactBlock({
     }
   };
 
-  const handleStageClick = (stage: string) => {
-    onUpdateContact({ stage });
-    setShowStageMenu(false);
-    showFlash(`Stage → ${stage}`);
-  };
   const handleBackgroundSave = () => {
     if (backgroundText !== (contact.background || "")) {
       onUpdateContact({ background: backgroundText });
@@ -270,12 +258,23 @@ export function ContactBlock({
   const command = detectCommand(newNote);
   const inputColor = command.type !== "none" ? COMMAND_COLORS[command.type] : undefined;
 
+  const statusColor = contact.status === "HOLD" ? HOLD_COLOR : C.accent;
+  const hasBriefing = Boolean(contact.briefing);
+  const hasJournal = Boolean(contact.relationshipJournal);
+
   return (
     <div
       id={`contact-${contact.id}`}
-      className={`relative bg-white mb-2 ${isInactive ? "opacity-50 hover:opacity-75" : ""}`}
-      style={{ border: `1px solid ${C.border}`, borderRadius: "10px", padding: "0.75rem 1rem" }}
+      className={`relative bg-white mb-2 overflow-hidden ${isInactive ? "opacity-50 hover:opacity-75" : ""}`}
+      style={{ border: `1px solid ${C.border}`, borderRadius: "10px", padding: "0.75rem 1rem 0.75rem 1.125rem" }}
     >
+      {/* Status bar — left edge, teal for ACTIVE, violet for HOLD */}
+      <div
+        className="absolute left-0 top-0 bottom-0 w-[3px]"
+        style={{ backgroundColor: statusColor }}
+        title={`Status: ${contact.status}`}
+        aria-label={`Status: ${contact.status}`}
+      />
       {/* Header */}
       <div className="flex items-center gap-1.5">
         {flash && (
@@ -286,122 +285,34 @@ export function ContactBlock({
             {flash}
           </span>
         )}
-        <h2 className="text-sm font-bold leading-tight" style={{ color: C.text }}>
+        <h2 className="text-sm font-bold leading-tight whitespace-nowrap" style={{ color: C.text }}>
           {contact.firstName} {contact.lastName}
         </h2>
 
         {companyName && (
-          <span className="text-xs" style={{ color: C.muted }}>
+          <span className="text-xs truncate min-w-0" style={{ color: C.muted }}>
             {companyName}
           </span>
         )}
 
-        <div className="relative ml-auto">
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setShowStageMenu(!showStageMenu);
-            }}
-            className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full transition-colors hover:opacity-80"
-            style={{ backgroundColor: `${accentColor}15`, color: accentColor }}
-          >
-            {contact.stage}
-          </button>
-          {showStageMenu && (
-            <>
-              <div className="fixed inset-0 z-10" onClick={() => setShowStageMenu(false)} />
-              <div
-                className="absolute right-0 top-full mt-1 bg-white rounded-lg shadow-lg z-20 py-1 min-w-[130px]"
-                style={{ border: `1px solid ${C.border}` }}
-              >
-                {STAGE_OPTIONS.map((s) => (
-                  <button
-                    key={s}
-                    onClick={() => handleStageClick(s)}
-                    className="block w-full text-left px-3 py-1 text-[11px] transition-colors hover:opacity-70"
-                    style={{
-                      color: s === contact.stage ? C.text : C.muted,
-                      fontWeight: s === contact.stage ? 600 : 400,
-                      backgroundColor: s === contact.stage ? C.accentLight : "transparent",
-                    }}
-                  >
-                    {s}
-                  </button>
-                ))}
-              </div>
-            </>
-          )}
-        </div>
-
-        <div className="relative">
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setShowStatusMenu(!showStatusMenu);
-              setShowStageMenu(false);
-            }}
-            className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full transition-colors hover:opacity-80"
-            style={{
-              backgroundColor: contact.status === "HOLD" ? "#f0ecf8" : `${C.accent}15`,
-              color: contact.status === "HOLD" ? "#6c5ce7" : C.accent,
-            }}
-          >
-            {contact.status}
-          </button>
-          {showStatusMenu && (
-            <>
-              <div className="fixed inset-0 z-10" onClick={() => setShowStatusMenu(false)} />
-              <div
-                className="absolute right-0 top-full mt-1 bg-white rounded-lg shadow-lg z-20 py-1 min-w-[100px]"
-                style={{ border: `1px solid ${C.border}` }}
-              >
-                {(["ACTIVE", "HOLD"] as const).map((s) => (
-                  <button
-                    key={s}
-                    onClick={() => {
-                      if (s !== contact.status) {
-                        onUpdateContact({ status: s });
-                        showFlash(`Status → ${s}`);
-                      }
-                      setShowStatusMenu(false);
-                    }}
-                    className="block w-full text-left px-3 py-1 text-[11px] transition-colors hover:opacity-70"
-                    style={{
-                      color: s === contact.status ? C.text : C.muted,
-                      fontWeight: s === contact.status ? 600 : 400,
-                      backgroundColor:
-                        s === contact.status ? (s === "HOLD" ? "#f0ecf8" : C.accentLight) : "transparent",
-                    }}
-                  >
-                    {s}
-                  </button>
-                ))}
-              </div>
-            </>
-          )}
-        </div>
-
-        {isStale && <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" style={{ color: C.stale }} />}
-        {hasViolations && !isStale && (
-          <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" style={{ color: C.stale }} />
-        )}
-
-        {/* Feature badges */}
-        {BADGES.map((badge, i) => {
-          const present = Boolean((contact as ContactWithRelations & Record<string, unknown>)[badge.dataKey]);
-          if (!present && !badge.alwaysShow) return null;
-          return (
+        <div className="ml-auto flex items-center gap-3">
+          {hasBriefing && (
             <a
-              key={i}
-              href={badge.route.replace(":contactId", String(contact.id))}
-              className="flex-shrink-0 hover:opacity-70 transition-colors"
-              title={badge.tooltip || ""}
-              style={{ fontSize: "14px", opacity: present ? 1 : 0.35 }}
+              href={`/briefings/${contact.id}`}
+              className="text-[11px] font-medium leading-none py-1.5 -my-1.5 transition-opacity hover:opacity-70 flex-shrink-0"
+              style={{ color: C.accentDark }}
             >
-              {badge.icon}
+              Briefing
             </a>
-          );
-        })}
+          )}
+          <a
+            href={`/journal/${contact.id}`}
+            className="text-[11px] font-medium leading-none py-1.5 -my-1.5 transition-opacity hover:opacity-70 flex-shrink-0"
+            style={{ color: hasJournal ? C.accentDark : C.muted }}
+          >
+            Journal
+          </a>
+        </div>
       </div>
 
       {/* Search snippet */}

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -32,17 +32,6 @@ import { useContactSearch } from "@/hooks/use-contact-search";
 // Pipeline order (funnel flow, top to bottom)
 const STAGES = ["ALL", "LEAD", "MEETING", "PROPOSAL", "NEGOTIATION", "LIVE", "RELATIONSHIP", "PASS"] as const;
 
-const STAGE_ACCENT: Record<string, string> = {
-  LIVE: "#2e7d32",
-  NEGOTIATION: "#d4880f",
-  PROPOSAL: "#2563eb",
-  MEETING: "#2bbcb3",
-  LEAD: "#5a7a7a",
-  HOLD: "#6c5ce7",
-  PASS: "#c0392b",
-  RELATIONSHIP: "#1a9e96",
-};
-
 const SORT_BUCKET: Record<string, number> = {
   NEGOTIATION: 0,
   PROPOSAL: 0,
@@ -692,7 +681,6 @@ export default function CrmPage() {
                 <ContactBlock
                   key={contact.id}
                   contact={contact}
-                  accentColor={STAGE_ACCENT[contact.stage] || "#5a7a7a"}
                   searchSnippet={snippet}
                   searchTerms={searchQuery.trim().split(/\s+/).filter(Boolean)}
                   onAddInteraction={(content, date, type) =>
@@ -721,7 +709,6 @@ export default function CrmPage() {
                 <ContactBlock
                   key={contact.id}
                   contact={contact}
-                  accentColor={STAGE_ACCENT[contact.stage] || "#5a7a7a"}
                   onAddInteraction={(content, date, type) =>
                     addInteraction.mutate({ contactId: contact.id, content, date, type })
                   }


### PR DESCRIPTION
## Summary
- Replaces tiny 📋/📓 emoji badges with plain teal `Briefing` / `Journal` text links next to the contact name — matches the existing `more…` / `Show N earlier` link style already used inside the card
- Removes the stage/status pills from the header row (rarely touched in the list; still editable via `/stage` and `/status` slash commands and kanban drag)
- Moves status to a 3px colored left-edge bar on each card — teal = ACTIVE, violet = HOLD
- Removes the stale/violations warning triangle from the header — redundant with the violation rows rendered below and the red OVERDUE marker on tasks

Designed for mobile-first use. The previous emoji badges were ~14px tap targets; text links inherit the card's existing link styling and sit with generous hit area.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [x] Focused E2E run covering the touched surfaces (see `e2e-screenshots/run.json`): login → card renders → `Briefing`/`Journal` links → status bar via `aria-label` → `/stage` / `/fu` slash commands still work
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)