### PR TITLE
Briefing upgrade: research protocol, 8-section format, staleness

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -110,11 +110,28 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 - On the contact list, verify each contact card has:
   - A 3px colored bar on its left edge (teal for ACTIVE, violet for HOLD)
   - A `Journal` text link on the right of the header row — teal if the relationship journal is populated, muted gray if empty
-  - A `Briefing` text link on the right of the header row **only when a briefing exists** for that contact
+  - A `Briefing` text link on the right of the header row **only when a briefing exists AND it's <7 days old** for that contact
 - Click the `Journal` link for a contact — verify it navigates to `/journal/<id>`
 - Navigate back; click the `Briefing` link for a contact that has one — verify it navigates to `/briefings/<id>`
 - Verify **no** stage pill, status pill, or emoji badges appear on the header row
 - **Screenshot** → `e2e-screenshots/07b-header-links.png`
+
+### 6c. UI: Briefing template + validation + staleness
+- Navigate to `/briefings/<id>` for a contact without a briefing. Verify the empty state reads "No briefing yet" and shows a **Start from template** button. Click it.
+- Verify the textarea prefills with the 8-section skeleton (`## TL;DR` → `## About them` → `## About the company` → `## Shared ground` → `## Our history` → `## What to discuss` → `## Offers / asks` → `## Watch-outs`), monospace, HTML comments acting as placeholders.
+- Edit one section and click **Save**. Verify it persists.
+- Now test validation: edit the briefing, delete the `## Watch-outs` section, click Save. Verify the save is rejected with a red error box naming the missing section and telling you to call `prepare_briefing`.
+- Fabricate a stale briefing (age > 7 days) — via DB: `UPDATE briefings SET updated_at = NOW() - INTERVAL '8 days' WHERE contact_id = <id>;`
+- Reload `/briefings/<id>`. Verify a yellow **Stale** banner appears above the briefing: "Stale — last updated 8 days ago. Briefings older than 7 days stop surfacing on contact cards."
+- Navigate back to the contact list (`/`). Verify the `Briefing` text link on that contact's card is **gone** (the Journal link is still there).
+- **Screenshot** → `e2e-screenshots/07c-briefing-template-and-staleness.png`
+
+### 6d. MCP: prepare_briefing + save_briefing validation
+- Call `prepare_briefing` via MCP with a known contactId. Verify the response JSON includes: `contact` (with `linkedinUrl` field), `interactions`, `activeFollowups`, `recentlyCompletedFollowups`, `journal`, `previousBriefing` (with `content`, `updatedAt`, `ageDays`, `stale`) if one exists, `template`, `research_protocol`, `required_sections`, and `instructions`.
+- Call `save_briefing` via MCP with malformed content (e.g. missing sections). Verify `isError: true` and the error text enumerates every missing section plus the canonical order.
+- Call `save_briefing` via MCP with content that has all 8 sections out of order. Verify `isError: true` and the error names the first out-of-order header.
+- Call `save_briefing` via MCP with a valid 8-section briefing. Verify it succeeds.
+- Call `get_briefing` via MCP on the contact. Verify the response JSON includes `content`, `updatedAt`, `ageDays`, and `stale: false`.
 
 ### 7. UI: Search contacts (Cmd+K)
 - Click the search icon (magnifying glass) in the header, OR press Cmd+K

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 2026-04-20
 
