### PR TITLE
Fix #123: strip leading `to <date>` prefix from journal titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-05-31
 
+### Strip leading `to <date>` prefix from journal titles
+Extended `stripDatePrefix` in `app/shared/journal.ts` to drop a leading `to ` / `to:` token when it sits in front of an absolute date — the back half of a `from X to Y` date range that occasionally leaked into journal entry titles (e.g. `to 2026-05-28: Imbik clears noise threshold...` → `Imbik clears noise threshold...`). Also broadened the post-date separator to accept em/en dashes alongside colons so titles like `to 2026-05-13 — telemetry...` get fully cleaned. Bare titles that happen to start with `to ...` (no following date) pass through untouched.
+
 ### Scrub embedded entry-date from journal titles
 Server-side defense-in-depth against doubled `### YYYY-MM-DD: YYYY-MM-DD ...` journal headings. `appendJournalEntry` already stripped a leading date prefix; it now also scrubs any standalone occurrence of the effective entry date elsewhere inside the title (e.g. writers passing `"Josh warmly re-engaged 2026-05-22; partner Barry"` on an entry dated `2026-05-22`). Unrelated dates in the title are left alone. New helper `scrubEntryDateFromTitle` in `app/shared/journal.ts`.
 

--- a/app/shared/journal.ts
+++ b/app/shared/journal.ts
@@ -329,22 +329,45 @@ export function todayIso(): string {
  * double-dated headings like `### 2026-05-10: 2026-05-10: Foo`. Stripped
  * silently — no existing valid title format starts with one of these
  * date+colon patterns, so this is purely additive cleanup.
+ *
+ * Also strips a leading `to ` / `to:` token in front of the date — this
+ * is the back half of a `from X to Y` date range leaking into the title
+ * (e.g. `to 2026-05-28: Imbik clears noise threshold...`). The leading
+ * `to` is meaningless without its `from` partner, so we drop it along
+ * with the date.
  */
 export function stripDatePrefix(title: string): string {
-  const t = title.trim();
+  // Drop a leading `to` / `to:` token (with optional trailing separator)
+  // that sits in front of an absolute date. Only stripped when followed
+  // by a date — bare titles that happen to start with "to ..." pass
+  // through untouched.
+  const t = title
+    .trim()
+    .replace(
+      /^to\b\s*[:-]?\s*(?=\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}\/\d{4}|(?:january|february|march|april|may|june|july|august|september|october|november|december)\b|Q[1-4]\s+\d{4}|(?:spring|summer|fall|autumn|winter)\s+\d{4})/i,
+      "",
+    );
   // Patterns mirror the absolute-date allow-list; each anchored to start
-  // and tolerates a trailing colon + whitespace before the actual title.
+  // and tolerates a trailing colon, dash, or em/en dash + whitespace
+  // before the actual title.
+  const sep = `\\s*[:\\-–—]?\\s*`;
   const patterns = [
-    // 2026-05-10 / 2026-05-10:
-    /^\d{4}-\d{2}-\d{2}\s*:?\s*/,
+    // 2026-05-10 / 2026-05-10: / 2026-05-10 —
+    new RegExp(`^\\d{4}-\\d{2}-\\d{2}${sep}`),
     // 5/10/2026 / 05/10/2026:
-    /^\d{1,2}\/\d{1,2}\/\d{4}\s*:?\s*/,
+    new RegExp(`^\\d{1,2}\\/\\d{1,2}\\/\\d{4}${sep}`),
     // May 10, 2026 / May 10 2026:
-    /^(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{1,2},?\s+\d{4}\s*:?\s*/i,
+    new RegExp(
+      `^(?:january|february|march|april|may|june|july|august|september|october|november|december)\\s+\\d{1,2},?\\s+\\d{4}${sep}`,
+      "i",
+    ),
     // August 2025 / Q3 2025 / Spring 2026 — year-only or coarse anchors used as title prefixes
-    /^(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{4}\s*:?\s*/i,
-    /^Q[1-4]\s+\d{4}\s*:?\s*/i,
-    /^(?:spring|summer|fall|autumn|winter)\s+\d{4}\s*:?\s*/i,
+    new RegExp(
+      `^(?:january|february|march|april|may|june|july|august|september|october|november|december)\\s+\\d{4}${sep}`,
+      "i",
+    ),
+    new RegExp(`^Q[1-4]\\s+\\d{4}${sep}`, "i"),
+    new RegExp(`^(?:spring|summer|fall|autumn|winter)\\s+\\d{4}${sep}`, "i"),
   ];
   for (const re of patterns) {
     if (re.test(t)) return t.replace(re, "").trim();


### PR DESCRIPTION
## Summary
- `stripDatePrefix` in `app/shared/journal.ts` now drops a leading `to ` / `to:` token when followed by an absolute date — the leaked back half of a `from X to Y` date range.
- Broadened the date-prefix separator to also accept em/en dashes (third issue example used `2026-05-13 — telemetry...`).
- Bare titles starting with `to ...` (no date) are untouched.

Closes #123.

## Test plan
- [x] Ran `npm run lint:fix && npm run format && npm run build` from `app/` — all green.
- [x] Spot-checked the three issue examples plus a few edge cases via `tsx` REPL:
  - `to 2026-05-28: Imbik clears noise threshold xyz` → `Imbik clears noise threshold xyz`
  - `to 2026-05-13 — telemetry, Shadow Browser` → `telemetry, Shadow Browser`
  - `to:2026-05-28 Imbik` → `Imbik`
  - `Going to 2026-05-28 conference` (mid-title `to`) → unchanged by `stripDatePrefix`
  - `Pure title with no date` → unchanged
- [ ] No E2E added — the change is a pure-string helper exercised through MCP `append_journal`, not surfaced through a UI flow. Existing journal E2E already covers the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)