### PR TITLE
Journal hygiene: double-dated headings, briefing/meeting linkage, Engagement History

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2026-05-11
+
+### Journal hygiene: triple-shot — double-dated headings, briefing/meeting linkage, Engagement History
+Three related issues surfaced during a CRM audit, all in the journal/briefing subsystem. Shipping together because they share an audience and a fix shape.
+
+**Issue 1 — Double-dated entry headings.** `append_journal` / `batch_append_journal` prepended `### YYYY-MM-DD:` while LLM callers regularly included the date as the first token of `title`, producing `### 2026-05-10: 2026-05-10: Foo`. New `stripDatePrefix(title)` helper in `shared/journal.ts` silently strips a leading absolute-date pattern from the title (YYYY-MM-DD, M/D/YYYY, "May 10, 2026", year-only "August 2025", "Q3 2025", "spring 2026") before composing the heading. Purely additive — no valid title started with one of those patterns. Existing entries untouched; the agent-side `crm-dreaming` skill handles historical cleanup via `edit_journal`.
+
+**Issue 2 — Briefings linked to a specific meeting.** Schema: new optional `briefings.meeting_id` (FK to `followups.id`, ON DELETE SET NULL). Boot migration adds the column idempotently. Tools:
+- `prepare_briefing` returns `candidateMeetingId` (next pending meeting on the contact) + `previousBriefing.linkedMeeting` / `previousBriefing.staleReason`. Agent passes `candidateMeetingId` through to `save_briefing.meetingId`.
+- `save_briefing` accepts and persists optional `meetingId`.
+- `get_briefing` returns `meetingId` + `linkedMeeting` (date/content/location) + `staleReason` (`age` / `meeting_completed` / `wrong_meeting` / null).
+- New `getBriefingStaleness(briefing, meetings)` helper in `shared/briefing.ts` — single source of truth used by client + server. A briefing is stale when age >7d, OR the linked meeting has completed, OR a newer meeting is now next pending on the contact.
+- Briefings without `meetingId` fall back to age-only — backward compatible.
+- Briefing page surfaces the reason in the stale banner ("the meeting this was for has already happened" / "a newer meeting is now next") and shows the linked meeting context line above the briefing.
+
+**Issue 3 — `## Engagement History` canonical section.** New canonical section between Wins and Entries. Edited in place via `edit_journal`, no `### YYYY-MM-DD:` requirement. Home for retrospective phase summaries — content authored about a *span* rather than about a single date (scope evolution, role changes, "Q1 2025 — Phase 1"). Mixing those into Entries with backdated headings distorted long-running timelines. Added to `CANONICAL_SECTIONS`, included in `JOURNAL_SKELETON`, accepted by `read_journal`'s `section` enum, documented in `get_crm_guide`. New `detectDateSpanDays(body)` helper plus a non-blocking `wide_date_span` warning on `append_journal` responses when the body references dates spanning >7 days — soft nudge that the content probably belongs in Engagement History.
+
+**Follow-up — `delete_briefing` MCP tool.** New tool so the dreaming skill can clear briefings flagged as stale-and-targeting-completed-meeting without an awkward placeholder save. Idempotent.
+
 ## 2026-05-04
 
 ### Seed: idempotent wipe-then-insert; populates journal, briefings, linkedin URLs

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -5,7 +5,7 @@ import type { ContactWithRelations } from "@shared/schema";
 import type { SearchSnippet } from "@/hooks/use-contact-search";
 import { fmtDate, fmtDateInput } from "@/lib/utils";
 import { useColors } from "@/App";
-import { isBriefingStale } from "@shared/briefing";
+import { getBriefingStaleness } from "@shared/briefing";
 
 const HOLD_COLOR = "#6c5ce7";
 
