### PR TITLE
Confidentiality rule: layer-specific scoping in get_crm_guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 2026-05-11
 
+### Confidentiality rule: layer-specific scoping
+The previous `get_crm_guide` confidentiality block was too blunt — "NEVER put pricing or deal terms in the CRM" — and forced agents to strip strategically important content from the journal where it actually belongs (case-study material, engagement history, partnership terms over time). New rules:
+- **Pricing / dollar amounts / fees / commission rates:** allowed in the journal only (Entries, Engagement History, Wins, Key People). Forbidden in tasks, interactions, briefings, and contact fields. Tasks/interactions reference payments by date + scope, not figure.
+- **Cross-client specifics:** never, in any layer.
+- **Credentials / account numbers / secrets:** never, anywhere.
+
+Pure text/policy update. No validator changes; the journal already accepts dollar amounts. Existing entries stay valid; cleanup of pricing in tasks/interactions is a `crm-dreaming` skill job.
+
 ### Journal hygiene: triple-shot — double-dated headings, briefing/meeting linkage, Engagement History
 Three related issues surfaced during a CRM audit, all in the journal/briefing subsystem. Shipping together because they share an audience and a fix shape.
 

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -334,9 +334,9 @@ Tasks and interactions should be SHORT reminders. The journal is where detail li
 10. Write dense. Every word earns its place. No filler, no throat-clearing, no hedges. Capture maximum context per character.
 
 ## Confidentiality
-- NEVER put pricing or deal terms in the CRM
-- NEVER cross-reference client details between prospects
-- Proposals reference dates only, no dollar amounts
+- Pricing, dollar amounts, deal terms, fees, commission rates: allowed in the journal only (Entries, Engagement History, Wins, Key People). Forbidden in tasks, interactions, briefings, contact fields (background, source, additionalContacts). When a task or interaction needs to reference a payment or invoice, use date and scope only ("Standard paid invoice INV-2035 on 2026-05-11"), not the figure.
+- Cross-client specifics: never, in any layer. Generic patterns are fine; named-client details are not.
+- Credentials, account numbers, secrets: never, anywhere.
 `,
           },
         ],


### PR DESCRIPTION
## Summary
The previous `get_crm_guide` confidentiality block was too blunt — "NEVER put pricing or deal terms in the CRM" — and forced agents to strip strategically important content from the journal where it belongs (case-study wins, engagement history, partnership terms tracked over time). Replaced with layer-scoped rules:

- **Pricing, dollar amounts, deal terms, fees, commission rates:** allowed in the journal only (Entries, Engagement History, Wins, Key People). Forbidden in tasks, interactions, briefings, and contact fields (background, source, additionalContacts). Tasks and interactions reference payments by date + scope, not figure (e.g. "Standard paid invoice INV-2035 on 2026-05-11").
- **Cross-client specifics:** never, in any layer. Generic patterns are fine; named-client details are not.
- **Credentials, account numbers, secrets:** never, anywhere.

Pure text/policy update. No validator changes — the journal already accepts dollar amounts. Existing journal entries stay valid; cleanup of pricing in tasks/interactions is the `crm-dreaming` skill's job.

## Test plan
- [x] Lint + build clean
- [x] Verified via MCP that `get_crm_guide` → Confidentiality section now returns the three layer-scoped rules verbatim
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)