### PR TITLE
Add Cmd+K full-text search across contacts and their content

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -99,6 +99,16 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 - Verify the follow-up disappears and the outcome appears in the timeline
 - **Screenshot** → `e2e-screenshots/06-task-completed.png`
 
+### 5b. UI: Cmd+K full-text search
+- Press **Cmd+K** (or Ctrl+K) anywhere on the CRM page. Verify the org name in the header is replaced by a search input with placeholder "Search contacts, interactions, tasks…" and that the Stage Filter icon is hidden (Menu icon stays).
+- Type a contact's first name (e.g. `sarah`). Verify the contact list filters down to matches with that contact at the top.
+- Clear the input. Type a distinctive word that appears in one contact's interaction or task content (e.g. `kicking` for Sarah Chen in the seed data). Verify only the contact whose body contains that word appears.
+- Press **ArrowDown** twice. Verify the 2nd result gets a teal ring (3px box-shadow) and scrolls into view if off-screen. Press **ArrowUp** — highlight moves back.
+- Press **Enter** — the input blurs but the filtered list and the query persist.
+- Press **Esc** — the search collapses, the query clears, and the full contact list is restored.
+- Apply a stage filter (e.g. PROPOSAL only), then open search and type a query — verify results ignore the stage filter (search overrides stage filter).
+- **Screenshot** → `e2e-screenshots/06b-search-body-match.png`
+
 ### 6. UI: Change stage via command
 - Type `/stage PROPOSAL` in a contact's input
 - Press Enter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-05-28
+
+### Frontend full-text search with Cmd+K
+Added an instantaneous search affordance to the top nav. A magnifying-glass icon sits left of the existing Filter + Menu icons; clicking it (or pressing `⌘K` / `Ctrl+K` from anywhere) expands an inline input that replaces the org name. Typing live-filters the contacts list using [MiniSearch](https://github.com/lucaong/minisearch) (BM25) — one document per contact, with `interactions`, `followups`, and `briefing.content` flattened into a `body` field so a hit on any of them surfaces the parent contact. Name and company are boosted 5× so a named contact ranks above incidental mentions in someone else's notes. `relationshipJournal` is intentionally excluded — it's long enough to dominate ranking.
+
+UX details:
+- **Prefix + fuzzy (0.2)** matching — typing `mis` matches `Misty` mid-word, and `mistr` still finds her.
+- While a query is active, the stage filter is ignored and view mode is forced to list (search overrides everything).
+- `↑`/`↓` move a teal highlight ring through the filtered list, scrolling the active card into view. `Enter` blurs but leaves the filter applied. `Esc` clears + collapses.
+- Index is built lazily on the first search open, then memoized against the contacts array reference — SSE-driven invalidations refresh it automatically.
+
+New: `client/src/hooks/use-contact-search.ts`, `client/src/components/search-bar.tsx`, `tests/search.spec.ts`. All work is client-side — no schema, no endpoint, no boot-migration.
+
 ## 2026-05-27
 
 ### Polish README and MCP tool descriptions

--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ Exceptions: `has_future_followup`, `stage_in` (exclude specific stages from rule
 | `/status STATUS` | `/status HOLD` |
 | plain text + Enter | `Had coffee with Idan` (logs as note) |
 
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `⌘K` / `Ctrl+K` | Open full-text search (MiniSearch / BM25) over contacts, interactions, follow-ups, meetings, briefings. Prefix + fuzzy matching, name and company boosted. `↑`/`↓` move the highlight, `Esc` closes. |
+
 ## Tech Stack
 
 React, Express, PostgreSQL, Drizzle ORM, Vite, Tailwind CSS, MCP SDK, Playwright E2E, GitHub Actions CI, Railway deploy, PWA (iOS), Pake (Mac desktop).

--- a/app/client/src/components/search-bar.tsx
+++ b/app/client/src/components/search-bar.tsx
@@ -1,0 +1,85 @@
+import { forwardRef } from "react";
+import { Search, X } from "lucide-react";
+import { useColors } from "@/App";
+
+export interface SearchBarProps {
+  open: boolean;
+  query: string;
+  onQueryChange: (q: string) => void;
+  onOpen: () => void;
+  onClose: () => void;
+  onArrowDown: () => void;
+  onArrowUp: () => void;
+  onEnter: () => void;
+}
+
+/**
+ * Top-nav search affordance. When closed, renders a magnifying-glass icon
+ * button. When open, renders an inline input with a close (X) button on the
+ * right. Keyboard contract:
+ *   - Esc:   onClose (parent clears query + collapses)
+ *   - Enter: onEnter (parent blurs but keeps filtered list)
+ *   - Up/Down: onArrowUp / onArrowDown (parent moves highlight)
+ *
+ * Cmd+K is handled by the parent at the window level (works from anywhere).
+ */
+export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(function SearchBar(
+  { open, query, onQueryChange, onOpen, onClose, onArrowDown, onArrowUp, onEnter },
+  ref,
+) {
+  const C = useColors();
+
+  if (!open) {
+    return (
+      <button
+        onClick={onOpen}
+        className="p-2 transition-colors"
+        style={{ color: C.muted }}
+        title="Search (⌘K)"
+        aria-label="Search"
+      >
+        <Search className="h-4 w-4" />
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1 flex-1">
+      <Search className="h-4 w-4 flex-shrink-0" style={{ color: C.muted }} />
+      <input
+        ref={ref}
+        type="text"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            onClose();
+          } else if (e.key === "Enter") {
+            e.preventDefault();
+            onEnter();
+          } else if (e.key === "ArrowDown") {
+            e.preventDefault();
+            onArrowDown();
+          } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            onArrowUp();
+          }
+        }}
+        placeholder="Search contacts, interactions, tasks…"
+        className="flex-1 min-w-0 bg-transparent text-[13px] outline-none px-1 py-1"
+        style={{ color: C.text }}
+        aria-label="Search contacts"
+      />
+      <button
+        onClick={onClose}
+        className="p-1 transition-colors flex-shrink-0"
+        style={{ color: C.muted }}
+        title="Close search (Esc)"
+        aria-label="Close search"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+});

