### PR TITLE
Fix #124: reject forward-verb content on add_interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-05-31
 
+### Reject forward-verb content on `add_interaction`
+Server-side guard against the tasks-as-interactions dual-write pattern (#124). Writers were logging imperative-mood content like `Send proposal to X`, `Follow up with Y`, `Check for Sal Velasco reply` as both a `note`-type interaction AND a followup task — the interaction was pure noise since the action belongs only in the tasks layer. `add_interaction` (both the remote MCP endpoint in `app/server/mcp-remote.ts` and the stdio variant in `app/server/mcp-server.ts`) now rejects `note`-type content whose trimmed body starts with a curated imperative verb (`send`, `follow up`, `check`, `reach out`, `schedule`, `prep`, `draft`, `remind`, `confirm`, `circle back`, `loop in`, `introduce`, `set up`, `book`). Typed interactions (`meeting`/`email`/`call`) are untouched — those are explicit past-event records. The rejection message tells the caller to switch to `create_task`, or rephrase in past tense. New helper `looksLikeForwardAction` in `app/shared/interactions.ts`.
+
 ### Strip leading `to <date>` prefix from journal titles
 Extended `stripDatePrefix` in `app/shared/journal.ts` to drop a leading `to ` / `to:` token when it sits in front of an absolute date — the back half of a `from X to Y` date range that occasionally leaked into journal entry titles (e.g. `to 2026-05-28: Imbik clears noise threshold...` → `Imbik clears noise threshold...`). Also broadened the post-date separator to accept em/en dashes alongside colons so titles like `to 2026-05-13 — telemetry...` get fully cleaned. Bare titles that happen to start with `to ...` (no following date) pass through untouched.
 

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -41,6 +41,7 @@ import {
   getBriefingStaleness,
   briefingAgeDays,
 } from "@shared/briefing";
+import { looksLikeForwardAction } from "@shared/interactions";
 import { db } from "./db";
 import { eq, and, isNull, gte, lte, asc, sql } from "drizzle-orm";
 import { sseManager } from "./sse";
@@ -619,6 +620,21 @@ Do NOT log follow-up tasks here — use create_task for those.`,
     },
     async ({ contactId, content, date, type }) => {
       try {
+        // Guard against the tasks-as-interactions dual-write pattern (#124).
+        // Imperative-mood content ("Send proposal to X", "Follow up with Y")
+        // belongs in the tasks layer, not the timeline. Reject before write
+        // so the caller switches to create_task instead of producing both.
+        if ((type ?? "note") === "note" && looksLikeForwardAction(content)) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Rejected: content "${content.slice(0, 80)}${content.length > 80 ? "…" : ""}" reads as a forward-looking action item, not a past-tense interaction. Use create_task for action items. If this really is a past event, rephrase in past tense (e.g. "Sent proposal" instead of "Send proposal").`,
+              },
+            ],
+            isError: true,
+          };
+        }
         const i = await storage.createInteraction({
           contactId,
           content,

--- a/app/server/mcp-server.ts
+++ b/app/server/mcp-server.ts
@@ -12,6 +12,7 @@ import {
   CONDITION_TYPES,
   EXCEPTION_TYPES,
 } from "@shared/schema";
+import { looksLikeForwardAction } from "@shared/interactions";
 
 // Zod enums from shared constants
 const stageEnum = z.enum(STAGES);
@@ -196,6 +197,18 @@ server.tool(
   },
   async ({ contactId, content, date, type }) => {
     try {
+      // Guard against the tasks-as-interactions dual-write pattern (#124).
+      if ((type ?? "note") === "note" && looksLikeForwardAction(content)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Rejected: content "${content.slice(0, 80)}${content.length > 80 ? "…" : ""}" reads as a forward-looking action item, not a past-tense interaction. Use create_task for action items. If this really is a past event, rephrase in past tense (e.g. "Sent proposal" instead of "Send proposal").`,
+            },
+          ],
+          isError: true,
+        };
+      }
       const interaction = await storage.createInteraction({
         contactId,
         content,

--- a/app/shared/interactions.ts
+++ b/app/shared/interactions.ts
@@ -1,0 +1,55 @@
+// Shared validators for interaction content.
+//
+// Interactions are the timeline of things that HAVE happened — past-tense,
+// factual records. Forward-looking action items belong in the tasks layer
+// (followups of type "task"). Writers occasionally dual-write the same
+// imperative-mood content as both an interaction and a task; the interaction
+// is then noise. See issue #124.
+//
+// We don't reject — that would block legitimate edge cases (a quoted email
+// that happens to start "Send me the deck"). Instead we surface a soft
+// warning the MCP caller can choose to honor.
+
+// Verbs that, at the *start* of an interaction body, strongly signal a
+// forward-looking action item ("Send X", "Follow up with Y") rather than a
+// past-tense record of something that happened. Kept tight: every verb here
+// must be a clear imperative in business-CRM context with low risk of
+// colliding with a noun-form opener ("Email from Bobby...", "Call notes:..."
+// would false-positive — those verbs are excluded). Past-tense variants
+// (e.g. "Sent proposal", "Followed up") are intentionally excluded too.
+const IMPERATIVE_VERBS = [
+  "send",
+  "follow up",
+  "followup",
+  "check",
+  "reach out",
+  "schedule",
+  "prep",
+  "prepare",
+  "draft",
+  "remind",
+  "confirm",
+  "circle back",
+  "loop in",
+  "introduce",
+  "set up",
+  "book",
+] as const;
+
+const IMPERATIVE_RE = new RegExp(`^\\s*(?:${IMPERATIVE_VERBS.map((v) => v.replace(/ /g, "\\s+")).join("|")})\\b`, "i");
+
+/**
+ * Heuristic: does `content` look like a forward-looking action item rather
+ * than a past-tense interaction record? Matches when the trimmed content
+ * starts with an imperative verb from the curated list. Case-insensitive.
+ *
+ * Note: this is a soft signal. Some legitimate past-tense narration can
+ * begin with these tokens (e.g. "Email from Bobby arrived"); the caller
+ * should treat the result as a nudge, not a hard reject.
+ */
+export function looksLikeForwardAction(content: string): boolean {
+  if (!content) return false;
+  return IMPERATIVE_RE.test(content);
+}
+
+export const IMPERATIVE_VERB_LIST = IMPERATIVE_VERBS;


### PR DESCRIPTION
## Summary
Server-side defense-in-depth against the tasks-as-interactions dual-write pattern (#124). Writers were logging imperative-mood content like `Send proposal to X`, `Follow up with Y`, `Check for Sal Velasco reply` as both a `note`-type interaction AND a followup task — the interaction was pure noise since the action belongs only in the tasks layer.

`add_interaction` (both remote MCP endpoint and stdio variant) now rejects `note`-type content whose trimmed body starts with a curated imperative verb. The rejection message nudges the caller to switch to `create_task` or rephrase in past tense. Typed interactions (`meeting` / `email` / `call`) are untouched — those are explicit past-event records.

New helper `looksLikeForwardAction` in `app/shared/interactions.ts`. Verb list is intentionally tight to avoid false positives on noun-form openers (`Email from Bobby…`, `Call notes:…`).

Closes #124.

## Test plan
- [x] `npm run lint:fix` clean
- [x] `npm run format` clean
- [x] `npm run build` succeeds
- [ ] E2E skipped: existing E2E suite doesn't exercise MCP `add_interaction` directly. Change is a pure server-side validator on the MCP tool surface, with no UI / DB / migration impact. The dual-write defect surfaces in agent-driven writes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)