### PR TITLE
SessionStart hook: push schema and seed demo data on first boot

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -27,4 +27,19 @@ if command -v psql >/dev/null 2>&1; then
       echo 'export SESSION_SECRET="dev-session-secret-not-for-prod"'
     } >> "$CLAUDE_ENV_FILE"
   fi
+
+  # Push schema (idempotent) so the seed and the dev server have tables.
+  DATABASE_URL="postgresql://claw:claw@localhost:5432/claw_crm" \
+    SESSION_SECRET="dev-session-secret-not-for-prod" \
+    npm run db:push
+
+  # Seed demo data on first boot only — `npm run db:seed` wipes existing
+  # rows, so skip if a user already exists from a prior session.
+  has_user=$(sudo -u postgres psql -tAd claw_crm -c \
+    "SELECT EXISTS (SELECT 1 FROM users);" 2>/dev/null || echo "f")
+  if [ "$has_user" != "t" ]; then
+    DATABASE_URL="postgresql://claw:claw@localhost:5432/claw_crm" \
+      SESSION_SECRET="dev-session-secret-not-for-prod" \
+      npm run db:seed
+  fi
 fi


### PR DESCRIPTION
## Summary
- Adds `npm run db:push` to the SessionStart hook so the schema is in place before anything else runs.
- Adds `npm run db:seed` guarded on "the `users` table is empty" — fresh containers come up with the PIN-1234 demo dataset; resumed sessions skip seeding so they don't lose work (seed wipes existing rows).

## Test plan
- [x] Fresh DB → `db:push` creates tables, `db:seed` runs (8 contacts / 8 companies / 3 rules).
- [x] Already-seeded DB → `db:push` no-ops, seed step is skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YBBxcFkQuUF4gKUFXJ1bxU)_