### PR TITLE
Clean search artifacts from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## 2026-05-27
-
-### Remove global search
-Removed the Cmd+K search bar, the BM25 server index, the `search_contacts` MCP tool, the `/api/search` endpoint, the `minisearch` dependency, and all inline highlight/auto-expand logic. The truncate-toggle on long interaction notes is preserved. Clears the deck so the feature can be rebuilt from scratch as a coding demo.
-
 ## 2026-05-15
 
 ### Meetings are never "overdue"


### PR DESCRIPTION
## Summary
- Removes the 2026-05-27 "Remove global search" CHANGELOG entry.
- The original PR #59 entry was already scrubbed in the previous removal PR (#115). With this change, CHANGELOG.md no longer mentions the search feature or its removal — a future coding agent reading the repo gets a clean baseline.

## Test plan
- [x] No code changes — CHANGELOG-only diff (-5 lines)
- [x] `grep -i "search_contacts\|bm25\|minisearch\|cmd+k"` across CHANGELOG / README / CLAUDE.md / SKILL.md returns zero hits
- [x] E2E manifest refreshed (reuses the prior run since no app code was touched)

## Note
This only cleans the in-repo documentation. Git history and merged PRs (#59, #115) are still visible on GitHub — those would require history rewrites or be deferred to an instruction to the future agent ("don't look at git history").

🤖 Generated with [Claude Code](https://claude.com/claude-code)