--- a/app/client/src/hooks/use-contact-search.ts
+++ b/app/client/src/hooks/use-contact-search.ts
@@ -1,0 +1,124 @@
+import { useMemo } from "react";
+import MiniSearch from "minisearch";
+import type { ContactWithRelations } from "@shared/schema";
+
+/**
+ * Frontend full-text search over contacts using MiniSearch (BM25).
+ *
+ * Lazy: the index is only constructed once `enabled` becomes true (i.e. the
+ * search input has been opened at least once). After that, it rebuilds
+ * whenever the `contacts` array reference changes — react-query swaps the
+ * reference on refetch / SSE-driven invalidation, so this stays fresh
+ * automatically.
+ *
+ * One document per contact. Non-contact fields (interactions, followups,
+ * briefing) are flattened into a `body` blob so a hit on any of them ranks
+ * the parent contact. relationshipJournal is intentionally excluded — it can
+ * be long enough to dominate ranking.
+ */
+export interface ContactSearch {
+  search: (query: string) => ContactWithRelations[];
+  ready: boolean;
+}
+
+interface IndexedDoc {
+  id: number;
+  firstName: string;
+  lastName: string;
+  title: string;
+  email: string;
+  phone: string;
+  location: string;
+  source: string;
+  additionalContacts: string;
+  background: string;
+  companyName: string;
+  companyNotes: string;
+  companyWebsite: string;
+  body: string;
+}
+
+function toDoc(c: ContactWithRelations): IndexedDoc {
+  const interactions = c.interactions.map((i) => i.content).join("\n");
+  const followups = c.followups.map((f) => f.content).join("\n");
+  const briefing = c.briefing?.content ?? "";
+  return {
+    id: c.id,
+    firstName: c.firstName ?? "",
+    lastName: c.lastName ?? "",
+    title: c.title ?? "",
+    email: c.email ?? "",
+    phone: c.phone ?? "",
+    location: c.location ?? "",
+    source: c.source ?? "",
+    additionalContacts: c.additionalContacts ?? "",
+    background: c.background ?? "",
+    companyName: c.company?.name ?? "",
+    companyNotes: c.company?.notes ?? "",
+    companyWebsite: c.company?.website ?? "",
+    body: [interactions, followups, briefing].filter(Boolean).join("\n"),
+  };
+}
+
+const SEARCH_FIELDS: (keyof IndexedDoc)[] = [
+  "firstName",
+  "lastName",
+  "title",
+  "email",
+  "phone",
+  "location",
+  "source",
+  "additionalContacts",
+  "background",
+  "companyName",
+  "companyNotes",
+  "companyWebsite",
+  "body",
+];
+
+const BOOST = {
+  firstName: 5,
+  lastName: 5,
+  companyName: 5,
+  title: 2,
+  email: 2,
+} as const;
+
+interface IndexBundle {
+  mini: MiniSearch<IndexedDoc>;
+  lookup: Map<number, ContactWithRelations>;
+}
+
+export function useContactSearch(contacts: ContactWithRelations[] | undefined, enabled: boolean): ContactSearch {
+  const bundle = useMemo<IndexBundle | null>(() => {
+    if (!enabled || !contacts || contacts.length === 0) return null;
+    const lookup = new Map<number, ContactWithRelations>();
+    for (const c of contacts) lookup.set(c.id, c);
+    const mini = new MiniSearch<IndexedDoc>({
+      fields: SEARCH_FIELDS as string[],
+      storeFields: ["id"],
+      idField: "id",
+    });
+    mini.addAll(contacts.map(toDoc));
+    return { mini, lookup };
+  }, [enabled, contacts]);
+
+  return {
+    ready: bundle !== null,
+    search: (query: string) => {
+      const q = query.trim();
+      if (!q || !bundle) return [];
+      const hits = bundle.mini.search(q, {
+        prefix: true,
+        fuzzy: 0.2,
+        boost: BOOST,
+      });
+      const out: ContactWithRelations[] = [];
+      for (const hit of hits) {
+        const c = bundle.lookup.get(hit.id as number);
+        if (c) out.push(c);
+      }
+      return out;
+    },
+  };
+}

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -1,9 +1,11 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useCrm } from "@/hooks/use-crm";
 import { useSSE } from "@/hooks/use-sse";
 import { useAuth } from "@/hooks/use-auth";
