### PR TITLE
Remove journal size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-05-30
+
+### Remove journal size limit
+Dropped the 100k-char ceiling on `relationshipJournal`. The guard fired three places — `storage.updateRelationshipJournal`, MCP `append_journal`, MCP `batch_append_journal` — and was the original justification for the "compact older entries" pressure on the agent. Postgres `text` has no practical size limit and the destructive-edit guard still protects against accidental wipes. The `JOURNAL_SIZE_LIMIT` constant and `"size_limit"` failure reason are gone; the in-app "X chars" indicator stays (it's a counter, not a cap).
+
 ## 2026-05-28
 
 ### Frontend full-text search with Cmd+K

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -23,7 +23,6 @@ import {
   validateJournalContent,
   appendJournalEntry,
   hashJournal,
-  JOURNAL_SIZE_LIMIT,
   isReasonableIsoDate,
   peekLastEntry,
   readJournalSection,
@@ -1557,22 +1556,6 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
           : (contact.relationshipJournal as string);
         const { updated, entryHeading } = appendJournalEntry(baseDoc, title, body, date);
 
-        if (updated.length > JOURNAL_SIZE_LIMIT) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: JSON.stringify({
-                  ok: false,
-                  reason: "size_limit",
-                  message: `Journal would exceed ${JOURNAL_SIZE_LIMIT} chars. Compact older Entries — capture more context per character.`,
-                }),
-              },
-            ],
-            isError: true,
-          };
-        }
-
         const result = await storage.updateRelationshipJournal(contactId, updated, {
           source: "agent",
           skipDestructiveGuard: true,
@@ -1686,22 +1669,6 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
           const { updated, entryHeading } = appendJournalEntry(doc, e.title, e.body, e.date);
           doc = updated;
           headings.push(entryHeading);
-        }
-
-        if (doc.length > JOURNAL_SIZE_LIMIT) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: JSON.stringify({
-                  ok: false,
-                  reason: "size_limit",
-                  message: `Batch would push journal past ${JOURNAL_SIZE_LIMIT} chars. Trim prose or split into smaller batches.`,
-                }),
-              },
-            ],
-            isError: true,
-          };
         }
 
         const result = await storage.updateRelationshipJournal(contactId, doc, {

--- a/app/server/storage.ts
+++ b/app/server/storage.ts
@@ -25,7 +25,7 @@ import {
   contactJournalRevisions,
   type ContactJournalRevision,
 } from "@shared/schema";
-import { hashJournal, isDestructiveChange, JOURNAL_SIZE_LIMIT } from "@shared/journal";
+import { hashJournal, isDestructiveChange } from "@shared/journal";
 import session from "express-session";
 import connectPg from "connect-pg-simple";
 import { db } from "./db";
@@ -452,7 +452,7 @@ export class Storage {
     | { ok: true; newHash: string; newSize: number }
     | {
         ok: false;
-        reason: "not_found" | "hash_conflict" | "size_limit" | "destructive_edit";
+        reason: "not_found" | "hash_conflict" | "destructive_edit";
         message: string;
         currentHash?: string;
       }
@@ -470,14 +470,6 @@ export class Storage {
         reason: "hash_conflict",
         message: "Journal has changed since your last read. Re-read and retry with the fresh hash.",
         currentHash,
-      };
-    }
-
-    if (newContent.length > JOURNAL_SIZE_LIMIT) {
-      return {
-        ok: false,
-        reason: "size_limit",
-        message: `Journal would exceed ${JOURNAL_SIZE_LIMIT} chars (attempted ${newContent.length}). Compact older Entries or tighten prose. Every word earns its place.`,
       };
     }
 

--- a/app/shared/journal.ts
+++ b/app/shared/journal.ts
@@ -3,7 +3,6 @@
 
 import { createHash } from "node:crypto";
 
-export const JOURNAL_SIZE_LIMIT = 100_000;
 // Fraction of the doc that can shrink without tripping destructive_edit.
 // Raised from 0.20 to 0.40 — cleanups ("remove one test entry") were hitting the gate.
 export const DESTRUCTIVE_SHRINK_THRESHOLD = 0.4;


### PR DESCRIPTION
## Summary
- Drops the 100k-char ceiling on `relationshipJournal`. Postgres `text` has no practical size limit and the destructive-edit guard still protects against accidental wipes.
- Removes the `JOURNAL_SIZE_LIMIT` constant and `"size_limit"` failure reason from three call sites: `storage.updateRelationshipJournal`, MCP `append_journal`, MCP `batch_append_journal`.
- The in-app "X chars" indicator stays — it's a counter, not a cap.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint:fix` clean
- [x] E2E: UI login + note add via Elena's input — persisted to timeline
- [x] E2E: MCP `append_journal` returns `ok:true` on a normal entry
- [x] E2E: MCP `append_journal` returns `ok:true` on a 105,869-char body (formerly blocked at 100k)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)