### PR TITLE
Slash-command placeholder: advertise /stage and /status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-05-14
+
+### Slash-command placeholder advertises `/stage` and `/status`
+The contact card's slash-command input used to read `+ note, /fu 4/15 task, /mtg 4/3 2pm meeting` — only two of the four available commands. After we removed the stage/status pills (PR #77), `/stage` and `/status` became the primary edit path for those fields but weren't discoverable from the input itself. New placeholder is `+ note · /fu · /mtg · /stage · /status` — all four advertised, dropping the M/D + time syntax cues since the typing-time contextual hint above the input already shows those when you start typing.
+
 ## 2026-05-11
 
 ### Confidentiality rule: layer-specific scoping

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -809,7 +809,7 @@ export function ContactBlock({
               value={newNote}
               onChange={(e) => setNewNote(e.target.value)}
               onKeyDown={handleNoteSubmit}
-              placeholder="+ note, /fu 4/15 task, /mtg 4/3 2pm meeting"
+              placeholder="+ note · /fu · /mtg · /stage · /status"
               className="w-full text-xs bg-transparent border-none outline-none transition-colors"
               style={{
                 color: inputColor || C.muted,


### PR DESCRIPTION
## Summary
The contact card's slash-command input only advertised two of the four available commands (`/fu`, `/mtg`). After PR #77 removed the stage/status pills, `/stage` and `/status` became the primary path for those edits but had no visual cue.

```diff
- placeholder="+ note, /fu 4/15 task, /mtg 4/3 2pm meeting"
+ placeholder="+ note · /fu · /mtg · /stage · /status"
```

All four commands now discoverable from the empty-state placeholder. M/D + time syntax cues already appear in the typing-time contextual chip above the input — no need to double-print them in the placeholder.

## Test plan
- [x] Lint + build clean
- [x] Visually verified at 390 × 844: placeholder shows all four commands without truncation
- [x] All four parsers + typing-time hints unchanged
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)