@@ -268,7 +268,17 @@ export function ContactBlock({
   const statusColor = contact.status === "HOLD" ? HOLD_COLOR : C.accent;
   // Stale briefings (>7d) stop surfacing here — they're not prep material.
   // Content is still available via the briefing page so the user can refresh.
-  const hasBriefing = Boolean(contact.briefing && !isBriefingStale(contact.briefing.updatedAt));
+  // Briefing stops surfacing here when stale — by age (>7d) OR by meeting
+  // linkage (the meeting it was scoped to has happened, or a newer meeting is
+  // now next on this contact). Raw content stays available on the briefing
+  // page so the user can review + refresh.
+  const meetingCtx = contact.followups
+    .filter((f) => f.type === "meeting")
+    .map((f) => ({ id: f.id, dueDate: f.dueDate, completed: f.completed, cancelled: !!f.cancelledAt }));
+  const briefingStaleness = contact.briefing
+    ? getBriefingStaleness({ meetingId: contact.briefing.meetingId, updatedAt: contact.briefing.updatedAt }, meetingCtx)
+    : null;
+  const hasBriefing = Boolean(contact.briefing && !briefingStaleness?.stale);
   const hasJournal = Boolean(contact.relationshipJournal);
 
   return (

--- a/app/client/src/pages/briefing-page.tsx
+++ b/app/client/src/pages/briefing-page.tsx
@@ -5,7 +5,7 @@ import { AlertTriangle, ArrowLeft } from "lucide-react";
 import { Link, useParams } from "wouter";
 import { useColors } from "@/App";
 import type { ContactWithRelations } from "@shared/schema";
-import { BRIEFING_TEMPLATE, BRIEFING_STALE_DAYS, isBriefingStale, briefingAgeDays } from "@shared/briefing";
+import { BRIEFING_TEMPLATE, BRIEFING_STALE_DAYS, getBriefingStaleness, briefingAgeDays } from "@shared/briefing";
 import { Markdown } from "@/components/markdown";
 
 export default function BriefingPage() {
@@ -61,8 +61,20 @@ export default function BriefingPage() {
 
   const contactName = contact ? `${contact.firstName} ${contact.lastName}` : "Loading...";
   const companyName = contact?.company?.name || "";
-  const stale = briefing ? isBriefingStale(briefing.updatedAt) : false;
+
+  // Meeting context for the new staleness check (age + meeting linkage).
+  const meetingCtx = (contact?.followups || [])
+    .filter((f) => f.type === "meeting")
+    .map((f) => ({ id: f.id, dueDate: f.dueDate, completed: f.completed, cancelled: !!f.cancelledAt }));
+  const staleness = briefing
+    ? getBriefingStaleness({ meetingId: briefing.meetingId, updatedAt: briefing.updatedAt }, meetingCtx)
+    : { stale: false, reason: null as null | string };
+  const stale = staleness.stale;
+  const staleReason = staleness.reason;
   const ageDays = briefing ? briefingAgeDays(briefing.updatedAt) : 0;
+  const linkedMeeting = briefing?.meetingId
+    ? (contact?.followups || []).find((f) => f.id === briefing.meetingId) || null
+    : null;
 
   // Find upcoming meetings for this contact
   const upcomingMeetings = (contact?.followups || []).filter(
@@ -114,7 +126,7 @@ export default function BriefingPage() {
           </div>
         )}
 
-        {/* Stale banner — briefing exists but hasn't been refreshed in >7 days */}
+        {/* Stale banner — briefing exists but is stale (age OR meeting linkage). */}
         {stale && !editing && (
           <div
             className="mb-3 flex items-start gap-2 rounded-lg px-3 py-2 text-xs"
@@ -122,12 +134,29 @@ export default function BriefingPage() {
           >
             <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0 mt-px" />
             <div>
-              <div className="font-semibold">Stale — last updated {ageDays} days ago.</div>
+              <div className="font-semibold">
+                {staleReason === "meeting_completed"
+                  ? "Stale — the meeting this briefing was for has already happened."
+                  : staleReason === "wrong_meeting"
+                    ? "Stale — a newer meeting is now next on this contact. This briefing was for a different conversation."
+                    : `Stale — last updated ${ageDays} days ago.`}
+              </div>
               <div>
-                Briefings older than {BRIEFING_STALE_DAYS} days stop surfacing on contact cards. Refresh with your agent
-                before the next meeting.
+                {staleReason === "age"
+                  ? `Briefings older than ${BRIEFING_STALE_DAYS} days stop surfacing on contact cards. Refresh with your agent before the next meeting.`
+                  : "Refresh with your agent before the next meeting, or delete the briefing if it's no longer useful."}
               </div>
             </div>
+          </div>
+        )}
+
+        {/* Linked meeting context — small line below the stale banner / above the briefing card. */}
+        {linkedMeeting && !editing && (
+          <div className="mb-3 text-[11px]" style={{ color: C.muted }}>
+            <span className="font-semibold uppercase tracking-wider mr-1.5">For meeting:</span>
+            {new Date(linkedMeeting.dueDate).toLocaleDateString()}
+            {linkedMeeting.time ? ` ${linkedMeeting.time}` : ""} — {linkedMeeting.content}
+            {linkedMeeting.location ? ` · ${linkedMeeting.location}` : ""}
           </div>
         )}
 

--- a/app/server/boot-migrations.ts
+++ b/app/server/boot-migrations.ts
@@ -69,6 +69,29 @@ CREATE INDEX IF NOT EXISTS contact_journal_revisions_contact_created_idx
     name: "add_contacts_linkedin_url",
     sql: `ALTER TABLE contacts ADD COLUMN IF NOT EXISTS linkedin_url TEXT;`,
   },
+  {
+    // 2026-05-04: briefings.meeting_id — optional FK to the meeting (a
+    // followup of type "meeting") this briefing was prepped for. Lets the
+    // staleness check detect when the meeting has already happened or when
+    // a newer meeting is now next on the contact. ON DELETE SET NULL so the
+    // briefing survives a meeting deletion and reverts to age-only staleness.
+    name: "add_briefings_meeting_id",
+    sql: `
+ALTER TABLE briefings ADD COLUMN IF NOT EXISTS meeting_id INTEGER;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'briefings_meeting_id_followups_id_fk'
+      AND table_name = 'briefings'
+  ) THEN
+    ALTER TABLE briefings
+      ADD CONSTRAINT briefings_meeting_id_followups_id_fk
+      FOREIGN KEY (meeting_id) REFERENCES followups(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+`,
+  },
 ];
 
 export async function runBootMigrations(): Promise<void> {

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -30,6 +30,7 @@ import {
   CANONICAL_SECTIONS,
   OPTIONAL_SECTIONS,
   ACCEPTED_DATE_FORMATS,
+  detectDateSpanDays,
   todayIso,
 } from "@shared/journal";
 import {
@@ -38,7 +39,7 @@ import {
   BRIEFING_TEMPLATE,
   BRIEFING_RESEARCH_PROTOCOL,
   validateBriefingSections,
-  isBriefingStale,
+  getBriefingStaleness,
   briefingAgeDays,
 } from "@shared/briefing";
 import { db } from "./db";
@@ -256,29 +257,32 @@ Meetings appear alongside tasks in contact cards and the Upcoming strip.
 After a meeting happens, log it as an interaction with add_interaction.
 
 ## Briefings
-A briefing is a research-backed prep document for the **next specific meeting** with one contact. One per contact (upsert). Stale after ${BRIEFING_STALE_DAYS} days — old briefings stop surfacing on contact cards until refreshed.
+A briefing is a research-backed prep document for the **next specific meeting** with one contact. One per contact (upsert). Stale when the briefing's linked meeting is completed, when a newer meeting is now next on the contact, OR after ${BRIEFING_STALE_DAYS} days — whichever comes first.
 
 **Workflow — always in this order:**
-1. Call \`prepare_briefing(contactId)\` to get a prep pack: the contact record (including \`linkedinUrl\` if set), interactions, active + recent followups, journal content, any existing briefing (labeled \`previousBriefing\` with \`ageDays\`), the canonical template, and the research protocol.
+1. Call \`prepare_briefing(contactId)\` to get a prep pack: the contact record (including \`linkedinUrl\` if set), interactions, active + recent followups, journal content, any existing briefing (labeled \`previousBriefing\` with \`ageDays\` + \`staleReason\` + \`linkedMeeting\`), a \`candidateMeetingId\` (the next pending meeting), the canonical template, and the research protocol.
 2. Do the research the protocol requires: fetch LinkedIn, web-search the person + company, cross-reference against what you know about your user, re-read the journal.
 3. Write the briefing into the 8-section template.
-4. Call \`save_briefing(contactId, content)\`. The server validates every canonical section is present and in order — missing sections are rejected with a specific error.
+4. Call \`save_briefing(contactId, content, meetingId)\`. Pass \`candidateMeetingId\` as \`meetingId\` so future staleness checks know which meeting this was for. The server validates every canonical section is present and in order — missing sections are rejected with a specific error.
 
 **Canonical 8 sections, enforced in order:** ${BRIEFING_SECTIONS.map((s) => `\`## ${s}\``).join(" → ")}.
+
+**Meeting linkage:** when \`previousBriefing.meetingId\` differs from the contact's current next pending meeting, \`staleReason: "wrong_meeting"\` — the briefing was for a different conversation. Refresh it. When the linked meeting is already completed, \`staleReason: "meeting_completed"\`. If you can't write a fresh one immediately and the existing one is misleading, use \`delete_briefing\`.
 
 If a \`previousBriefing\` exists, update it in place: preserve what's still true, change what's changed, add new signal. Do not rewrite from scratch.
 
 ## Relationship Journal
 The persistent, file-like narrative of the relationship. Freeform markdown per contact, everlasting, append-mostly. Tools: \`read_journal\`, \`peek_last_journal_entry\`, \`edit_journal\`, \`append_journal\`, \`batch_append_journal\`.
 
-**Document structure — canonical three, optional three more:**
+**Document structure — canonical four, optional three more:**
 1. \`## Key People\` — stakeholder roster with roles and current relationship state. Edit in place.
 2. \`## Wins / Case Study Material\` — durable outcomes, measurable impact, quotable moments. Case-study fodder. Edit in place.
-3. \`## Entries\` — dated narrative entries. Append-only via \`append_journal\` / \`batch_append_journal\`. Each entry: \`### YYYY-MM-DD: <title>\` followed by body.
+3. \`## Engagement History\` — retrospective phase summaries, scope evolution, role changes, compensation history. Edit in place via \`edit_journal\`. No \`### YYYY-MM-DD:\` headings required. Use this when authoring content about a span (weeks/months/years) rather than a single dated event — those entries belong here, NOT in \`## Entries\` with backdated headings.
+4. \`## Entries\` — dated narrative entries. Append-only via \`append_journal\` / \`batch_append_journal\`. Each entry: \`### YYYY-MM-DD: <title>\` followed by body.
 
 Optional sections, add only when you have real signal that doesn't fit: \`## Open Questions\`, \`## Risks\`, \`## Next Moves\`. Default answer is still Entries.
 
-Every new dated content lands in Entries. Evergreen context edits in place in Key People / Wins.
+Every single-date narrative lands in Entries. Span-based retrospectives land in Engagement History. Evergreen context edits in place in Key People / Wins.
 
 **THE DATA-PARTITION RULE (read this every time you're about to write):**
 
@@ -293,6 +297,7 @@ Every piece of info has exactly ONE home. The DATE belongs to the atom; the MEAN
 | Prep for the **next specific** conversation | **briefing** | save_briefing | bullets, replaced at next prep |
 | A stakeholder with a role | **journal → Key People** | edit_journal | edit in place |
 | A durable outcome / case-study material | **journal → Wins** | edit_journal | edit in place |
+| Retrospective phase summary, scope evolution, role/comp change | **journal → Engagement History** | edit_journal | edit in place, no \`### date:\` heading |
 | Interpretation, strategic read, "what this means", narrative context | **journal → Entries** | append_journal | long-form prose, dated |
 
 **Worked example — single call with Jeff on 2026-04-18:**
@@ -1012,7 +1017,7 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
 
   server.tool(
     "prepare_briefing",
-    `Get everything needed to write a briefing for a contact: the contact record (including linkedinUrl if set), all interactions, active + recently-completed followups, the relationship journal, any existing briefing (as \`previousBriefing\` with ageDays + stale flag), the canonical template, and the research protocol the agent MUST follow. Call this BEFORE save_briefing. ${BRIEFING_CONTRACT}`,
+    `Get everything needed to write a briefing for a contact: the contact record (including linkedinUrl if set), all interactions, active + recently-completed followups, the relationship journal, any existing briefing (as \`previousBriefing\` with ageDays + stale + staleReason + linkedMeeting), the canonical template, the research protocol, and a \`candidateMeetingId\` (the next pending meeting on the contact, if any — pass through to save_briefing.meetingId so future staleness checks know which meeting this was for). Call this BEFORE save_briefing. ${BRIEFING_CONTRACT}`,
     {
       contactId: z.number().describe("Contact ID. Get from search_contacts."),
     },
@@ -1022,17 +1027,54 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
         if (!contact) return notFoundError("Contact", contactId, "search_contacts");
 
         const now = new Date();
+        // Meeting context for the briefing's staleness + the candidate meeting id.
+        const meetings = contact.followups
+          .filter((f) => f.type === "meeting")
+          .map((f) => ({
+            id: f.id,
+            dueDate: f.dueDate,
+            completed: f.completed,
+            cancelled: !!f.cancelledAt,
+            content: f.content,
+            time: f.time,
+            location: f.location,
+          }));
+        const nextPendingMeeting = meetings
+          .filter((m) => !m.completed && !m.cancelled)
+          .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime())[0];
+
         const previousBriefing = contact.briefing
-          ? {
-              content: contact.briefing.content,
-              updatedAt: contact.briefing.updatedAt,
-              ageDays: briefingAgeDays(contact.briefing.updatedAt, now),
-              stale: isBriefingStale(contact.briefing.updatedAt, now),
-            }
+          ? (() => {
+              const stale = getBriefingStaleness(
+                { meetingId: contact.briefing?.meetingId, updatedAt: contact.briefing!.updatedAt },
+                meetings,
+                now,
+              );
+              const linked = contact.briefing!.meetingId
+                ? (meetings.find((m) => m.id === contact.briefing!.meetingId) ?? null)
+                : null;
+              return {
+                content: contact.briefing!.content,
+                updatedAt: contact.briefing!.updatedAt,
+                meetingId: contact.briefing!.meetingId,
+                ageDays: briefingAgeDays(contact.briefing!.updatedAt, now),
+                stale: stale.stale,
+                staleReason: stale.reason,
+                linkedMeeting: linked
+                  ? {
+                      id: linked.id,
+                      dueDate: linked.dueDate,
+                      content: linked.content,
+                      time: linked.time,
+                      location: linked.location,
+                      completed: linked.completed,
+                      cancelled: linked.cancelled,
+                    }
+                  : null,
+              };
+            })()
           : null;
 
-        // Separate active followups from recently-completed ones so the agent
-        // can see both "what's open" and "what just closed" without a giant list.
         const activeFollowups = contact.followups.filter((f) => !f.completed);
         const completedFollowups = contact.followups
           .filter((f) => f.completed)
@@ -1080,11 +1122,24 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
           })),
           journal: contact.relationshipJournal ?? null,
           previousBriefing,
+          // The meeting this briefing should be threaded against. Pass to
+          // save_briefing.meetingId so staleness can later detect when the
+          // briefing's meeting has passed or been replaced.
+          candidateMeetingId: nextPendingMeeting?.id ?? null,
+          candidateMeeting: nextPendingMeeting
+            ? {
+                id: nextPendingMeeting.id,
+                dueDate: nextPendingMeeting.dueDate,
+                content: nextPendingMeeting.content,
+                time: nextPendingMeeting.time,
+                location: nextPendingMeeting.location,
+              }
+            : null,
           template: BRIEFING_TEMPLATE(`${contact.firstName} ${contact.lastName}`, contact.company?.name),
           research_protocol: BRIEFING_RESEARCH_PROTOCOL,
           required_sections: BRIEFING_SECTIONS,
           instructions:
-            "Follow the research_protocol above. Then write a briefing that exactly matches the template: all 8 sections in order. Call save_briefing(contactId, content) with the result. Validation will reject the save if any canonical section is missing or out of order.",
+            "Follow the research_protocol above. Write a briefing matching the 8-section template, then call save_briefing(contactId, content, meetingId). Pass candidateMeetingId as meetingId so the briefing is scoped to this specific meeting — staleness checks rely on it. If candidateMeetingId is null (no pending meeting), omit meetingId.",
         };
 
         return { content: [{ type: "text" as const, text: JSON.stringify(prepPack, null, 2) }] };