+### Briefing upgrade — research protocol, enforced 8-section format, staleness
+Briefings were a single free-form blob. The agent got no guidance on what to research, no target format, no prior context beyond what it bothered to look up. Every briefing was invented from vibes.
+
+**New MCP tool — `prepare_briefing(contactId)`.** Always call this first. Returns a JSON prep pack: the contact record (including `linkedinUrl` if set), every interaction, active + recently-completed followups, the relationship journal, any existing briefing (labeled `previousBriefing` with `ageDays` + `stale` flag), the canonical template, a `required_sections` list, and the research protocol the agent must follow before writing. The protocol tells the agent to draw on its knowledge of the user, fetch the contact's LinkedIn, web-search the person and company, cross-reference for shared ground, and re-read the journal. If a previous briefing exists, it's handed back as a starting point — agents update in place rather than rewriting.
+
+**Canonical 8-section format, enforced server-side.** Every briefing must contain `## TL;DR → ## About them → ## About the company → ## Shared ground → ## Our history → ## What to discuss → ## Offers / asks → ## Watch-outs`, in order. `save_briefing` validates and rejects with a specific error naming missing or out-of-order sections; the REST PUT endpoint validates too, so the UI gets the same guardrail. The error message points the agent back at `prepare_briefing` for the template. UI "Start from template" prefills the 8-section skeleton on first create.
+
+**Staleness — 7-day TTL.** A briefing stops surfacing on the contact list once it's >7 days old. The `Briefing` text link disappears from the contact card. The briefing page still renders the content with a yellow stale banner + age callout so the user can review and refresh with their agent. `get_briefing` and `prepare_briefing` both return `stale` + `ageDays` so agents know when to refresh vs. preserve.
+
+**New contact field — `linkedinUrl`.** Optional text field on `contacts`. Exposed through `create_contact`, `update_contact`, `get_contact`, and `prepare_briefing`. Biggest research unlock for the agent: a direct pointer to the person's profile. Boot migration adds the column idempotently.
+
+**Rewritten `get_crm_guide` → Briefings section.** The one-liner that said "store prep notes" is now a full workflow: always call prepare_briefing → research per protocol → write to template → save_briefing validates. Points at the enforced section list and the staleness rule.
+
+`app/shared/briefing.ts` owns the contract — constants, template, validator, staleness helper — so server (MCP + REST), client (contact card + briefing page) all read the same truth.
+
 ### Contact header: text links for Briefing/Journal, quieter status
 Emoji badges (📋 / 📓) are gone. Briefing and Journal now appear as plain teal text links on the right of the contact card header, matching the existing `more…` / `Show N earlier` link style already used inside the card. Much better tap targets on mobile, and consistent visual language across the row.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Reference prompts for scheduled agents that operate on your behalf live in [`doc
 | `list_rules` / `create_rule` / `update_rule` / `delete_rule` | Manage business rules. |
 | `list_violations` | Active rule violations with contact names. |
 | `get_upcoming_meetings` / `cancel_meeting` | Meeting management. |
-| `save_briefing` / `get_briefing` | Per-contact prep notes. |
+| `prepare_briefing` | Gather everything an agent needs before writing a briefing: contact record (with `linkedinUrl`), interactions, followups, journal, any previous briefing (with `ageDays` + `stale` flag), canonical 8-section template, and the research protocol. First call in every briefing workflow. |
+| `save_briefing` / `get_briefing` | Upsert / read the briefing. `save_briefing` validates the 8-section structure and rejects missing or out-of-order sections. `get_briefing` returns content + `ageDays` + `stale` (true after 7 days). |
 | `read_journal` / `peek_last_journal_entry` | Read the full `relationship_journal` (optional `section` scope) or just the most recent dated Entry + doc hash. |
 | `edit_journal` / `append_journal` / `batch_append_journal` | Modify the journal. Absolute-dates-only validator, verbatim blockquote escape, destructive edits gated behind `confirmed_with_user`. `batch_append_journal` writes many dated entries transactionally — the bulk-migration path. |
 
@@ -159,7 +160,7 @@ Exceptions: `has_future_followup`, `stage_in` (exclude specific stages from rule
 | **Interactions** | Timeline entries — what happened (past tense). |
 | **Follow-ups** | Action items with due dates. |
 | **Meetings** | Future scheduled events. |
-| **Briefings** | Per-contact prep notes (upsert). |
+| **Briefings** | Per-contact prep for the next specific meeting. Canonical 8-section structure (TL;DR, About them, About the company, Shared ground, Our history, What to discuss, Offers / asks, Watch-outs) enforced by the server. Stale after 7 days — old briefings stop surfacing on contact cards but remain readable on the briefing page. |
 | **Journal** | Per-contact markdown narrative — Key People, Wins / Case Study Material, dated Entries. Full revision history. |
 | **Rules** | Business logic — conditions + actions as JSONB. |
 | **Violations** | Alerts created by rules, auto-cleared when resolved. |

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -5,6 +5,7 @@ import type { ContactWithRelations } from "@shared/schema";
 import type { SearchSnippet } from "@/hooks/use-contact-search";
 import { fmtDate, fmtDateInput } from "@/lib/utils";
 import { useColors } from "@/App";
+import { isBriefingStale } from "@shared/briefing";
 
 const HOLD_COLOR = "#6c5ce7";
 
@@ -259,7 +260,9 @@ export function ContactBlock({
   const inputColor = command.type !== "none" ? COMMAND_COLORS[command.type] : undefined;
 
   const statusColor = contact.status === "HOLD" ? HOLD_COLOR : C.accent;
-  const hasBriefing = Boolean(contact.briefing);
+  // Stale briefings (>7d) stop surfacing here — they're not prep material.
+  // Content is still available via the briefing page so the user can refresh.
+  const hasBriefing = Boolean(contact.briefing && !isBriefingStale(contact.briefing.updatedAt));
   const hasJournal = Boolean(contact.relationshipJournal);
 
   return (

--- a/app/client/src/pages/briefing-page.tsx
+++ b/app/client/src/pages/briefing-page.tsx
@@ -5,12 +5,7 @@ import { AlertTriangle, ArrowLeft } from "lucide-react";
 import { Link, useParams } from "wouter";
 import { useColors } from "@/App";
 import type { ContactWithRelations } from "@shared/schema";
-import {
-  BRIEFING_TEMPLATE,
-  BRIEFING_STALE_DAYS,
-  isBriefingStale,
-  briefingAgeDays,
-} from "@shared/briefing";
+import { BRIEFING_TEMPLATE, BRIEFING_STALE_DAYS, isBriefingStale, briefingAgeDays } from "@shared/briefing";
 
 export default function BriefingPage() {
   const C = useColors();

--- a/app/client/src/pages/briefing-page.tsx
+++ b/app/client/src/pages/briefing-page.tsx
@@ -1,10 +1,16 @@
 import { useState } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
-import { ArrowLeft } from "lucide-react";
+import { AlertTriangle, ArrowLeft } from "lucide-react";
 import { Link, useParams } from "wouter";
 import { useColors } from "@/App";
 import type { ContactWithRelations } from "@shared/schema";
+import {
+  BRIEFING_TEMPLATE,
+  BRIEFING_STALE_DAYS,
+  isBriefingStale,
+  briefingAgeDays,
+} from "@shared/briefing";
 
 export default function BriefingPage() {
   const C = useColors();
@@ -19,6 +25,7 @@ export default function BriefingPage() {
   const briefing = contact?.briefing;
   const [editing, setEditing] = useState(false);
   const [content, setContent] = useState("");
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   // Init content from briefing
   if (briefing && !editing && content !== briefing.content) {
@@ -34,11 +41,32 @@ export default function BriefingPage() {
       queryClient.invalidateQueries({ queryKey: [`/api/contacts/${contactId}`] });
       queryClient.invalidateQueries({ queryKey: ["/api/contacts"] });
       setEditing(false);
+      setSaveError(null);
+    },
+    onError: (err: Error) => {
+      // apiRequest throws `${status}: ${body}`. Body for validation failures
+      // is JSON — pull the message out if we can, otherwise fall through.
+      const raw = err.message || "";
+      const jsonStart = raw.indexOf("{");
+      if (jsonStart > 0) {
+        try {
+          const parsed = JSON.parse(raw.slice(jsonStart));
+          if (parsed?.message) {
+            setSaveError(parsed.message);
+            return;
+          }
+        } catch {
+          // fall through to raw
+        }
+      }
+      setSaveError(raw || "Failed to save. Check that all 8 sections are present and in order.");
     },
   });
 
   const contactName = contact ? `${contact.firstName} ${contact.lastName}` : "Loading...";
   const companyName = contact?.company?.name || "";
+  const stale = briefing ? isBriefingStale(briefing.updatedAt) : false;
+  const ageDays = briefing ? briefingAgeDays(briefing.updatedAt) : 0;
 
   // Find upcoming meetings for this contact
   const upcomingMeetings = (contact?.followups || []).filter(
@@ -90,6 +118,23 @@ export default function BriefingPage() {
           </div>
         )}
 
+        {/* Stale banner — briefing exists but hasn't been refreshed in >7 days */}
+        {stale && !editing && (
+          <div
+            className="mb-3 flex items-start gap-2 rounded-lg px-3 py-2 text-xs"
+            style={{ backgroundColor: "#fef3c7", color: "#854d0e", border: "1px solid #fbbf24" }}
+          >
+            <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0 mt-px" />
+            <div>
+              <div className="font-semibold">Stale — last updated {ageDays} days ago.</div>
+              <div>
+                Briefings older than {BRIEFING_STALE_DAYS} days stop surfacing on contact cards. Refresh with your agent
+                before the next meeting.
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* Briefing content */}
         <div className="bg-white" style={{ border: `1px solid ${C.border}`, borderRadius: "12px", padding: "1.25rem" }}>
           {editing ? (
@@ -98,10 +143,18 @@ export default function BriefingPage() {
                 autoFocus
                 value={content}
                 onChange={(e) => setContent(e.target.value)}
-                className="w-full text-sm leading-relaxed rounded-lg p-3 outline-none resize-none min-h-[300px]"
+                className="w-full text-sm leading-relaxed rounded-lg p-3 outline-none resize-none min-h-[400px] font-mono"
                 style={{ color: C.text, backgroundColor: C.accentLight, border: `1px solid ${C.border}` }}
-                placeholder="Write your briefing here...&#10;&#10;Talking points:&#10;- &#10;&#10;Open items:&#10;- &#10;&#10;Notes:&#10;- "
+                placeholder="Fill in each ## section. All 8 are required."
               />
+              {saveError && (
+                <div
+                  className="mt-2 text-xs rounded-lg px-3 py-2"
+                  style={{ backgroundColor: "#fee2e2", color: "#991b1b", border: "1px solid #fecaca" }}
+                >
+                  {saveError}
+                </div>
+              )}
               <div className="flex gap-2 mt-3">
                 <button
                   onClick={() => saveBriefing.mutate(content)}
@@ -114,6 +167,7 @@ export default function BriefingPage() {
                   onClick={() => {
                     setEditing(false);
                     setContent(briefing?.content || "");
+                    setSaveError(null);
                   }}
                   className="text-xs px-3 py-1.5"
                   style={{ color: C.muted }}
@@ -152,15 +206,19 @@ export default function BriefingPage() {
               <p className="text-sm mb-3" style={{ color: C.muted }}>
                 No briefing yet
               </p>
+              <p className="text-[11px] mb-3" style={{ color: C.muted }}>
+                Ask your agent to call <code>prepare_briefing</code> for research-backed prep, or start from the
+                template below.
+              </p>
               <button
                 onClick={() => {
-                  setContent("");
+                  setContent(BRIEFING_TEMPLATE(contactName, companyName));
                   setEditing(true);
                 }}
                 className="text-xs font-medium text-white px-4 py-2 rounded-lg"
                 style={{ backgroundColor: C.accentDark }}
               >
-                Create Briefing
+                Start from template
               </button>
             </div>
           )}

--- a/app/server/boot-migrations.ts
+++ b/app/server/boot-migrations.ts
@@ -62,6 +62,13 @@ CREATE INDEX IF NOT EXISTS contact_journal_revisions_contact_created_idx
   ON contact_journal_revisions (contact_id, created_at DESC);
 `,
   },
