### PR TITLE
Fix: "days until" off-by-one in upcoming list + followup chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-04-23
+
+### Fix: "days until" off-by-one for followups due tomorrow
+The Upcoming list and contact-card follow-up chips used `differenceInDays` from date-fns, which measures 24-hour periods rather than calendar-day boundaries. With due dates stored at noon UTC and "now" at 8 AM PT, tomorrow's item was only ~21 hours away and rounded down to `0d` — items due tomorrow displayed as "today-ish" when they should have read `1d`. Switched both spots to `differenceInCalendarDays`, which counts midnight crossings independent of the hour-of-day. Items due 4/24 now correctly show `1d` on 4/23.
+
 ## 2026-04-20
 
 ### Briefing upgrade — research protocol, enforced 8-section format, staleness

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { isPast, isToday, differenceInDays } from "date-fns";
+import { isPast, isToday, differenceInCalendarDays } from "date-fns";
 import { Square, AlertTriangle, Trash2, Clock } from "lucide-react";
 import type { ContactWithRelations } from "@shared/schema";
 import type { SearchSnippet } from "@/hooks/use-contact-search";
@@ -551,7 +551,8 @@ export function ContactBlock({
               const due = new Date(fu.dueDate);
               const isOverdue = isPast(due) && !isToday(due);
               const isTodayDue = isToday(due);
-              const daysUntil = differenceInDays(due, new Date());
+              // Calendar-day difference — see note in crm-page.tsx.
+              const daysUntil = differenceInCalendarDays(due, new Date());
               const isEditingFu = editingFollowupId === fu.id;
               const isCompleting = completingFollowupId === fu.id;
 

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 import { KanbanBoard } from "@/components/kanban/kanban-board";
 import { Link } from "wouter";
-import { format, isPast, isToday, differenceInDays } from "date-fns";
+import { format, isPast, isToday, differenceInCalendarDays } from "date-fns";
 import type { Followup, ActivityLogEntry, Briefing } from "@shared/schema";
 import { fmtDate } from "@/lib/utils";
 import { useConfig, useColors } from "@/App";
@@ -491,7 +491,10 @@ export default function CrmPage() {
                   const due = new Date(fu.dueDate);
                   const isOverdue = isPast(due) && !isToday(due);
                   const isTodayDue = isToday(due);
-                  const daysUntil = differenceInDays(due, new Date());
+                  // Calendar-day difference — counts midnight crossings, so an item due tomorrow
+                  // reads as "1d" regardless of what hour it is today. differenceInDays measures
+                  // 24h periods, which is wrong for human-facing "days until".
+                  const daysUntil = differenceInCalendarDays(due, new Date());
                   const dateColor = isOverdue ? C.red : isTodayDue ? C.stale : C.accentDark;
                   const isCompleting = completingUpcomingId === fu.id;
 


### PR DESCRIPTION
## Summary
Items due tomorrow were rendering as `0d` instead of `1d`. Root cause: `differenceInDays` from date-fns measures 24-hour periods — with followup `due_date`s stored at noon UTC and "now" at 8am PT (15:06 UTC), tomorrow-at-noon is only ~21 hours away, floored to 0.

Switched both the Upcoming list (`crm-page.tsx`) and the contact-card followup chips (`contact-block.tsx`) to `differenceInCalendarDays`, which counts midnight crossings regardless of the hour-of-day.

## Test plan
- [x] Lint + build clean
- [x] Verified on local dev at 2026-04-23 morning PT: 4/24 reads `1d`, 4/25 reads `2d`, 4/26 reads `3d`, today still reads `TODAY`, overdue still reads `OVERDUE`
- [x] E2E manifest: `e2e-screenshots/run.json`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)