@@ -1099,7 +1154,7 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
 
   server.tool(
     "save_briefing",
-    `Save a meeting prep briefing for a contact (upsert). Validates the 8-section canonical structure — rejects content with missing or out-of-order sections. ${BRIEFING_CONTRACT}`,
+    `Save a meeting prep briefing for a contact (upsert). Validates the 8-section canonical structure — rejects content with missing or out-of-order sections. Pass \`meetingId\` (from prepare_briefing.candidateMeetingId) to scope the briefing to a specific meeting so staleness can detect when that meeting has passed or been replaced. ${BRIEFING_CONTRACT}`,
     {
       contactId: z.number(),
       content: z
@@ -1107,8 +1162,15 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
         .describe(
           `Full briefing markdown. MUST contain all 8 canonical sections as \`## Section\` headers in order: ${BRIEFING_SECTIONS.map((s) => `## ${s}`).join(" → ")}. Produce via prepare_briefing's template.`,
         ),
+      meetingId: z
+        .number()
+        .nullable()
+        .optional()
+        .describe(
+          "Followup ID of the meeting this briefing was written for. Use prepare_briefing.candidateMeetingId. Optional — when null/omitted, staleness falls back to age-only (>7 days).",
+        ),
     },
-    async ({ contactId, content }) => {
+    async ({ contactId, content, meetingId }) => {
       try {
         const validation = validateBriefingSections(content);
         if (!validation.ok) {
@@ -1120,9 +1182,12 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
 
         const [existing] = await db.select().from(briefings).where(eq(briefings.contactId, contactId));
         if (existing) {
-          await db.update(briefings).set({ content, updatedAt: new Date() }).where(eq(briefings.contactId, contactId));
+          await db
+            .update(briefings)
+            .set({ content, meetingId: meetingId ?? null, updatedAt: new Date() })
+            .where(eq(briefings.contactId, contactId));
         } else {
-          await db.insert(briefings).values({ contactId, content });
+          await db.insert(briefings).values({ contactId, content, meetingId: meetingId ?? null });
         }
         sseManager.broadcast({ type: "briefing_updated", contactId });
         storage.logActivity("briefing.saved", `Briefing saved (${content.length} chars)`, {
@@ -1131,7 +1196,12 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
         });
         return {
           content: [
-            { type: "text" as const, text: `Briefing saved for contact ${contactId} (${content.length} chars)` },
+            {
+              type: "text" as const,
+              text:
+                `Briefing saved for contact ${contactId} (${content.length} chars)` +
+                (meetingId ? `, linked to meeting ${meetingId}.` : "."),
+            },
           ],
         };
       } catch (err: unknown) {
@@ -1140,7 +1210,7 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
             content: [
               {
                 type: "text" as const,
-                text: `Contact ${contactId} not found. Use search_contacts to find valid contacts.`,
+                text: `Contact ${contactId} or meeting ${meetingId} not found. Use search_contacts / get_upcoming_meetings to find valid ids.`,
               },
             ],
             isError: true,
@@ -1152,7 +1222,7 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
 
   server.tool(
     "get_briefing",
-    `Get the current briefing for a contact. Returns content plus ageDays and stale (true if >${BRIEFING_STALE_DAYS}d old). Stale briefings are still returned so the agent can refresh them via prepare_briefing + save_briefing. For writing a new briefing, use prepare_briefing instead — it bundles everything the agent needs.`,
+    `Get the current briefing for a contact. Returns content + ageDays + stale + staleReason (\`age\` / \`meeting_completed\` / \`wrong_meeting\` / null) + linkedMeeting (date/content/location of the meeting it was scoped to, when meetingId is set). Stale briefings are still returned so the agent can refresh them. For writing a new briefing, use prepare_briefing — it bundles everything the agent needs.`,
     {
       contactId: z.number(),
     },
@@ -1168,16 +1238,72 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
               },
             ],
           };
+        // Pull the contact's meetings to compute meeting-aware staleness.
+        const allFollowups = await db.select().from(followups).where(eq(followups.contactId, contactId));
+        const meetings = allFollowups
+          .filter((f) => f.type === "meeting")
+          .map((f) => ({
+            id: f.id,
+            dueDate: f.dueDate,
+            completed: f.completed,
+            cancelled: !!f.cancelledAt,
+            content: f.content,
+            time: f.time,
+            location: f.location,
+          }));
         const now = new Date();
+        const stale = getBriefingStaleness({ meetingId: b.meetingId, updatedAt: b.updatedAt }, meetings, now);
+        const linked = b.meetingId ? (meetings.find((m) => m.id === b.meetingId) ?? null) : null;
         const payload = {
           content: b.content,
           updatedAt: b.updatedAt,
+          meetingId: b.meetingId,
           ageDays: briefingAgeDays(b.updatedAt, now),
-          stale: isBriefingStale(b.updatedAt, now),
+          stale: stale.stale,
+          staleReason: stale.reason,
+          linkedMeeting: linked
+            ? {
+                id: linked.id,
+                dueDate: linked.dueDate,
+                content: linked.content,
+                time: linked.time,
+                location: linked.location,
+                completed: linked.completed,
+                cancelled: linked.cancelled,
+              }
+            : null,
         };
         return { content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }] };
       } catch (err: unknown) {
         return { content: [{ type: "text" as const, text: actionableError("reading briefing", err) }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    "delete_briefing",
+    `Delete the current briefing for a contact. Use when the existing briefing is stale-and-targeting-a-completed-meeting (or otherwise wrong) and you don't have a fresh one ready to replace it. Re-create via prepare_briefing + save_briefing when ready.`,
+    {
+      contactId: z.number(),
+    },
+    async ({ contactId }) => {
+      try {
+        const result = await db.delete(briefings).where(eq(briefings.contactId, contactId)).returning();
+        if (result.length === 0) {
+          return {
+            content: [
+              { type: "text" as const, text: `No briefing found for contact ${contactId} — nothing to delete.` },
+            ],
+          };
+        }
+        sseManager.broadcast({ type: "briefing_deleted", contactId });
+        storage.logActivity("briefing.deleted", `Briefing deleted`, { contactId, source: "agent" });
+        return { content: [{ type: "text" as const, text: `Briefing deleted for contact ${contactId}.` }] };
+      } catch (err: unknown) {
+        return {
+          content: [{ type: "text" as const, text: actionableError("deleting briefing", err) }],
+          isError: true,
+        };
       }
     },
   );
@@ -1194,11 +1320,19 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
 
   server.tool(
     "read_journal",
-    `Read a contact's relationship_journal. Returns the document text, a content hash (pass as expectedHash on subsequent edits to avoid silent overwrite), and whether the doc has been initialized. Call this BEFORE any edit so you're working from current content. Use the optional \`section\` parameter to scope the read when you only need Key People, Wins, or Entries — saves context on mature journals. ${JOURNAL_CONTRACT}`,
+    `Read a contact's relationship_journal. Returns the document text, a content hash (pass as expectedHash on subsequent edits to avoid silent overwrite), and whether the doc has been initialized. Call this BEFORE any edit so you're working from current content. Use the optional \`section\` parameter to scope the read when you only need Key People, Wins, Engagement History, or Entries — saves context on mature journals. ${JOURNAL_CONTRACT}`,
     {
       contactId: z.number().describe("Contact ID. Get from search_contacts or get_contact."),
       section: z
-        .enum(["Key People", "Wins / Case Study Material", "Entries", "Open Questions", "Risks", "Next Moves"])
+        .enum([
+          "Key People",
+          "Wins / Case Study Material",
+          "Engagement History",
+          "Entries",
+          "Open Questions",
+          "Risks",
+          "Next Moves",
+        ])
         .optional()
         .describe(
           "Return only the named section (between `## Section` and the next `## `). If omitted, returns the full doc. Full-doc hash is always returned for use with edit_journal.",
@@ -1291,7 +1425,15 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
           "Replacement text. Absolute dates only. Substantive content (>40 chars) must contain an absolute date. On rejection the error payload includes: field, reason, offending phrase, excerpt around the match, and position — enough to fix without guessing.",
         ),
       section: z
-        .enum(["Key People", "Wins / Case Study Material", "Entries", "Open Questions", "Risks", "Next Moves"])
+        .enum([
+          "Key People",
+          "Wins / Case Study Material",
+          "Engagement History",
+          "Entries",
+          "Open Questions",
+          "Risks",
+          "Next Moves",
+        ])
         .optional()
         .describe(
           "Scope the edit to within one named section. When set, oldString is matched only inside that section's content and the edit cannot cross section boundaries.",
@@ -1550,6 +1692,17 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
           source: "agent",
           metadata: { entryHeading, seeded, backdated: date !== undefined && date !== todayIso() },
         });
+        // Soft warning when the body contains absolute dates spanning >7 days —
+        // retrospective spans almost certainly belong in `## Engagement History`
+        // rather than a single dated `## Entries` entry. Non-blocking.
+        const spanDays = detectDateSpanDays(body);
+        const spanWarning =
+          spanDays !== null && spanDays > 7
+            ? {
+                code: "wide_date_span",
+                message: `Body references dates spanning ${spanDays} days. Retrospective spans usually belong in \`## Engagement History\` (edited in place) rather than a single dated \`## Entries\` entry. Consider edit_journal to move this content there instead.`,
+              }
+            : null;
         return {
           content: [
             {
@@ -1560,6 +1713,7 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
                 newHash: result.newHash,
                 newSize: result.newSize,
                 seeded,
+                ...(spanWarning ? { warning: spanWarning } : {}),
               }),
             },
           ],

--- a/app/server/routes.ts
+++ b/app/server/routes.ts
@@ -421,7 +421,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   app.put("/api/briefings/:contactId", requireAuth, async (req, res) => {
-    const { content } = req.body;
+    const { content, meetingId } = req.body;
     if (!content || typeof content !== "string") return res.status(400).json({ message: "content required" });
     const validation = validateBriefingSections(content);
     if (!validation.ok) {
@@ -431,17 +431,27 @@ export async function registerRoutes(app: Express): Promise<Server> {
         missing: validation.missing,
       });
     }
+    // meetingId is optional; accept null/undefined/number. Anything else is bad input.
+    const normalizedMeetingId =
+      meetingId === null || meetingId === undefined
+        ? null
+        : typeof meetingId === "number" && Number.isFinite(meetingId)
+          ? meetingId
+          : undefined;
+    if (normalizedMeetingId === undefined) {
+      return res.status(400).json({ message: "meetingId must be a number, null, or omitted" });
+    }
     const contactId = parseInt(req.params.contactId);
     const [existing] = await db.select().from(briefings).where(eq(briefings.contactId, contactId));
     let result;
     if (existing) {
       [result] = await db
         .update(briefings)
-        .set({ content, updatedAt: new Date() })
+        .set({ content, meetingId: normalizedMeetingId, updatedAt: new Date() })
         .where(eq(briefings.contactId, contactId))
         .returning();
     } else {
-      [result] = await db.insert(briefings).values({ contactId, content }).returning();
+      [result] = await db.insert(briefings).values({ contactId, content, meetingId: normalizedMeetingId }).returning();
     }
     sseManager.broadcast({ type: "briefing_updated", contactId });
     storage.logActivity("briefing.saved", `Briefing updated (${content.length} chars)`, { contactId, source: "user" });

--- a/app/server/seed.ts
+++ b/app/server/seed.ts
@@ -7,6 +7,7 @@ import { hashPin } from "./auth";
 import { randomBytes } from "crypto";
 import { toNoonUTC } from "@shared/dates";
 import { JOURNAL_SKELETON } from "@shared/journal";
+import { runBootMigrations } from "./boot-migrations";
 
 /**
  * SAFETY GUARDRAIL — prevent accidentally seeding (and wiping!) a real DB.
@@ -88,6 +89,12 @@ async function seed() {
   if (process.env.CLAW_SEED_FORCE === "1") {
     await new Promise((r) => setTimeout(r, 3000));
   }
+
+  // Run idempotent boot migrations first — keeps the seed in sync with new
+  // columns (e.g. linkedin_url, briefings.meeting_id) without requiring the
+  // dev server to start once before seeding.
+  console.log("Running boot migrations...");
+  await runBootMigrations();
 
   console.log("Wiping existing data...");
   await wipeAllTables();

--- a/app/shared/briefing.ts
+++ b/app/shared/briefing.ts
@@ -146,6 +146,69 @@ export function isBriefingStale(updatedAt: Date | string | number, now: Date = n
 }
 
 /**
+ * Why a briefing is considered stale. `null` means it isn't stale.
+ *   - `age`: simply >7 days old.
+ *   - `meeting_completed`: the meeting it was scoped to has already happened.
+ *   - `wrong_meeting`: the contact's next pending meeting is a different one
+ *     than the briefing's linked meeting.
+ */
+export type BriefingStaleReason = "age" | "meeting_completed" | "wrong_meeting" | null;
+
+export interface BriefingMeetingContext {
+  /** The meeting (followup of type "meeting") the briefing was written for. */
+  meetingId?: number | null;
+  updatedAt: Date | string | number;
+}
+
+export interface MeetingLite {
+  id: number;
+  dueDate: Date | string;
+  completed: boolean;
+  cancelled?: boolean;
+}
+
+/**
+ * Full staleness check with optional meeting linkage. Pass the briefing's
+ * `meetingId` + `updatedAt`, and the contact's full list of meetings
+ * (active + completed; cancelled are ignored). Returns { stale, reason }.
+ *
+ * A briefing without a `meetingId` falls back to age-only — backward
+ * compatible with all pre-2026-05-04 briefings.
+ */
+export function getBriefingStaleness(
+  briefing: BriefingMeetingContext,
+  meetings: MeetingLite[],
+  now: Date = new Date(),
+): { stale: boolean; reason: BriefingStaleReason } {
+  // Age check first — applies regardless of linkage.
+  if (isBriefingStale(briefing.updatedAt, now)) {
+    return { stale: true, reason: "age" };
+  }
+  if (briefing.meetingId == null) {
+    return { stale: false, reason: null };
+  }
+  const linked = meetings.find((m) => m.id === briefing.meetingId);
+  if (linked) {
+    if (linked.completed) {
+      return { stale: true, reason: "meeting_completed" };
+    }
+    if (linked.cancelled) {
+      return { stale: true, reason: "meeting_completed" };
+    }
+  }
+  // Find the next pending (uncancelled, uncompleted, future-or-today) meeting.
+  const pending = meetings
+    .filter((m) => !m.completed && !m.cancelled)
+    .slice()
+    .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime());
+  const next = pending[0];
+  if (next && next.id !== briefing.meetingId) {
+    return { stale: true, reason: "wrong_meeting" };
+  }
+  return { stale: false, reason: null };
+}
+
+/**
  * Integer days since the briefing was last updated. Floors to the full day.
  */
 export function briefingAgeDays(updatedAt: Date | string | number, now: Date = new Date()): number {

--- a/app/shared/journal.ts
+++ b/app/shared/journal.ts
@@ -118,15 +118,27 @@ const ABSOLUTE_DATE_PATTERNS: Array<{ label: string; re: RegExp }> = [
 export const ACCEPTED_DATE_FORMATS = ABSOLUTE_DATE_PATTERNS.map((p) => p.label);
 
 /**
- * Required top-level sections. Every journal has at least these three.
+ * Required top-level sections. Every journal has at least these four.
  * Destructive-heading detection only protects `### YYYY-MM-DD:` entry headings;
  * `##` sections are documentation contract, not enforcement.
+ *
+ * Engagement History sits between Wins and Entries. It's edited in place
+ * (no `### YYYY-MM-DD:` requirement) and is the canonical home for
+ * retrospective phase summaries — content authored about a span rather than
+ * about a single date (scope evolution, role changes, compensation history,
+ * "Q1 2025 — Phase 1 AI enablement"). Mixing these into Entries with
+ * backdated headings distorts the chronological timeline.
  */
-export const CANONICAL_SECTIONS = ["Key People", "Wins / Case Study Material", "Entries"] as const;
+export const CANONICAL_SECTIONS = [
+  "Key People",
+  "Wins / Case Study Material",
+  "Engagement History",
+  "Entries",
+] as const;
 
 /**
  * Sections an agent MAY add when they have genuine signal that doesn't fit the
- * canonical three. Keep the list short; the journal should favor narrative over
+ * canonical set. Keep the list short; the journal should favor narrative over
  * structure.
  */
 export const OPTIONAL_SECTIONS = ["Open Questions", "Risks", "Next Moves"] as const;
@@ -135,10 +147,13 @@ export function JOURNAL_SKELETON(name: string): string {
   return `# ${name}
 
 ## Key People
-<!-- Roster of stakeholders with roles and the current relationship state. Who matters, what they care about. -->
+<!-- Roster of stakeholders with roles and the current relationship state. Who matters, what they care about. Edit in place. -->
 
 ## Wins / Case Study Material
-<!-- Durable wins worth preserving for future BD and case studies. Concrete outcomes, measurable impact, quotable moments. -->
+<!-- Durable wins worth preserving for future BD and case studies. Concrete outcomes, measurable impact, quotable moments. Edit in place. -->
+
+## Engagement History
+<!-- Retrospective phase summaries, scope evolution, role changes, compensation history. For content authored about a span rather than about a single date. Edit in place. No \`### YYYY-MM-DD:\` headings required here. -->
 
 ## Entries
 <!-- Dated narrative entries, newest at the bottom. Append-only. Each entry: ### YYYY-MM-DD: <title> -->
@@ -310,10 +325,87 @@ export function todayIso(): string {
 }
 
 /**
+ * Strip a leading absolute-date prefix from a title. Agents (especially LLMs)
+ * regularly prepend the date as the first token of `title`, producing
+ * double-dated headings like `### 2026-05-10: 2026-05-10: Foo`. Stripped
+ * silently — no existing valid title format starts with one of these
+ * date+colon patterns, so this is purely additive cleanup.
+ */
+export function stripDatePrefix(title: string): string {
+  const t = title.trim();
+  // Patterns mirror the absolute-date allow-list; each anchored to start
+  // and tolerates a trailing colon + whitespace before the actual title.
+  const patterns = [
+    // 2026-05-10 / 2026-05-10:
+    /^\d{4}-\d{2}-\d{2}\s*:?\s*/,
+    // 5/10/2026 / 05/10/2026:
+    /^\d{1,2}\/\d{1,2}\/\d{4}\s*:?\s*/,
+    // May 10, 2026 / May 10 2026:
+    /^(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{1,2},?\s+\d{4}\s*:?\s*/i,
+    // August 2025 / Q3 2025 / Spring 2026 — year-only or coarse anchors used as title prefixes
+    /^(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{4}\s*:?\s*/i,
+    /^Q[1-4]\s+\d{4}\s*:?\s*/i,
+    /^(?:spring|summer|fall|autumn|winter)\s+\d{4}\s*:?\s*/i,
+  ];
+  for (const re of patterns) {
+    if (re.test(t)) return t.replace(re, "").trim();
+  }
+  return t;
+}
+
+/**
+ * Detect the date span (max - min, in days) implied by a body of journal
+ * prose. Returns null when fewer than two absolute dates are present. Used
+ * to softly warn agents that retrospective spans probably belong in
+ * `## Engagement History` rather than a single `## Entries` entry.
+ */
+export function detectDateSpanDays(body: string): number | null {
+  const masked = maskBlockquotes(body);
+  const dates: Date[] = [];
+  // Only the unambiguous patterns are useful for span detection.
+  const yyyy = /\b(\d{4})-(\d{2})-(\d{2})\b/g;
+  const mdyyyy = /\b(\d{1,2})\/(\d{1,2})\/(\d{4})\b/g;
+  const monthName =
+    /\b(january|february|march|april|may|june|july|august|september|october|november|december)\s+(\d{1,2}),?\s+(\d{4})\b/gi;
+  let m: RegExpExecArray | null;
+  while ((m = yyyy.exec(masked))) {
+    const dt = new Date(`${m[1]}-${m[2]}-${m[3]}T12:00:00Z`);
+    if (!isNaN(dt.getTime())) dates.push(dt);
+  }
+  while ((m = mdyyyy.exec(masked))) {
+    const dt = new Date(`${m[3]}-${m[1].padStart(2, "0")}-${m[2].padStart(2, "0")}T12:00:00Z`);
+    if (!isNaN(dt.getTime())) dates.push(dt);
+  }
+  const months: Record<string, number> = {
+    january: 1,
+    february: 2,
+    march: 3,
+    april: 4,
+    may: 5,
+    june: 6,
+    july: 7,
+    august: 8,
+    september: 9,
+    october: 10,
+    november: 11,
+    december: 12,
+  };
+  while ((m = monthName.exec(masked))) {
+    const mm = months[m[1].toLowerCase()];
+    const dt = new Date(`${m[3]}-${String(mm).padStart(2, "0")}-${m[2].padStart(2, "0")}T12:00:00Z`);
+    if (!isNaN(dt.getTime())) dates.push(dt);
+  }
+  if (dates.length < 2) return null;
+  const times = dates.map((d) => d.getTime());
+  return Math.round((Math.max(...times) - Math.min(...times)) / (1000 * 60 * 60 * 24));
+}
+
+/**
  * Append a new Entry to the doc. If `## Entries` is missing, appends it at the
  * end. Caller may supply an explicit ISO `dateIso` to backdate migrated notes;
  * otherwise today's date is used. Returns the updated doc and the full entry
- * heading.
+ * heading. Strips any leading absolute-date prefix from `title` so the
+ * heading doesn't end up double-dated.
  */
 export function appendJournalEntry(
   doc: string,
@@ -322,7 +414,8 @@ export function appendJournalEntry(
   dateIso?: string,
 ): { updated: string; entryHeading: string } {
   const effectiveDate = dateIso && isReasonableIsoDate(dateIso) ? dateIso : todayIso();
-  const heading = `### ${effectiveDate}: ${title.trim()}`;
+  const cleanTitle = stripDatePrefix(title);
+  const heading = `### ${effectiveDate}: ${cleanTitle}`;
   const entry = `${heading}\n\n${body.trim()}\n`;
 
   const sectionRe = /^##\s+Entries\s*$/m;

--- a/app/shared/schema.ts
+++ b/app/shared/schema.ts
@@ -169,6 +169,12 @@ export const briefings = pgTable("briefings", {
     .notNull()
     .references(() => contacts.id, { onDelete: "cascade" }),
   content: text("content").notNull(),
+  // Optional: the meeting (followup of type "meeting") this briefing was
+  // written for. When set, staleness considers whether that meeting still
+  // matches the contact's next pending meeting and whether it's completed.
+  // ON DELETE SET NULL — if the meeting is deleted, the briefing survives
+  // but reverts to age-only staleness.
+  meetingId: integer("meeting_id").references(() => followups.id, { onDelete: "set null" }),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at").notNull().defaultNow(),
 });


### PR DESCRIPTION
## Summary
Three related fixes from a CRM audit, all in the journal/briefing subsystem. Shipped together because they share an audience and fix-shape.

### Issue 1 — Double-dated entry headings
`append_journal` / `batch_append_journal` prepend `### YYYY-MM-DD:` while LLM callers regularly include the date as the first token of `title`, producing `### 2026-05-10: 2026-05-10: Foo`. New `stripDatePrefix(title)` helper in `shared/journal.ts` silently strips a leading absolute-date pattern from the title before composing the heading. Purely additive — no valid title started with one of those patterns. Existing entries untouched.

### Issue 2 — Briefings linked to a specific meeting
Schema: optional `briefings.meeting_id` (FK to `followups.id`, `ON DELETE SET NULL`). Boot migration adds the column idempotently.

- `prepare_briefing` returns `candidateMeetingId` (next pending meeting on contact) + `previousBriefing.linkedMeeting` / `staleReason`. Agent passes through to `save_briefing.meetingId`.
- `save_briefing` accepts and persists optional `meetingId`.
- `get_briefing` returns `meetingId` + `linkedMeeting` + `staleReason` (`age` / `meeting_completed` / `wrong_meeting` / null).
- New `getBriefingStaleness(briefing, meetings)` helper in `shared/briefing.ts` — single source of truth used by client + server. A briefing is stale when age >7d, OR the linked meeting has completed, OR a newer meeting is now next pending.
- Briefings without `meetingId` fall back to age-only — backward compatible.
- Briefing page surfaces the reason in the stale banner ("the meeting this was for has already happened" / "a newer meeting is now next") and shows the linked meeting context line above the briefing.

### Issue 3 — `## Engagement History` canonical section
New canonical section between Wins and Entries. Edited in place via `edit_journal`, no `### YYYY-MM-DD:` requirement. Home for retrospective phase summaries — content authored about a *span* rather than a single date (scope evolution, role changes, "Q1 2025 — Phase 1"). Mixing those into Entries with backdated headings distorted long-running timelines.

Added to `CANONICAL_SECTIONS`, included in `JOURNAL_SKELETON`, accepted by `read_journal`'s `section` enum, documented in `get_crm_guide`. New `detectDateSpanDays(body)` helper plus a non-blocking `wide_date_span` warning on `append_journal` when the body references dates spanning >7 days — soft nudge.

### Follow-up — `delete_briefing` MCP tool
New tool so the dreaming skill can clear briefings flagged as stale-and-targeting-completed-meeting without an awkward placeholder save. Idempotent.

### Also
- Seed now runs `runBootMigrations()` before TRUNCATE so seeding a freshly-pushed schema works without needing the dev server to start first.

## Test plan
- [x] Lint + build clean
- [x] Local seed runs cleanly with new `meeting_id` column
- [x] `append_journal({title: "2026-05-10: Foo", date: "2026-05-10"})` → heading `### 2026-05-10: Foo` (no double-date)
- [x] `append_journal` with body spanning 318 days → response includes `warning.code: "wide_date_span"`
- [x] `prepare_briefing` returns `candidateMeetingId` matching the contact's next pending meeting
- [x] `save_briefing(..., meetingId: 4)` persists; `get_briefing` returns `stale: false`
- [x] Mark linked meeting completed → `get_briefing` returns `stale: true, staleReason: "meeting_completed"`
- [x] Add a newer pending meeting (and revert linked back to active) → `staleReason: "wrong_meeting"`
- [x] `delete_briefing` removes briefing; calling again is a no-op
- [x] `read_journal({section: "Engagement History"})` returns the section content
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)