+  {
+    // 2026-04-20: contacts.linkedin_url — optional handle to the contact's
+    // LinkedIn profile. Biggest research unlock for briefing agents (and the
+    // user) with no downside when absent.
+    name: "add_contacts_linkedin_url",
+    sql: `ALTER TABLE contacts ADD COLUMN IF NOT EXISTS linkedin_url TEXT;`,
+  },
 ];
 
 export async function runBootMigrations(): Promise<void> {

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -32,6 +32,15 @@ import {
   ACCEPTED_DATE_FORMATS,
   todayIso,
 } from "@shared/journal";
+import {
+  BRIEFING_SECTIONS,
+  BRIEFING_STALE_DAYS,
+  BRIEFING_TEMPLATE,
+  BRIEFING_RESEARCH_PROTOCOL,
+  validateBriefingSections,
+  isBriefingStale,
+  briefingAgeDays,
+} from "@shared/briefing";
 import { db } from "./db";
 import { eq, and, isNull, gte, lte, asc, sql } from "drizzle-orm";
 import { sseManager } from "./sse";
@@ -247,8 +256,17 @@ Meetings appear alongside tasks in contact cards and the Upcoming strip.
 After a meeting happens, log it as an interaction with add_interaction.
 
 ## Briefings
-Use save_briefing to store prep notes for a contact (one per contact, upsert).
-Good for: talking points, recent news, open items before a meeting.
+A briefing is a research-backed prep document for the **next specific meeting** with one contact. One per contact (upsert). Stale after ${BRIEFING_STALE_DAYS} days — old briefings stop surfacing on contact cards until refreshed.
+
+**Workflow — always in this order:**
+1. Call \`prepare_briefing(contactId)\` to get a prep pack: the contact record (including \`linkedinUrl\` if set), interactions, active + recent followups, journal content, any existing briefing (labeled \`previousBriefing\` with \`ageDays\`), the canonical template, and the research protocol.
+2. Do the research the protocol requires: fetch LinkedIn, web-search the person + company, cross-reference against what you know about your user, re-read the journal.
+3. Write the briefing into the 8-section template.
+4. Call \`save_briefing(contactId, content)\`. The server validates every canonical section is present and in order — missing sections are rejected with a specific error.
+
+**Canonical 8 sections, enforced in order:** ${BRIEFING_SECTIONS.map((s) => `\`## ${s}\``).join(" → ")}.
+
+If a \`previousBriefing\` exists, update it in place: preserve what's still true, change what's changed, add new signal. Do not rewrite from scratch.
 
 ## Relationship Journal
 The persistent, file-like narrative of the relationship. Freeform markdown per contact, everlasting, append-mostly. Tools: \`read_journal\`, \`peek_last_journal_entry\`, \`edit_journal\`, \`append_journal\`, \`batch_append_journal\`.
@@ -589,6 +607,7 @@ IMPORTANT formatting rules:
 - email: Their direct email address. Always populate if known.
 - phone: Their direct phone number. Always populate if known.
 - website: Company website domain only (no https://), e.g. "standardcommunities.com"
+- linkedinUrl: Full URL to the contact's personal LinkedIn profile, e.g. "https://www.linkedin.com/in/jane-doe". Populate whenever known — briefing research leans on it.
 - location: City or short location, e.g. "LA" or "Torrance, CA" or "Monterrey, Mexico"
 - background: 1-2 sentences about the company and why they're relevant. Keep it SHORT — this is a quick-scan tearsheet, not a full bio. Do NOT dump all context here.
 - source: How we met or who referred them, e.g. "Ryan Chan (referral)" or "Direct" or "Met at YPO event"
@@ -608,6 +627,10 @@ After creating the contact, use add_interaction to log the key events (meetings,
       email: z.string().optional().describe("Direct email address — always include if known"),
       phone: z.string().optional().describe("Direct phone number"),
       website: z.string().optional().describe("Company website domain (no https://), e.g. 'acme.com'"),
+      linkedinUrl: z
+        .string()
+        .optional()
+        .describe("Full URL to the contact's LinkedIn profile, e.g. 'https://www.linkedin.com/in/jane-doe'"),
       location: z.string().optional().describe("City or short location, e.g. 'LA' or 'NYC'"),
       background: z
         .string()
@@ -656,6 +679,7 @@ After creating the contact, use add_interaction to log the key events (meetings,
       email: z.string().optional().describe("Direct email address"),
       phone: z.string().optional().describe("Direct phone number"),
       website: z.string().optional().describe("Company website domain (no https://)"),
+      linkedinUrl: z.string().optional().describe("Full URL to the contact's LinkedIn profile"),
       location: z.string().optional().describe("City or short location"),
       background: z.string().optional().describe("1-2 sentence company context. Keep short."),
       source: z.string().optional().describe("Referral source"),
@@ -978,15 +1002,122 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
   });
 
   // --- Briefings ---
+  // Shared contract so save_briefing and prepare_briefing stay in sync. Points
+  // at get_crm_guide for the full decision tree.
+  const BRIEFING_CONTRACT =
+    `A briefing is research-backed prep for the **next specific meeting**. One per contact. Stale after ${BRIEFING_STALE_DAYS} days. ` +
+    `Required sections in order: ${BRIEFING_SECTIONS.map((s) => `## ${s}`).join(" → ")}. ` +
+    "See get_crm_guide → Briefings for the full workflow. " +
+    "ALWAYS call prepare_briefing(contactId) first to get the template, the contact's full context, and the research protocol.";
+
+  server.tool(
+    "prepare_briefing",
+    `Get everything needed to write a briefing for a contact: the contact record (including linkedinUrl if set), all interactions, active + recently-completed followups, the relationship journal, any existing briefing (as \`previousBriefing\` with ageDays + stale flag), the canonical template, and the research protocol the agent MUST follow. Call this BEFORE save_briefing. ${BRIEFING_CONTRACT}`,
+    {
+      contactId: z.number().describe("Contact ID. Get from search_contacts."),
+    },
+    async ({ contactId }) => {
+      try {
+        const contact = await storage.getContactWithRelations(contactId);
+        if (!contact) return notFoundError("Contact", contactId, "search_contacts");
+
+        const now = new Date();
+        const previousBriefing = contact.briefing
+          ? {
+              content: contact.briefing.content,
+              updatedAt: contact.briefing.updatedAt,
+              ageDays: briefingAgeDays(contact.briefing.updatedAt, now),
+              stale: isBriefingStale(contact.briefing.updatedAt, now),
+            }
+          : null;
+
+        // Separate active followups from recently-completed ones so the agent
+        // can see both "what's open" and "what just closed" without a giant list.
+        const activeFollowups = contact.followups.filter((f) => !f.completed);
+        const completedFollowups = contact.followups
+          .filter((f) => f.completed)
+          .sort((a, b) => new Date(b.completedAt ?? 0).getTime() - new Date(a.completedAt ?? 0).getTime())
+          .slice(0, 5);
+
+        const prepPack = {
+          contact: {
+            id: contact.id,
+            firstName: contact.firstName,
+            lastName: contact.lastName,
+            title: contact.title,
+            email: contact.email,
+            phone: contact.phone,
+            website: contact.website,
+            linkedinUrl: contact.linkedinUrl,
+            location: contact.location,
+            background: contact.background,
+            source: contact.source,
+            additionalContacts: contact.additionalContacts,
+            stage: contact.stage,
+            status: contact.status,
+            cadence: contact.cadence,
+            company: contact.company
+              ? { id: contact.company.id, name: contact.company.name, website: contact.company.website }
+              : null,
+          },
+          interactions: contact.interactions.map((i) => ({
+            date: i.date,
+            type: i.type,
+            content: i.content,
+          })),
+          activeFollowups: activeFollowups.map((f) => ({
+            id: f.id,
+            type: f.type,
+            dueDate: f.dueDate,
+            content: f.content,
+            time: f.time,
+            location: f.location,
+          })),
+          recentlyCompletedFollowups: completedFollowups.map((f) => ({
+            type: f.type,
+            completedAt: f.completedAt,
+            content: f.content,
+          })),
+          journal: contact.relationshipJournal ?? null,
+          previousBriefing,
+          template: BRIEFING_TEMPLATE(`${contact.firstName} ${contact.lastName}`, contact.company?.name),
+          research_protocol: BRIEFING_RESEARCH_PROTOCOL,
+          required_sections: BRIEFING_SECTIONS,
+          instructions:
+            "Follow the research_protocol above. Then write a briefing that exactly matches the template: all 8 sections in order. Call save_briefing(contactId, content) with the result. Validation will reject the save if any canonical section is missing or out of order.",
+        };
+
+        return { content: [{ type: "text" as const, text: JSON.stringify(prepPack, null, 2) }] };
+      } catch (err: unknown) {
+        return {
+          content: [{ type: "text" as const, text: actionableError("preparing briefing", err) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
   server.tool(
     "save_briefing",
-    "Save a meeting prep briefing for a contact. One per contact (upsert). Use bullet points for scannability.",
+    `Save a meeting prep briefing for a contact (upsert). Validates the 8-section canonical structure — rejects content with missing or out-of-order sections. ${BRIEFING_CONTRACT}`,
     {
       contactId: z.number(),
-      content: z.string().describe("Briefing text — talking points, context, prep notes"),
+      content: z
+        .string()
+        .describe(
+          `Full briefing markdown. MUST contain all 8 canonical sections as \`## Section\` headers in order: ${BRIEFING_SECTIONS.map((s) => `## ${s}`).join(" → ")}. Produce via prepare_briefing's template.`,
+        ),
     },
     async ({ contactId, content }) => {
       try {
+        const validation = validateBriefingSections(content);
+        if (!validation.ok) {
+          return {
+            content: [{ type: "text" as const, text: validation.message }],
+            isError: true,
+          };
+        }
+
         const [existing] = await db.select().from(briefings).where(eq(briefings.contactId, contactId));
         if (existing) {
           await db.update(briefings).set({ content, updatedAt: new Date() }).where(eq(briefings.contactId, contactId));
@@ -1021,7 +1152,7 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
 
   server.tool(
     "get_briefing",
-    "Get the prep briefing for a contact.",
+    `Get the current briefing for a contact. Returns content plus ageDays and stale (true if >${BRIEFING_STALE_DAYS}d old). Stale briefings are still returned so the agent can refresh them via prepare_briefing + save_briefing. For writing a new briefing, use prepare_briefing instead — it bundles everything the agent needs.`,
     {
       contactId: z.number(),
     },
@@ -1031,10 +1162,20 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
         if (!b)
           return {
             content: [
-              { type: "text" as const, text: `No briefing for contact ${contactId}. Use save_briefing to create one.` },
+              {
+                type: "text" as const,
+                text: `No briefing for contact ${contactId}. Use prepare_briefing to start one.`,
+              },
             ],
           };
-        return { content: [{ type: "text" as const, text: b.content }] };
+        const now = new Date();
+        const payload = {
+          content: b.content,
+          updatedAt: b.updatedAt,
+          ageDays: briefingAgeDays(b.updatedAt, now),
+          stale: isBriefingStale(b.updatedAt, now),
+        };
+        return { content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }] };
       } catch (err: unknown) {
         return { content: [{ type: "text" as const, text: actionableError("reading briefing", err) }], isError: true };
       }

--- a/app/server/routes.ts
+++ b/app/server/routes.ts
@@ -17,6 +17,7 @@ import {
 import { db } from "./db";
 import { eq, and, isNull, gte, lte, asc, desc } from "drizzle-orm";
 import { toNoonUTC } from "@shared/dates";
+import { validateBriefingSections } from "@shared/briefing";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   setupAuth(app);
@@ -422,6 +423,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.put("/api/briefings/:contactId", requireAuth, async (req, res) => {
     const { content } = req.body;
     if (!content || typeof content !== "string") return res.status(400).json({ message: "content required" });
+    const validation = validateBriefingSections(content);
+    if (!validation.ok) {
+      return res.status(400).json({
+        message: validation.message,
+        reason: validation.reason,
+        missing: validation.missing,
+      });
+    }
     const contactId = parseInt(req.params.contactId);
     const [existing] = await db.select().from(briefings).where(eq(briefings.contactId, contactId));
     let result;
@@ -435,7 +444,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       [result] = await db.insert(briefings).values({ contactId, content }).returning();
     }
     sseManager.broadcast({ type: "briefing_updated", contactId });
-    storage.logActivity("briefing.saved", `Briefing updated (${content.length} chars)`, { contactId, source: "agent" });
+    storage.logActivity("briefing.saved", `Briefing updated (${content.length} chars)`, { contactId, source: "user" });
     searchService.invalidate();
     res.json(result);
   });

--- a/app/shared/briefing.ts
+++ b/app/shared/briefing.ts
@@ -1,0 +1,155 @@
+// Shared briefing contract: template, required sections, validator, staleness.
+// Used by server (MCP tools + REST validation) and client (UI gating).
+
+// Briefings older than this stop surfacing as action links on contact cards.
+// Raw content is still retrievable via the briefing page so the user can
+// review + refresh — but a stale briefing is not prep material.
+export const BRIEFING_STALE_DAYS = 7;
+
+/**
+ * The eight canonical sections every briefing must contain, in this order.
+ * Enforced by validateBriefingSections and surfaced to agents via the tool
+ * description + the template skeleton.
+ */
+export const BRIEFING_SECTIONS = [
+  "TL;DR",
+  "About them",
+  "About the company",
+  "Shared ground",
+  "Our history",
+  "What to discuss",
+  "Offers / asks",
+  "Watch-outs",
+] as const;
+
+export type BriefingSection = (typeof BRIEFING_SECTIONS)[number];
+
+/**
+ * The agent-facing research protocol. Loaded into save_briefing's description
+ * and into prepare_briefing's response so the behaviour is attached to the
+ * tool contract, not buried in a skill file.
+ */
+export const BRIEFING_RESEARCH_PROTOCOL = `Before writing, you MUST:
+1. Draw on what you already know about your user — their role, expertise, background, what they offer. Every talking point, offer, and ask should ground in their actual capability. If you do not know the user well enough to brief on their behalf, say so and stop.
+2. Fetch the contact's LinkedIn if a URL is available on the contact record. Note current role, prior roles, education, skills, recent posts/activity.
+3. Web-search the contact by name + company. Note press, writing, talks, GitHub, podcasts — whatever reveals what they care about.
+4. Research the company. What they do, stage, size, funding, recent news (last 90 days), strategic context.
+5. Cross-reference your user's background against the contact's profile. Flag every overlap: shared schools (years), shared employers (tenure), shared domains, mutual second-degree connections if inferable.
+6. Re-read the journal, interactions, and open followups returned by prepare_briefing. Do NOT repeat what's there — reference it.
+
+If a \`previousBriefing\` is returned, treat it as a starting point: preserve what's still true, update what's changed, add what's new. Do not rewrite from scratch when an earlier briefing exists.
+
+If information isn't available for a section, write "Unknown — [what you'd want to know]" rather than inventing.`;
+
+/**
+ * Target skeleton the agent fills in. Also prefilled into the UI "Create
+ * Briefing" flow so manually-written briefings start in the canonical shape.
+ */
+export function BRIEFING_TEMPLATE(contactName: string, companyName?: string | null): string {
+  const header = companyName ? `# ${contactName} — ${companyName}` : `# ${contactName}`;
+  return `${header}
+
+## TL;DR
+<!-- 2-3 sentences: who they are, where we stand, what this meeting is for. -->
+
+## About them
+<!-- Role, background, recent activity. -->
+
+## About the company
+<!-- What they do, stage, size, funding, recent news, strategic context. -->
+
+## Shared ground
+<!-- Overlap with the user's background — schools, employers, domains, mutual connections. If none, say so plainly. -->
+
+## Our history
+<!-- Stage, first contact, 3-5 key moments, current open items. Reference — don't repeat — the journal and interactions. -->
+
+## What to discuss
+<!-- 3-5 specific talking points grounded in the user's expertise and this person's situation. -->
+
+## Offers / asks
+<!-- Could offer: ... / Could ask: ... -->
+
+## Watch-outs
+<!-- Sensitive topics, past friction, dead-end areas, anything worth flagging. -->
+`;
+}
+
+export type BriefingValidationFailure = {
+  ok: false;
+  reason: "missing_sections" | "out_of_order";
+  missing?: BriefingSection[];
+  firstOutOfOrder?: BriefingSection;
+  message: string;
+};
+
+export type BriefingValidationSuccess = { ok: true };
+
+export type BriefingValidationResult = BriefingValidationSuccess | BriefingValidationFailure;
+
+/**
+ * Every canonical section must appear as a `## Section` heading, and they must
+ * appear in the canonical order. Extra `##` sections and `###` subheadings are
+ * fine — we only check the canonical eight.
+ */
+export function validateBriefingSections(content: string): BriefingValidationResult {
+  const positions: Array<{ section: BriefingSection; index: number }> = [];
+  const missing: BriefingSection[] = [];
+
+  for (const section of BRIEFING_SECTIONS) {
+    // Match `## Section` as a standalone header line. Escape regex metachars so
+    // sections like "Offers / asks" (with `/`) work. Anchor with ^ and $ via
+    // the `m` flag so we don't match prose that happens to quote the header.
+    const escaped = section.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(`^##\\s+${escaped}\\s*$`, "m");
+    const match = re.exec(content);
+    if (!match || match.index === undefined) {
+      missing.push(section);
+    } else {
+      positions.push({ section, index: match.index });
+    }
+  }
+
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      reason: "missing_sections",
+      missing,
+      message: `Briefing missing required section(s): ${missing.map((s) => `## ${s}`).join(", ")}. Every briefing must contain all 8 canonical sections in order: ${BRIEFING_SECTIONS.map((s) => `## ${s}`).join(" → ")}. Call prepare_briefing(contactId) to get the template and research protocol.`,
+    };
+  }
+
+  for (let i = 1; i < positions.length; i++) {
+    if (positions[i].index < positions[i - 1].index) {
+      return {
+        ok: false,
+        reason: "out_of_order",
+        firstOutOfOrder: positions[i].section,
+        message: `Briefing sections out of order: "## ${positions[i].section}" appears before "## ${positions[i - 1].section}". Canonical order: ${BRIEFING_SECTIONS.map((s) => `## ${s}`).join(" → ")}.`,
+      };
+    }
+  }
+
+  return { ok: true };
+}
+
+/**
+ * A briefing is stale when it hasn't been updated in BRIEFING_STALE_DAYS.
+ * Accepts anything Date can consume (Date, ISO string, timestamp) for
+ * convenience from the client and the API.
+ */
+export function isBriefingStale(updatedAt: Date | string | number, now: Date = new Date()): boolean {
+  const updated = new Date(updatedAt);
+  const ageMs = now.getTime() - updated.getTime();
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+  return ageDays > BRIEFING_STALE_DAYS;
+}
+
+/**
+ * Integer days since the briefing was last updated. Floors to the full day.
+ */
+export function briefingAgeDays(updatedAt: Date | string | number, now: Date = new Date()): number {
+  const updated = new Date(updatedAt);
+  const ageMs = now.getTime() - updated.getTime();
+  return Math.floor(ageMs / (1000 * 60 * 60 * 24));
+}

--- a/app/shared/schema.ts
+++ b/app/shared/schema.ts
@@ -55,6 +55,7 @@ export const contacts = pgTable("contacts", {
   email: text("email"),
   phone: text("phone"),
   website: text("website"),
+  linkedinUrl: text("linkedin_url"),
   location: text("location"),
   background: text("background"),
   status: text("status").notNull().default("ACTIVE"), // ACTIVE | HOLD


### PR DESCRIPTION
## Summary
- **`prepare_briefing(contactId)`** — new MCP tool. Returns a prep pack (contact + interactions + followups + journal + `previousBriefing` with `ageDays`/`stale` + template + research protocol). Agents call this first.
- **Enforced 8-section format** — `## TL;DR → ## About them → ## About the company → ## Shared ground → ## Our history → ## What to discuss → ## Offers / asks → ## Watch-outs`. Validated by both `save_briefing` (MCP) and `PUT /api/briefings/:id` (REST).
- **7-day staleness TTL** — Briefing text link hides on contact cards after 7 days. Briefing page renders content with a stale banner so the user can refresh.
- **New `contacts.linkedin_url`** — optional field, exposed through `create_contact` / `update_contact` / `prepare_briefing`. Boot-migration adds the column.
- **`get_crm_guide` → Briefings** rewritten from a 2-liner to the full workflow.
- **Shared contract in `app/shared/briefing.ts`** — constants, template, validator, staleness helper.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Boot-migration adds `contacts.linkedin_url` idempotently (`[boot-migration] add_contacts_linkedin_url: ok`)
- [x] REST `PUT /api/briefings/:id` rejects missing-sections (specific list) and out-of-order (first offender named)
- [x] REST accepts valid 8-section content
- [x] MCP `prepare_briefing` returns full prep pack including `previousBriefing.stale` and `previousBriefing.ageDays` when a prior briefing exists
- [x] MCP `save_briefing` rejects malformed content with actionable error
- [x] Stale briefing (8d old) hides the `Briefing` text link on the contact card
- [x] Briefing page shows yellow stale banner + still renders content + edit works
- [x] "Start from template" button prefills the 8-section skeleton on a new briefing
- [x] Full E2E run manifest: `e2e-screenshots/run.json`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)