+import { useContactSearch } from "@/hooks/use-contact-search";
 import { ContactBlock } from "@/components/contact-block";
+import { SearchBar } from "@/components/search-bar";
 import {
   Loader2,
   LogOut,
@@ -65,7 +67,28 @@ export default function CrmPage() {
   }, [viewMode]);
   const [showFilter, setShowFilter] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
+  // Search state — lives at the CrmPage level because it overrides
+  // displayedContacts and forces list view while a query is active.
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const { search } = useContactSearch(contacts, searchOpen);
   useSSE();
+
+  // Global Cmd+K (Ctrl+K elsewhere) opens search from anywhere on the page.
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setSearchOpen(true);
+        // focus on next tick so the input has mounted
+        requestAnimationFrame(() => searchInputRef.current?.focus());
+      }
+    }
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
 
   const sortedContacts = useMemo(() => {
     const sorted = [...contacts].sort((a, b) => {
@@ -110,6 +133,38 @@ export default function CrmPage() {
   }, [contacts]);
 
   const kanbanContacts = useMemo(() => contacts.filter((c) => c.status !== "HOLD"), [contacts]);
+
+  // Search results override the normal pipeline view when a query is active.
+  // Per spec ("search overrides everything"): we ignore the stage filter and
+  // force list mode while results are showing.
+  const trimmedQuery = searchQuery.trim();
+  const searchResults = useMemo(() => (trimmedQuery ? search(trimmedQuery) : null), [search, trimmedQuery]);
+  const isSearching = searchResults !== null;
+  const displayedContacts = isSearching ? searchResults : filteredContacts;
+  const effectiveViewMode = isSearching ? "list" : viewMode;
+
+  // Clamp the keyboard highlight whenever the result set shrinks.
+  useEffect(() => {
+    if (highlightedIndex >= displayedContacts.length) {
+      setHighlightedIndex(Math.max(0, displayedContacts.length - 1));
+    }
+  }, [displayedContacts.length, highlightedIndex]);
+
+  // Scroll the highlighted contact into view as the user arrow-keys through
+  // results. Mirrors the kanban onContactTap polling approach.
+  useEffect(() => {
+    if (!isSearching) return;
+    const target = displayedContacts[highlightedIndex];
+    if (!target) return;
+    const el = document.getElementById(`contact-${target.id}`);
+    if (el) el.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [isSearching, highlightedIndex, displayedContacts]);
+
+  const closeSearch = () => {
+    setSearchOpen(false);
+    setSearchQuery("");
+    setHighlightedIndex(0);
+  };
 
   // Follow-ups due within N days (including overdue), sorted by due date
   const allFollowups = useMemo(() => {
@@ -171,23 +226,43 @@ export default function CrmPage() {
     <div className="min-h-screen" style={{ backgroundColor: "#f0f8f8" }}>
       {/* Header */}
       <header className="sticky top-0 z-50 bg-white" style={{ borderBottom: `1px solid ${C.border}` }}>
-        <div className="max-w-[640px] mx-auto px-4 py-3 flex items-center justify-between">
-          <h1 className="text-[13px] font-semibold tracking-[0.2em] uppercase" style={{ color: C.text }}>
-            {orgName}
-          </h1>
-          <div className="flex items-center gap-0.5 relative">
-            {/* Filter button */}
-            <button
-              onClick={() => {
-                setShowFilter(!showFilter);
+        <div className="max-w-[640px] mx-auto px-4 py-3 flex items-center justify-between gap-2">
+          {!searchOpen && (
+            <h1 className="text-[13px] font-semibold tracking-[0.2em] uppercase" style={{ color: C.text }}>
+              {orgName}
+            </h1>
+          )}
+          <div className={`flex items-center gap-0.5 relative ${searchOpen ? "flex-1" : ""}`}>
+            <SearchBar
+              ref={searchInputRef}
+              open={searchOpen}
+              query={searchQuery}
+              onQueryChange={setSearchQuery}
+              onOpen={() => {
+                setSearchOpen(true);
+                setShowFilter(false);
                 setShowMenu(false);
+                requestAnimationFrame(() => searchInputRef.current?.focus());
               }}
-              className="p-2 transition-colors"
-              style={{ color: activeStage !== "ALL" ? C.accent : C.muted }}
-              title="Filter by stage"
-            >
-              <SlidersHorizontal className="h-4 w-4" />
-            </button>
+              onClose={closeSearch}
+              onEnter={() => searchInputRef.current?.blur()}
+              onArrowDown={() => setHighlightedIndex((i) => Math.min(displayedContacts.length - 1, i + 1))}
+              onArrowUp={() => setHighlightedIndex((i) => Math.max(0, i - 1))}
+            />
+            {/* Filter button — hidden while searching to give the input room */}
+            {!searchOpen && (
+              <button
+                onClick={() => {
+                  setShowFilter(!showFilter);
+                  setShowMenu(false);
+                }}
+                className="p-2 transition-colors"
+                style={{ color: activeStage !== "ALL" ? C.accent : C.muted }}
+                title="Filter by stage"
+              >
+                <SlidersHorizontal className="h-4 w-4" />
+              </button>
+            )}
 
             {/* Menu button */}
             <button
@@ -386,7 +461,7 @@ export default function CrmPage() {
         </div>
       )}
 
-      {viewMode === "kanban" ? (
+      {effectiveViewMode === "kanban" ? (
         <KanbanBoard
           contacts={kanbanContacts}
           updateContact={updateContact}
@@ -621,27 +696,38 @@ export default function CrmPage() {
           )}
 
           {/* Contact cards */}
-          {filteredContacts.map((contact) => (
-            <ContactBlock
-              key={contact.id}
-              contact={contact}
-              onAddInteraction={(content, date, type) =>
-                addInteraction.mutate({ contactId: contact.id, content, date, type })
-              }
-              onUpdateInteraction={(id, data) => updateInteraction.mutate({ id, ...data })}
-              onDeleteInteraction={(id) => deleteInteraction.mutate(id)}
-              onCreateFollowup={(content, dueDate, opts) =>
-                createFollowup.mutate({ contactId: contact.id, content, dueDate, ...opts })
-              }
-              onUpdateFollowup={(id, data) => updateFollowup.mutate({ id, ...data })}
-              onDeleteFollowup={(id) => deleteFollowup.mutate(id)}
-              onCompleteFollowup={(id, outcome) => completeFollowup.mutate({ id, outcome })}
-              onUpdateContact={(data) => updateContact.mutate({ id: contact.id, ...data })}
-            />
-          ))}
-          {filteredContacts.length === 0 && (
+          {displayedContacts.map((contact, idx) => {
+            const isHighlighted = isSearching && idx === highlightedIndex;
+            return (
+              <div
+                key={contact.id}
+                className="rounded-[10px]"
+                style={{
+                  boxShadow: isHighlighted ? `0 0 0 2px ${C.accent}` : undefined,
+                  transition: "box-shadow 120ms ease-out",
+                }}
+              >
+                <ContactBlock
+                  contact={contact}
+                  onAddInteraction={(content, date, type) =>
+                    addInteraction.mutate({ contactId: contact.id, content, date, type })
+                  }
+                  onUpdateInteraction={(id, data) => updateInteraction.mutate({ id, ...data })}
+                  onDeleteInteraction={(id) => deleteInteraction.mutate(id)}
+                  onCreateFollowup={(content, dueDate, opts) =>
+                    createFollowup.mutate({ contactId: contact.id, content, dueDate, ...opts })
+                  }
+                  onUpdateFollowup={(id, data) => updateFollowup.mutate({ id, ...data })}
+                  onDeleteFollowup={(id) => deleteFollowup.mutate(id)}
+                  onCompleteFollowup={(id, outcome) => completeFollowup.mutate({ id, outcome })}
+                  onUpdateContact={(data) => updateContact.mutate({ id: contact.id, ...data })}
+                />
+              </div>
+            );
+          })}
+          {displayedContacts.length === 0 && (
             <p className="text-center py-16 text-sm" style={{ color: C.muted }}>
-              No contacts in this stage
+              {isSearching ? "No contacts match your search" : "No contacts in this stage"}
             </p>
           )}
         </main>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -46,6 +46,7 @@
         "express": "^4.21.2",
         "express-session": "^1.18.1",
         "lucide-react": "^0.453.0",
+        "minisearch": "^7.2.0",
         "pg": "^8.20.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -8849,6 +8850,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
     },
     "node_modules/mitt": {
       "version": "3.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -56,6 +56,7 @@
     "express": "^4.21.2",
     "express-session": "^1.18.1",
     "lucide-react": "^0.453.0",
+    "minisearch": "^7.2.0",
     "pg": "^8.20.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/app/tests/search.spec.ts
+++ b/app/tests/search.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+
+// Frontend MiniSearch (BM25) over contacts + their flattened interactions /
+// followups / briefing. Tests assume the demo seed data (PIN 1234) — Sarah
+// Chen exists and her interactions contain "kicking".
+
+test.describe("Cmd+K full-text search", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/auth");
+    await page.locator('input[type="password"]').fill("1234");
+    await page.locator("button", { hasText: "Unlock" }).click();
+    await expect(page.locator("text=Upcoming")).toBeVisible({ timeout: 5000 });
+  });
+
+  test("Cmd+K opens the search input and Esc closes it", async ({ page }) => {
+    await page.keyboard.press("Meta+K");
+    const input = page.locator('input[aria-label="Search contacts"]');
+    await expect(input).toBeFocused();
+
+    await page.keyboard.press("Escape");
+    await expect(input).toHaveCount(0);
+  });
+
+  test("typing a name filters contacts with the named one ranked first", async ({ page }) => {
+    await page.keyboard.press("Meta+K");
+    const input = page.locator('input[aria-label="Search contacts"]');
+    await input.fill("sarah");
+
+    const names = page.locator("main h2");
+    await expect(names.first()).toHaveText("Sarah Chen", { timeout: 2000 });
+  });
+
+  test("typing a word that only appears in one contact's interactions finds them", async ({
+    page,
+  }) => {
+    await page.keyboard.press("Meta+K");
+    const input = page.locator('input[aria-label="Search contacts"]');
+    // "kicking" only appears in Sarah Chen's interactions in the seed data.
+    await input.fill("kicking");
+
+    const names = page.locator("main h2");
+    await expect(names).toHaveCount(1);
+    await expect(names.first()).toHaveText("Sarah Chen");
+  });
+
+  test("ArrowDown moves the highlight ring; Esc clears + restores the full list", async ({
+    page,
+  }) => {
+    await page.keyboard.press("Meta+K");
+    const input = page.locator('input[aria-label="Search contacts"]');
+    await input.fill("sarah");
+
+    // At least two matches expected (name + body hits across seed data).
+    const names = page.locator("main h2");
+    const initialCount = await names.count();
+    expect(initialCount).toBeGreaterThanOrEqual(1);
+
+    if (initialCount >= 2) {
+      await page.keyboard.press("ArrowDown");
+      // The second result should now have a teal ring (box-shadow).
+      const ringed = page.locator('main div[style*="box-shadow"]');
+      await expect(ringed.first()).toBeVisible();
+    }
+
+    await page.keyboard.press("Escape");
+    await expect(input).toHaveCount(0);
+    // Full list restored — there are 8 seed contacts.
+    await expect(names).toHaveCount(8);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a magnifying-glass icon to the top nav (left of Filter + Menu). Clicking it or pressing **⌘K / Ctrl+K** opens an inline input that replaces the org name and live-filters the contact list as you type.
- Index is [MiniSearch](https://github.com/lucaong/minisearch) (BM25), one doc per contact with `interactions` + `followups` + `briefing.content` flattened into a `body` field. Name and company fields are boosted 5×; prefix + fuzzy (0.2) matching. `relationshipJournal` is intentionally excluded (length would dominate ranking).
- Search overrides stage filter and forces list view while a query is active. `↑`/`↓` move a teal highlight ring (with `scrollIntoView`), `Enter` blurs but keeps the filter, `Esc` clears and collapses. Index is built lazily on first open and memoized against the contacts array reference, so SSE-driven invalidations refresh it for free.
- All changes are client-side — no schema, no endpoint, no boot-migration touched.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` clean (`--max-warnings 0`)
- [x] `npm run test` — 13/13 pass, including 4 new specs in `tests/search.spec.ts`
- [x] Manual verification at `http://localhost:3000`: Cmd+K opens, name search ranks the named contact first, body-content search (`kicking` → Sarah Chen) works, ArrowDown rings the next card, Esc restores full list
- [x] E2E step added to `.claude/skills/e2e-test/SKILL.md` (step 5b)
- [x] README updated with new "Keyboard Shortcuts" section
- [x] CHANGELOG entry under 2026-05-28

🤖 Generated with [Claude Code](https://claude.com/claude-code)