### PR TITLE
Add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR/app"
+
+# Install npm dependencies and Playwright's Chromium browser.
+npm install --no-audit --no-fund
+npx --yes playwright install --with-deps chromium
+
+# Provision a local Postgres so `npm run db:push` and the Playwright suite
+# (which boots the Express server) work out of the box.
+if command -v psql >/dev/null 2>&1; then
+  sudo service postgresql start >/dev/null 2>&1 || true
+  sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='claw_crm'" \
+    | grep -q 1 || sudo -u postgres createdb claw_crm
+  sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='claw'" \
+    | grep -q 1 || sudo -u postgres psql -c "CREATE ROLE claw WITH LOGIN SUPERUSER PASSWORD 'claw';"
+  sudo -u postgres psql -c "ALTER DATABASE claw_crm OWNER TO claw;" >/dev/null
+
+  if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    {
+      echo 'export DATABASE_URL="postgresql://claw:claw@localhost:5432/claw_crm"'
+      echo 'export SESSION_SECRET="dev-session-secret-not-for-prod"'
+    } >> "$CLAUDE_ENV_FILE"
+  fi
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- New `.claude/hooks/session-start.sh` (gated on `CLAUDE_CODE_REMOTE=true`, so it's a no-op locally) that runs `npm install` from `app/`, installs Playwright's Chromium, provisions a local Postgres (`claw_crm` DB + `claw` superuser), and exports `DATABASE_URL` / `SESSION_SECRET` via `$CLAUDE_ENV_FILE`.
- Registers the hook under `SessionStart` in `.claude/settings.json` alongside the existing `PreToolUse` hook.

## Test plan
- [x] Hook runs end-to-end with `CLAUDE_CODE_REMOTE=true` (deps + Chromium + Postgres provisioned)
- [x] `npx eslint shared/schema.ts` passes
- [x] `npm run db:push` succeeds against the provisioned DB
- [x] `npx playwright test tests/api.spec.ts` — 4/4 passing


---
_Generated by [Claude Code](https://claude.ai/code/session_01YBBxcFkQuUF4gKUFXJ1bxU)_