### PR TITLE
Revert grill-me batch questions

### DIFF
--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -12,7 +12,7 @@ the codebase instead.
 
 For each question, provide your recommended answer.
 
-Use the AskUserQuestion tool to present 3–5 questions together in
-a single round so the user can answer them as a batch in Claude
-Code's structured interface. Group related decisions; don't drip
-questions out one at a time.
+Use the AskUserQuestion tool for every question so the user gets
+the structured question/answer interface in Claude Code. Ask one
+question at a time — do not batch multiple questions into a single
+prompt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Polish README and MCP tool descriptions
 Small accuracy and clarity pass: bumped the README's "25+ tools" claim to "27+" to match the current `mcp-remote.ts` registration count, and sharpened two MCP tool descriptions. `get_contact` now mentions that company and briefing are included in the returned bundle. `list_violations` clarifies that it returns unresolved violations only and is paginated.
 
-### Batch grill-me questions in single round
-The `grill-me` skill drip-fed one AskUserQuestion at a time, which is slower and less natural than answering related decisions together. Updated the skill body to present 3–5 grouped questions per round so the user can batch-answer in Claude Code's structured interface.
+### Revert grill-me batch questions
+Reverting #117. The one-question-at-a-time flow was preferred — grouping into batches of 3–5 lost the conversational rhythm the skill was designed for. Skill body restored to the prior wording.
 
 ## 2026-05-15
 


### PR DESCRIPTION
## Summary
- Reverts #117. Restores the `grill-me` skill body to one-question-at-a-time via AskUserQuestion
- CHANGELOG: drops the original "Batch grill-me questions" entry and replaces it with a revert note under 2026-05-27

## Test plan
- [ ] CI green (skill-file-only change; no app code touched)