### PR TITLE
Meetings are never "overdue"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-05-15
+
+### Meetings are never "overdue"
+A meeting is a scheduled event — once its date is in the past, it has *happened*, not become overdue. The CRM was treating past-dated meetings the same as past-dated tasks: flagging them with the red `OVERDUE` label in the Upcoming list and on contact cards, and generating Past-Due Follow-Up rule violations. Wrong semantics, wrong visual treatment.
+
+Gated three spots on `type !== "meeting"`:
+- `crm-page.tsx` Upcoming list — `isOverdue` no longer flips true for meetings.
+- `contact-block.tsx` per-contact followup display — same fix.
+- `rules-engine.ts` `followup_past_due` condition (and its activity-message helper) — meetings never match, so the rule fires on tasks only.
+
+Past meetings now render with their normal blue date prefix and neutral body text. The `no_followup_after_meeting` rule still handles the "you should log this" nudge — that's the right surface for it.
+
 ## 2026-05-14
 
 ### Slash-command placeholder advertises `/stage` and `/status`

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -565,7 +565,9 @@ export function ContactBlock({
           <div className="space-y-1 mb-2">
             {activeFollowups.map((fu) => {
               const due = new Date(fu.dueDate);
-              const isOverdue = isPast(due) && !isToday(due);
+              // Meetings are scheduled events, not action items — a past meeting has
+              // happened, it's not "overdue". Overdue only applies to tasks.
+              const isOverdue = fu.type !== "meeting" && isPast(due) && !isToday(due);
               const isTodayDue = isToday(due);
               // Calendar-day difference — see note in crm-page.tsx.
               const daysUntil = differenceInCalendarDays(due, new Date());

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -489,7 +489,9 @@ export default function CrmPage() {
               <div className="space-y-1.5">
                 {allFollowups.map(({ followup: fu, contactName, briefing }) => {
                   const due = new Date(fu.dueDate);
-                  const isOverdue = isPast(due) && !isToday(due);
+                  // Meetings are scheduled events, not action items — a past meeting has
+                  // happened, it's not "overdue". Overdue only applies to tasks.
+                  const isOverdue = fu.type !== "meeting" && isPast(due) && !isToday(due);
                   const isTodayDue = isToday(due);
                   // Calendar-day difference — counts midnight crossings, so an item due tomorrow
                   // reads as "1d" regardless of what hour it is today. differenceInDays measures

--- a/app/server/rules-engine.ts
+++ b/app/server/rules-engine.ts
@@ -113,7 +113,12 @@ function checkCondition(
     }
     case "followup_past_due": {
       const now = new Date();
-      violated = contactFollowups.some((f) => !f.completed && new Date(f.dueDate) < now);
+      // Meetings are scheduled events, not action items — a past meeting has happened,
+      // it's not "overdue". The no_followup_after_meeting rule handles the "you should
+      // log this" nudge. Restrict past-due to tasks only.
+      violated = contactFollowups.some(
+        (f) => !f.completed && f.type !== "meeting" && new Date(f.dueDate) < now,
+      );
       break;
     }
     case "no_followup_after_meeting": {
@@ -171,7 +176,10 @@ function buildMessage(
     const daysSince = Math.floor((Date.now() - new Date(last.date).getTime()) / (1000 * 60 * 60 * 24));
     message = message.replace("{{days_since_last}}", String(daysSince));
   }
-  const overdue = contactFollowups.filter((f) => !f.completed && new Date(f.dueDate) < new Date());
+  // Same restriction as the rule itself — overdue tasks only, never meetings.
+  const overdue = contactFollowups.filter(
+    (f) => !f.completed && f.type !== "meeting" && new Date(f.dueDate) < new Date(),
+  );
   if (overdue.length > 0) message = message.replace("{{followup_content}}", overdue[0].content);
   const pastMeetings = contactInteractions.filter((i) => i.type === "meeting");
   if (pastMeetings.length > 0)

--- a/app/server/rules-engine.ts
+++ b/app/server/rules-engine.ts
@@ -116,9 +116,7 @@ function checkCondition(
       // Meetings are scheduled events, not action items — a past meeting has happened,
       // it's not "overdue". The no_followup_after_meeting rule handles the "you should
       // log this" nudge. Restrict past-due to tasks only.
-      violated = contactFollowups.some(
-        (f) => !f.completed && f.type !== "meeting" && new Date(f.dueDate) < now,
-      );
+      violated = contactFollowups.some((f) => !f.completed && f.type !== "meeting" && new Date(f.dueDate) < now);
       break;
     }
     case "no_followup_after_meeting": {


### PR DESCRIPTION
## Summary
A meeting is a scheduled event — once its date is in the past, it has *happened*, not become overdue. The CRM treated past-dated meetings the same as past-dated tasks: red `OVERDUE` label, red date color, AND a Past-Due Follow-Up rule violation. Wrong semantics, wrong visual treatment.

Gated three spots on `f.type !== "meeting"`:

- `crm-page.tsx` Upcoming list — `isOverdue` no longer flips true for meetings.
- `contact-block.tsx` per-contact followup display — same fix.
- `rules-engine.ts` `followup_past_due` (and its activity-message helper) — meetings never match, so the rule fires on tasks only.

The `no_followup_after_meeting` rule still handles the "you should log this" nudge for past meetings — that's the right surface for it.

## Test plan
- [x] Lint + build clean
- [x] Reseeded local, backdated `Coffee with Elena` meeting to `NOW() - 3d`
- [x] DOM query on home page at 390 × 844 returns 0 nodes containing "Overdue" / "OVERDUE" / "· Overdue"
- [x] `rule_violations` table empty for the Past-Due Follow-Up rule despite the past-dated meeting
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)