### PR TITLE
Polish README and MCP tool descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-05-27
 
+### Polish README and MCP tool descriptions
+Small accuracy and clarity pass: bumped the README's "25+ tools" claim to "27+" to match the current `mcp-remote.ts` registration count, and sharpened two MCP tool descriptions. `get_contact` now mentions that company and briefing are included in the returned bundle. `list_violations` clarifies that it returns unresolved violations only and is paginated.
+
 ### Batch grill-me questions in single round
 The `grill-me` skill drip-fed one AskUserQuestion at a time, which is slower and less natural than answering related decisions together. Updated the skill body to present 3–5 grouped questions per round so the user can batch-answer in Claude Code's structured interface.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Most CRMs are built for sales teams. Claw is built for one person managing 10-50
 
 - **Notebook view** — your entire pipeline in one scrollable feed, sorted by urgency
 - **Slash commands** — `/fu 4/15 check on proposal`, `/mtg 4/3 2pm Coffee @ Verve`, `/stage PROPOSAL`
-- **AI agents write, you verify** — Claude connects via MCP and manages your CRM through 25+ tools
+- **AI agents write, you verify** — Claude connects via MCP and manages your CRM through 27+ tools
 - **Relationship journal** — a per-contact markdown document that's the durable home for the narrative of the relationship: Key People, Wins / Case Study Material, and dated Entries. Absolute-dates-only validator, full revision history with diff view, verbatim blockquote escape for preserving emails and transcripts.
 - **Rules engine** — business logic stored as data, not code. "Flag contacts with no interaction for 14 days." Agents can create, modify, and delete rules.
 - **Real-time** — SSE pushes every change to the UI instantly, whether you or an agent made it

--- a/app/server/mcp-server.ts
+++ b/app/server/mcp-server.ts
@@ -30,7 +30,7 @@ const server = new McpServer({
 
 server.tool(
   "get_contact",
-  "Get full details for a contact including interactions, follow-ups, and violations",
+  "Get full details for a contact including company, interactions, follow-ups, briefing, and active violations.",
   { contactId: z.number().describe("Contact ID") },
   async ({ contactId }) => {
     const contact = await storage.getContactWithRelations(contactId);
@@ -50,7 +50,7 @@ server.tool(
 
 server.tool(
   "list_violations",
-  "Get all active rule violations, enriched with contact names",
+  "List active (unresolved) rule violations, enriched with contact names. Paginated.",
   {
     severity: severityEnum.optional().describe(`Filter by severity: ${SEVERITIES.join(", ")}`),
     limit: z.number().optional().describe("Max results (default 25)"),


### PR DESCRIPTION
## Summary
- Sharpen `get_contact` and `list_violations` MCP tool descriptions
- Bump README tool count from 25+ to 27+ to match current `mcp-remote.ts`
- CHANGELOG entry

Three small docs/metadata commits — no runtime behavior change. **Intended to be merged without squash** to keep all three commits on `main`.

E2E skipped — docs/metadata only, mirroring the precedent from PR #79 (feat/inbox-agent-prompt).

## Test plan
- [x] Doc/description-only changes; no executable code path touched
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)