### PR TITLE
Seed: idempotent wipe-then-insert; populate journal, briefings, linkedin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-05-04
+
+### Seed: idempotent wipe-then-insert; populates journal, briefings, linkedin URLs
+The seed accumulated duplicates on each re-run (we'd end up with three "Sarah Chen" rows). Now TRUNCATEs every table CASCADE before inserting, so re-running gives a clean state every time. Adds a safety guardrail: refuses to run against a non-local DB unless `CLAW_SEED_FORCE=1` is set, prints the target host, and pauses 3 seconds for the operator to abort.
+
+Also catches the seed up to features that have shipped since:
+- **Sarah Chen:** rich relationship journal (Key People + Wins + 3 Entries with absolute dates) + a fresh 8-section briefing dated today.
+- **Marcus Webb:** smaller journal + a 10-day-old briefing that demonstrates the staleness banner + hidden-on-card behavior.
+- **Elena Vasquez & James Thornton:** medium journals.
+- **Rachel Foster:** initialised journal skeleton.
+- **All five active prospects:** populated `linkedinUrl` so briefing-research flows have something to follow.
+
+New `dIso(daysFromToday)` helper produces inline `YYYY-MM-DD` strings for the journal/briefing prose so dated content stays anchored against today regardless of when the seed runs.
+
 ## 2026-04-29
 
 ### Upcoming list: 2-line layout so task content is actually readable on mobile

--- a/app/server/seed.ts
+++ b/app/server/seed.ts
@@ -1,13 +1,80 @@
 /* eslint-disable no-console */
 import "dotenv/config";
+import { sql } from "drizzle-orm";
 import { db } from "./db";
-import { companies, contacts, interactions, followups, rules } from "@shared/schema";
+import { companies, contacts, interactions, followups, rules, briefings, users } from "@shared/schema";
 import { hashPin } from "./auth";
-import { users } from "@shared/schema";
 import { randomBytes } from "crypto";
 import { toNoonUTC } from "@shared/dates";
+import { JOURNAL_SKELETON } from "@shared/journal";
+
+/**
+ * SAFETY GUARDRAIL — prevent accidentally seeding (and wiping!) a real DB.
+ *
+ * The seed TRUNCATEs every table CASCADE before inserting. That's what makes it
+ * idempotent — but it's also a foot-gun if pointed at production. So:
+ *  - Local hosts (localhost / 127.0.0.1 / containing "local") run free.
+ *  - Anything else requires `CLAW_SEED_FORCE=1` to be set.
+ * The operator confirms the target host out loud before forcing.
+ */
+function assertSafeToWipe(): void {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error("DATABASE_URL is not set.");
+    process.exit(1);
+  }
+  let host = "(unparseable)";
+  try {
+    host = new URL(url).host;
+  } catch {
+    // ignore — we'll still print and gate
+  }
+  const isLocal = /localhost|127\.0\.0\.1|host\.docker\.internal|^local|\.local(:|$)/.test(host);
+  console.log(`Target DB host: ${host}`);
+  if (isLocal) return;
+  if (process.env.CLAW_SEED_FORCE !== "1") {
+    console.error(
+      `\nRefusing to wipe a non-local DB host (${host}).\n` +
+        `If this is intentional, re-run with CLAW_SEED_FORCE=1.\n` +
+        `This script TRUNCATEs every table — do not point it at production.`,
+    );
+    process.exit(1);
+  }
+  console.warn(`\n⚠️  CLAW_SEED_FORCE=1 set. Wiping ${host} in 3 seconds. Ctrl+C to abort.`);
+}
+
+/**
+ * Wipe every app table CASCADE so the seed is idempotent. Lists tables
+ * explicitly (not `pg_class`) so a typo never reaches a table we don't expect.
+ */
+async function wipeAllTables(): Promise<void> {
+  await db.execute(sql`
+    TRUNCATE
+      contacts,
+      companies,
+      interactions,
+      followups,
+      briefings,
+      rules,
+      rule_violations,
+      contact_journal_revisions,
+      activity_log,
+      users,
+      session
+    RESTART IDENTITY CASCADE;
+  `);
+}
 
 async function seed() {
+  assertSafeToWipe();
+  // 3-second pause only when forcing a non-local wipe — gives operator time to abort.
+  if (process.env.CLAW_SEED_FORCE === "1") {
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+
+  console.log("Wiping existing data...");
+  await wipeAllTables();
+
   console.log("Seeding database with demo data...");
 
   // Create user
@@ -17,8 +84,11 @@ async function seed() {
   await db.insert(users).values({ pin, apiKey, mcpToken, orgName: "Claw CRM" }).returning();
   console.log(`Created user — PIN: 1234, API key: ${apiKey}, MCP token: ${mcpToken}`);
 
-  /** Days from today → noon UTC. Negative = past, positive = future. */
+  /** Days from today → noon UTC Date. Negative = past, positive = future. */
   const d = (daysFromToday: number) => toNoonUTC(new Date(Date.now() + daysFromToday * 86_400_000));
+
+  /** Days from today → "YYYY-MM-DD" string for inline use in journal/briefing prose. */
+  const dIso = (daysFromToday: number) => d(daysFromToday).toISOString().slice(0, 10);
 
   // Companies
   const companyData = [
@@ -39,6 +109,30 @@ async function seed() {
   }
 
   // --- Sarah Chen — Meridian Capital (LIVE) ---
+  const sarahJournal = `# Sarah Chen
+
+## Key People
+- **Sarah Chen** (Managing Partner) — primary sponsor, biweekly cadence on Tuesdays. Decisive, pattern-matches fast.
+- **Lisa Bouyer** (VP Enterprise Planning) — operational counterpart for portfolio rollouts. Detail-oriented; runs the actual programs.
+
+## Wins / Case Study Material
+- ${dIso(-61)}: Sarah signed 3-month engagement covering 4 portfolio companies — first paid engagement of the year.
+- ${dIso(-28)}: Two of the four portfolio companies (Atlas + one other) showing measurable AI adoption gains. Quotable: *"This is what enablement looks like when it actually lands."*
+
+## Entries
+
+### ${dIso(-61)}: Engagement signed
+Pre-call she said the proposal "felt expensive but right." Signed 9 days after we sent it. Lisa joined for the kickoff to align on which portfolio companies were ready first. Read: she's investing in *us*, not just the project.
+
+### ${dIso(-28)}: Mid-engagement check-in
+Atlas + one other showing strong adoption. Sarah floated the idea of expanding to the other two portfolio companies in Q3. Did not commit yet.
+
+### ${dIso(-7)}: Partner motion signal
+Sarah said "I want to think bigger than a deck." Read: she's signaling she wants Magnetic to function as a partner, not a vendor. Worth leading with the BD stance in the next prep.
+
+> *Verbatim from her email on ${dIso(-7)}:*
+> *"Two of our portfolio companies are asking for AI advisory directly. Can we expand the scope?"*
+`;
   const [sarah] = await db
     .insert(contacts)
     .values({
@@ -48,6 +142,7 @@ async function seed() {
       email: "sarah@meridiancap.com",
       phone: "415.555.0101",
       website: "meridiancap.com",
+      linkedinUrl: "https://www.linkedin.com/in/sarahchen-meridian",
       location: "SF",
       background: "Growth-stage VC. Strong AI thesis. Previously at Sequoia.",
       status: "ACTIVE",
@@ -56,6 +151,7 @@ async function seed() {
       sortOrder: 0,
       source: "Direct (met at AI Summit 2025)",
       cadence: "Biweekly (Tuesdays)",
+      relationshipJournal: sarahJournal,
     })
     .returning();
   await db.insert(interactions).values([
@@ -83,6 +179,12 @@ async function seed() {
       content: "Monthly check-in. Two companies showing strong AI adoption progress.",
       type: "meeting",
     },
+    {
+      contactId: sarah.id,
+      date: d(-7),
+      content: "Sarah emailed: two portfolio companies asking for AI advisory directly. Floated expansion.",
+      type: "email",
+    },
   ]);
   await db.insert(followups).values({
     contactId: sarah.id,
@@ -91,8 +193,61 @@ async function seed() {
     type: "task",
     completed: false,
   });
+  // Fresh briefing (today) — demonstrates the canonical 8-section format.
+  await db.insert(briefings).values({
+    contactId: sarah.id,
+    content: `# Sarah Chen — Meridian Capital
+
+## TL;DR
+Sarah is signaling a shift from vendor to *partner* relationship. Two of her portfolio companies are asking for AI advisory expansion. Use this meeting to anchor the partner framing and scope the expansion.
+
+## About them
+- **Role:** Managing Partner at Meridian Capital, leads the AI thesis.
+- **Background:** Previously at Sequoia. Investing in AI tooling since 2021.
+- **Recent activity:** Spoke at AI Summit 2025; published a thesis post on agent ops in March.
+
+## About the company
+Growth-stage VC, $2B AUM. Strong AI thesis, ~30 portfolio companies. Recent fund close in 2026-Q1 reportedly oversubscribed.
+
+## Shared ground
+- Stanford GSB overlap (different years).
+- Mutual: David Kim (early Meridian advisor, also referred Northbridge).
+- Both have written about AI ops; her thesis aligns with Magnetic's positioning.
+
+## Our history
+- Stage: **LIVE** since ${dIso(-61)}.
+- Initial meeting at AI Summit 2025; proposal sent ${dIso(-70)}; signed 9 days later.
+- Open: Q2 portfolio review deck due ${dIso(2)}.
+
+## What to discuss
+1. The two new portfolio companies — qualify need, scope, timing.
+2. Pricing model for partner-tier engagement (no specifics — see Confidentiality).
+3. Cadence: keep biweekly Tuesdays or shift to monthly?
+4. Case-study material — would she let us write one on the existing engagement?
+
+## Offers / asks
+- **Could offer:** intro to the evals framework that landed well at Atlas.
+- **Could ask:** a warm intro to one of the two AI-curious portfolio CEOs.
+
+## Watch-outs
+Don't lead with the deck refresh — she explicitly said "think bigger than a deck." Avoid pricing specifics in writing — keep dollars verbal.
+`,
+  });
 
   // --- Marcus Webb — Atlas Robotics (PROPOSAL) ---
+  const marcusJournal = `# Marcus Webb
+
+## Key People
+- **Marcus Webb** (CTO) — primary contact, the technical decision-maker. Hands-on, will eval everything himself before approving.
+
+## Wins / Case Study Material
+<!-- Nothing yet — engagement still in proposal. -->
+
+## Entries
+
+### ${dIso(-31)}: Discovery call
+45-minute call. Team of 30 engineers, mostly Python. The real pain is QA pipeline cycle time — they want LLMs in the test gen + triage flow, not customer-facing AI. Different problem than Sarah's portfolio.
+`;
   const [marcus] = await db
     .insert(contacts)
     .values({
@@ -101,6 +256,7 @@ async function seed() {
       title: "CTO",
       email: "marcus@atlasrobotics.io",
       website: "atlasrobotics.io",
+      linkedinUrl: "https://www.linkedin.com/in/marcuswebb-atlas",
       location: "Austin",
       background: "Series B warehouse automation. 200 employees. Engineering team needs AI upskilling.",
       status: "ACTIVE",
@@ -108,6 +264,7 @@ async function seed() {
       companyId: co["Atlas Robotics"],
       sortOrder: 1,
       source: "Sarah Chen (Meridian portfolio)",
+      relationshipJournal: marcusJournal,
     })
     .returning();
   await db.insert(interactions).values([
@@ -132,8 +289,62 @@ async function seed() {
     type: "task",
     completed: false,
   });
+  // Stale briefing (10 days old) — demonstrates the staleness banner + hidden-on-card behavior.
+  await db.insert(briefings).values({
+    contactId: marcus.id,
+    content: `# Marcus Webb — Atlas Robotics
+
+## TL;DR
+Proposal is out, awaiting Marcus's eval. Last we heard, he was going to review over the weekend. Use this touch to qualify next steps without pushing.
+
+## About them
+- **Role:** CTO at Atlas Robotics, 200-person Series B warehouse automation company.
+- **Background:** Stanford CS. Prior stints at AWS and a robotics startup pre-acquisition.
+- **Recent activity:** Posted about LLM evals two weeks ago — strong opinions on hallucination tolerance.
+
+## About the company
+Series B, post-Series-B funding round closed late 2025. ~200 engineers and ops, fast-growing. Warehouse automation customers across logistics + retail.
+
+## Shared ground
+- Both at Stanford; different years.
+- Sarah Chen referred — Atlas is in the Meridian portfolio.
+
+## Our history
+- Stage: **PROPOSAL** since ${dIso(-23)}.
+- Discovery call ${dIso(-31)}; proposal sent 8 days later.
+- Open: follow-up on proposal due ${dIso(5)}.
+
+## What to discuss
+1. Status on his eval of the proposal.
+2. Any blockers from finance or his eng leadership team.
+3. Their QA pipeline pain — does the proposal scope match what he needs?
+
+## Offers / asks
+- **Could offer:** sample evals deliverable from a past client (anonymized).
+- **Could ask:** what would unblock signing this week vs. next month?
+
+## Watch-outs
+He's hands-on technical. Don't oversell — he'll see through it. Stick to specifics.
+`,
+    // Stale: 10 days old, exceeds the 7-day TTL.
+    updatedAt: new Date(Date.now() - 10 * 86_400_000),
+  });
 
   // --- Elena Vasquez — Solara Energy (MEETING) ---
+  const elenaJournal = `# Elena Vasquez
+
+## Key People
+- **Elena Vasquez** (VP Operations) — entry point, runs the day-to-day across 500+ installations.
+- **Mike Torres** (CTO) — technical decision-maker. Elena introduced him; he hasn't engaged directly yet.
+
+## Wins / Case Study Material
+<!-- Too early — still qualifying. -->
+
+## Entries
+
+### ${dIso(-33)}: First call
+30 minutes. Elena described maintenance challenges across 500 sites. AI for predictive panel failures was her idea, not ours. She wants to bring Mike in for the technical scope. Read: warm but needs Mike's blessing before anything moves.
+`;
   const [elena] = await db
     .insert(contacts)
     .values({
@@ -142,6 +353,7 @@ async function seed() {
       title: "VP Operations",
       email: "elena.v@solaraenergy.com",
       phone: "310.555.0202",
+      linkedinUrl: "https://www.linkedin.com/in/elena-vasquez-solara",
       location: "LA",
       background: "Commercial solar + storage. 500+ installations. Wants AI for predictive maintenance.",
       status: "ACTIVE",
@@ -150,6 +362,7 @@ async function seed() {
       sortOrder: 2,
       source: "LinkedIn (cold outreach)",
       additionalContacts: "Mike Torres (CTO): mike@solaraenergy.com",
+      relationshipJournal: elenaJournal,
     })
     .returning();
   await db.insert(interactions).values([
@@ -193,6 +406,22 @@ async function seed() {
   ]);
 
   // --- James Thornton — Northbridge Holdings (NEGOTIATION) ---
+  const jamesJournal = `# James Thornton
+
+## Key People
+- **James Thornton** (Principal) — deal lead. Slow but methodical. Drives the investment committee process.
+
+## Wins / Case Study Material
+- ${dIso(-38)}: Proposal accepted in principle. Pending committee approval. *"Proposal looks good. Need to run it by our investment committee."*
+
+## Entries
+
+### ${dIso(-46)}: Zoom scoping call
+James outlined the 12-company portfolio. Wants a phased approach — 3 companies for Phase 1, then expand based on results. Not in a rush; family office decision pace.
+
+### ${dIso(-25)}: Committee in the loop
+Quoted him: *"Proposal looks good. Need to run it by our investment committee."* Committee meets monthly. Realistic close: 2–3 weeks out.
+`;
   const [james] = await db
     .insert(contacts)
     .values({
@@ -201,6 +430,7 @@ async function seed() {
       title: "Principal",
       email: "jthornton@northbridge.co",
       phone: "212.555.0303",
+      linkedinUrl: "https://www.linkedin.com/in/jthornton-northbridge",
       location: "NYC",
       background: "Family office. Exploring AI across portfolio of 12 companies. Big budget, slow decision-making.",
       status: "ACTIVE",
@@ -208,6 +438,7 @@ async function seed() {
       companyId: co["Northbridge Holdings"],
       sortOrder: 3,
       source: "Referral (David Kim)",
+      relationshipJournal: jamesJournal,
     })
     .returning();
   await db.insert(interactions).values([
@@ -258,6 +489,7 @@ async function seed() {
       lastName: "Patel",
       title: "CEO & Co-founder",
       email: "priya@quantumlabs.ai",
+      linkedinUrl: "https://www.linkedin.com/in/priyapatel-quantumlabs",
       location: "Boston",
       background: "AI-native drug discovery. Series A. Small team, moving fast.",
       status: "ACTIVE",
@@ -321,6 +553,7 @@ async function seed() {
       lastName: "Foster",
       title: "CEO",
       email: "rachel@horizonmedia.co",
+      linkedinUrl: "https://www.linkedin.com/in/rachelfoster-horizon",
       location: "NYC",
       background: "Digital media studio. Old colleague. Not a prospect — just a good relationship to maintain.",
       status: "ACTIVE",
@@ -328,6 +561,10 @@ async function seed() {
       companyId: co["Horizon Media"],
       sortOrder: 6,
       source: "Former colleague",
+      // Skeleton journal — appears as "Start journal" CTA on the demo if the user
+      // hasn't appended yet. (Server skeleton init also exists; this is just so
+      // the demo isn't entirely empty.)
+      relationshipJournal: JOURNAL_SKELETON("Rachel Foster"),
     })
     .returning();
   await db.insert(interactions).values([
@@ -424,7 +661,9 @@ async function seed() {
     },
   ]);
 
-  console.log("Seed complete! 8 demo contacts, 8 companies, 3 rules.");
+  console.log(
+    "Seed complete! 8 demo contacts (4 with journals, 2 with briefings — Sarah fresh, Marcus stale), 8 companies, 3 rules.",
+  );
   console.log(`\nMCP URL: /mcp/${mcpToken}`);
   process.exit(0);
 }

--- a/app/server/seed.ts
+++ b/app/server/seed.ts
@@ -46,23 +46,40 @@ function assertSafeToWipe(): void {
 /**
  * Wipe every app table CASCADE so the seed is idempotent. Lists tables
  * explicitly (not `pg_class`) so a typo never reaches a table we don't expect.
+ * Skips tables that don't exist yet — `session` is created lazily by
+ * connect-pg-simple at runtime, so it's missing on a freshly-pushed schema
+ * (notably CI's test DB).
  */
 async function wipeAllTables(): Promise<void> {
-  await db.execute(sql`
-    TRUNCATE
-      contacts,
-      companies,
-      interactions,
-      followups,
-      briefings,
-      rules,
-      rule_violations,
-      contact_journal_revisions,
-      activity_log,
-      users,
-      session
-    RESTART IDENTITY CASCADE;
-  `);
+  const candidates = [
+    "contacts",
+    "companies",
+    "interactions",
+    "followups",
+    "briefings",
+    "rules",
+    "rule_violations",
+    "contact_journal_revisions",
+    "activity_log",
+    "users",
+    "session",
+  ];
+  // Inline the candidate list — names are literal and trusted, no SQL injection
+  // surface. Avoids drizzle's array-binding quirks across drivers.
+  const inList = candidates.map((t) => `'${t}'`).join(", ");
+  const result = await db.execute<{ table_name: string }>(
+    sql.raw(
+      `SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name IN (${inList})`,
+    ),
+  );
+  // drizzle's `db.execute` returns either { rows: [...] } or [...] depending on the driver.
+  const rows =
+    (result as unknown as { rows?: { table_name: string }[] }).rows ?? (result as unknown as { table_name: string }[]);
+  const existing = rows.map((r) => r.table_name);
+  if (existing.length === 0) return;
+  // Names are drawn from the literal allow-list above, so quoting + raw is safe.
+  const truncateList = existing.map((t) => `"${t}"`).join(", ");
+  await db.execute(sql.raw(`TRUNCATE ${truncateList} RESTART IDENTITY CASCADE;`));
 }
 
 async function seed() {


### PR DESCRIPTION
## Summary
The seed used to accumulate duplicates on each re-run — running it twice gave us three Sarah Chens. Now TRUNCATEs every table CASCADE before inserting, so re-running gives a clean state every time.

**Safety guardrail:** refuses to run against a non-local DB unless `CLAW_SEED_FORCE=1` is set. Prints the target host. With the flag set, pauses 3 seconds for the operator to abort.

Catches the seed up to features that have shipped since:
- **Sarah Chen:** rich relationship journal (Key People + Wins + 3 dated Entries with verbatim blockquote) + a fresh 8-section briefing dated today
- **Marcus Webb:** smaller journal + a 10-day-old briefing that demonstrates the staleness banner + hidden-on-card behavior
- **Elena Vasquez & James Thornton:** medium journals
- **Rachel Foster:** initialised journal skeleton
- **All five active prospects:** populated `linkedinUrl` so briefing-research flows have something to follow

New `dIso(daysFromToday)` helper produces inline `YYYY-MM-DD` strings so dated journal/briefing prose stays anchored against today regardless of when the seed runs.

Used to re-seed the demo at https://demo-crm.up.railway.app/ (Railway project `1e6352a4-9576-4bc2-b075-43a31994e09c` only — never touched the prod project).

## Test plan
- [x] Lint + build clean
- [x] Local seed run wipes + reinserts cleanly
- [x] Sarah's journal renders Key People / Wins / dated Entries with the new compact markdown
- [x] Marcus's stale briefing surfaces the yellow banner and hides the Briefing link on his contact card
- [x] Guardrail blocks non-local hosts without `CLAW_SEED_FORCE=1`; runs cleanly with it
- [x] Seeded demo Railway DB (`maglev.proxy.rlwy.net:24039`) and verified live at https://demo-crm.up.railway.app/
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)