### PR TITLE
Fix: followup date edits silently revert on Save

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "claw-crm-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "app", "run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-04-27
+
+### Fix: followup date edits silently revert on Save
+The followup edit flow's Save button used `onMouseDown` + `e.preventDefault()` — pattern copy-pasted from the *interaction* edit flow, where it correctly prevents the input's `onBlur` from firing `handleInteractionSave` first. The followup inputs have no `onBlur`, so the `preventDefault` was unnecessary and actively broke the native `<input type="date">` picker: focus stayed on the input, the picker's value didn't always commit to React state in time, and the save handler closed over a stale `editingFollowupDate`. New date got dropped, old date persisted.
+
+Two fixes:
+- Switched the Save and Trash buttons from `onMouseDown` + `preventDefault` to plain `onClick`. The focus-trap pattern wasn't needed here.
+- Added a `ref` on the date input and read its live DOM value at save time, falling back to React state. This bulletproofs against Safari's `<input type="date">` quirk where `onChange` only fires on blur — the live ref always has the committed value regardless of React batching.
+
+Verified by manually setting the DOM input value without dispatching events (mimicking Safari's stale-state scenario) and clicking Save — date persisted correctly.
+
 ## 2026-04-23
 
 ### Fix: "days until" off-by-one for followups due tomorrow

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -254,8 +254,7 @@ export function ContactBlock({
     // Prefer the live DOM value over React state — `<input type="date">` on
     // Safari only fires onChange on blur, so state can lag behind the picker.
     const liveDate = followupDateRef.current?.value || editingFollowupDate;
-    if (liveDate && liveDate !== origDate)
-      updates.dueDate = new Date(liveDate + "T12:00:00").toISOString();
+    if (liveDate && liveDate !== origDate) updates.dueDate = new Date(liveDate + "T12:00:00").toISOString();
     if (Object.keys(updates).length > 0) {
       onUpdateFollowup(id, updates);
       showFlash("Updated");

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { isPast, isToday, differenceInCalendarDays } from "date-fns";
 import { Square, AlertTriangle, Trash2, Clock } from "lucide-react";
 import type { ContactWithRelations } from "@shared/schema";
@@ -132,6 +132,10 @@ export function ContactBlock({
   const [editingFollowupId, setEditingFollowupId] = useState<number | null>(null);
   const [editingFollowupText, setEditingFollowupText] = useState("");
   const [editingFollowupDate, setEditingFollowupDate] = useState("");
+  // Live reference to the date <input> so save can read the committed value
+  // directly. Bypasses any React batching / browser quirk where onChange
+  // doesn't fire until blur (Safari's <input type="date"> behavior).
+  const followupDateRef = useRef<HTMLInputElement>(null);
   const [completingFollowupId, setCompletingFollowupId] = useState<number | null>(null);
   const [completingFollowupText, setCompletingFollowupText] = useState("");
 
@@ -247,8 +251,11 @@ export function ContactBlock({
   const handleFollowupSave = (id: number, origDate: string) => {
     const updates: { content?: string; dueDate?: string } = {};
     if (editingFollowupText.trim()) updates.content = editingFollowupText;
-    if (editingFollowupDate && editingFollowupDate !== origDate)
-      updates.dueDate = new Date(editingFollowupDate + "T12:00:00").toISOString();
+    // Prefer the live DOM value over React state — `<input type="date">` on
+    // Safari only fires onChange on blur, so state can lag behind the picker.
+    const liveDate = followupDateRef.current?.value || editingFollowupDate;
+    if (liveDate && liveDate !== origDate)
+      updates.dueDate = new Date(liveDate + "T12:00:00").toISOString();
     if (Object.keys(updates).length > 0) {
       onUpdateFollowup(id, updates);
       showFlash("Updated");
@@ -623,6 +630,7 @@ export function ContactBlock({
                 return (
                   <div key={fu.id} className="flex items-center gap-1.5 text-xs">
                     <input
+                      ref={followupDateRef}
                       type="date"
                       value={editingFollowupDate}
                       onChange={(e) => setEditingFollowupDate(e.target.value)}
@@ -646,18 +654,19 @@ export function ContactBlock({
                       style={{ border: `1px solid ${C.border}`, color: C.text }}
                     />
                     <button
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        handleFollowupSave(fu.id, fmtDateInput(due));
-                      }}
+                      // onClick (not onMouseDown+preventDefault): the date inputs here
+                      // have no onBlur handler, so the focus-trap pattern used in the
+                      // interaction edit flow is unnecessary — and it actively breaks
+                      // the native date picker, which can leave its value uncommitted
+                      // when the user hits Save without first clicking elsewhere.
+                      onClick={() => handleFollowupSave(fu.id, fmtDateInput(due))}
                       className="text-[10px] font-medium"
                       style={{ color: C.accentDark }}
                     >
                       Save
                     </button>
                     <button
-                      onMouseDown={(e) => {
-                        e.preventDefault();
+                      onClick={() => {
                         onDeleteFollowup(fu.id);
                         setEditingFollowupId(null);
                         showFlash("Deleted");


### PR DESCRIPTION
## Summary
The followup edit flow's Save button used `onMouseDown` + `e.preventDefault()` — copy-pasted from the *interaction* edit flow where it's needed to block the input's `onBlur` from firing `handleInteractionSave` first. The followup inputs have no `onBlur`, so the `preventDefault` was unnecessary and actively broke the native `<input type="date">` picker: focus stayed trapped on the input, the picker's value didn't always commit to React state in time, and the save handler closed over a stale `editingFollowupDate`. The new date was dropped silently.

**Two fixes:**
- Save + Trash buttons → plain `onClick`. No focus-trap needed here.
- New `ref` on the date input. `handleFollowupSave` reads the live DOM value first, falls back to React state. Bulletproofs against Safari's `<input type="date">` quirk where `onChange` only fires on blur.

Also commits `.claude/launch.json` (the Claude Preview dev-server config added earlier this session).

## Test plan
- [x] Lint + build clean
- [x] **Repro of the actual bug:** set the DOM input value via JS *without* dispatching any events (mimics Safari's "value committed but React onChange hasn't fired" scenario), clicked Save, verified the new date persisted in Postgres. Pre-fix this would have saved the OLD value.
- [x] Standard happy-path: type new date → Save → DB confirms new value
- [x] E2E manifest: `e2e-screenshots/run.json`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)