### PR TITLE
Fix #125: reject same-day note paraphrases of typed interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-05-31
 
+### Reject same-day note paraphrases of typed interactions
+Server-side guard against the paraphrase dual-write pattern (#125). Writers were logging a typed interaction (meeting/email/call) for an event and then *also* writing a `note` on the same date that restated the same content in fewer words — the note was pure noise. `add_interaction` (both `app/server/mcp-remote.ts` and `app/server/mcp-server.ts`) now scans existing same-day typed interactions for the contact and rejects a `note` write that shares ≥3 proper nouns with any of them. Threshold tuned to require enough overlap that the note is clearly the *same* event; bumping a generic note ("AF processed inbox") never trips it. New helpers `extractProperNouns`, `sharesProperNouns`, `sameUTCDate` in `app/shared/interactions.ts`.
+
 ### Reject forward-verb content on `add_interaction`
 Server-side guard against the tasks-as-interactions dual-write pattern (#124). Writers were logging imperative-mood content like `Send proposal to X`, `Follow up with Y`, `Check for Sal Velasco reply` as both a `note`-type interaction AND a followup task — the interaction was pure noise since the action belongs only in the tasks layer. `add_interaction` (both the remote MCP endpoint in `app/server/mcp-remote.ts` and the stdio variant in `app/server/mcp-server.ts`) now rejects `note`-type content whose trimmed body starts with a curated imperative verb (`send`, `follow up`, `check`, `reach out`, `schedule`, `prep`, `draft`, `remind`, `confirm`, `circle back`, `loop in`, `introduce`, `set up`, `book`). Typed interactions (`meeting`/`email`/`call`) are untouched — those are explicit past-event records. The rejection message tells the caller to switch to `create_task`, or rephrase in past tense. New helper `looksLikeForwardAction` in `app/shared/interactions.ts`.
 

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -41,7 +41,7 @@ import {
   getBriefingStaleness,
   briefingAgeDays,
 } from "@shared/briefing";
-import { looksLikeForwardAction } from "@shared/interactions";
+import { looksLikeForwardAction, sameUTCDate, sharesProperNouns } from "@shared/interactions";
 import { db } from "./db";
 import { eq, and, isNull, gte, lte, asc, sql } from "drizzle-orm";
 import { sseManager } from "./sse";
@@ -635,10 +635,36 @@ Do NOT log follow-up tasks here — use create_task for those.`,
             isError: true,
           };
         }
+        const interactionDate = date ? toNoonUTC(date) : toNoonUTC(new Date());
+        // Guard against same-day paraphrase of a typed interaction (#125).
+        // If a note shares ≥3 proper nouns with an existing meeting/email/call
+        // on the same date for this contact, it is almost certainly a
+        // restatement and should not be written.
+        if ((type ?? "note") === "note") {
+          const existing = await storage.getInteractions(contactId);
+          const sameDayTyped = existing.filter((i) => i.type !== "note" && sameUTCDate(i.date, interactionDate));
+          if (
+            sameDayTyped.length > 0 &&
+            sharesProperNouns(
+              content,
+              sameDayTyped.map((i) => i.content),
+            )
+          ) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `Rejected: this note appears to paraphrase a same-day ${sameDayTyped[0].type} interaction already logged for contact ${contactId}. Edit the existing typed interaction instead of adding a duplicate note.`,
+                },
+              ],
+              isError: true,
+            };
+          }
+        }
         const i = await storage.createInteraction({
           contactId,
           content,
-          date: date ? toNoonUTC(date) : toNoonUTC(new Date()),
+          date: interactionDate,
           type: type || "note",
         });
         return { content: [{ type: "text" as const, text: `Logged ${i.type} for contact ${contactId}` }] };

--- a/app/server/mcp-server.ts
+++ b/app/server/mcp-server.ts
@@ -12,7 +12,7 @@ import {
   CONDITION_TYPES,
   EXCEPTION_TYPES,
 } from "@shared/schema";
-import { looksLikeForwardAction } from "@shared/interactions";
+import { looksLikeForwardAction, sameUTCDate, sharesProperNouns } from "@shared/interactions";
 
 // Zod enums from shared constants
 const stageEnum = z.enum(STAGES);
@@ -209,10 +209,32 @@ server.tool(
           isError: true,
         };
       }
+      const interactionDate = date ? new Date(date) : new Date();
+      // Guard against same-day paraphrase of a typed interaction (#125).
+      // If a note shares ≥3 proper nouns with an existing meeting/email/call
+      // on the same date for this contact, it is almost certainly a
+      // restatement and should not be written.
+      if ((type ?? "note") === "note") {
+        const existing = await storage.getInteractions(contactId);
+        const sameDayTyped = existing
+          .filter((i) => i.type !== "note" && sameUTCDate(i.date, interactionDate))
+          .map((i) => i.content);
+        if (sameDayTyped.length > 0 && sharesProperNouns(content, sameDayTyped)) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Rejected: this note appears to paraphrase a same-day ${existing.find((i) => i.type !== "note" && sameUTCDate(i.date, interactionDate))?.type ?? "typed"} interaction already logged for contact ${contactId}. Edit the existing typed interaction instead of adding a duplicate note.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
       const interaction = await storage.createInteraction({
         contactId,
         content,
-        date: date ? new Date(date) : new Date(),
+        date: interactionDate,
         type: type || "note",
       });
       return { content: [{ type: "text" as const, text: `Logged ${interaction.type} for contact ${contactId}` }] };

--- a/app/shared/interactions.ts
+++ b/app/shared/interactions.ts
@@ -53,3 +53,124 @@ export function looksLikeForwardAction(content: string): boolean {
 }
 
 export const IMPERATIVE_VERB_LIST = IMPERATIVE_VERBS;
+
+// --- Same-day paraphrase detector (issue #125) ---
+//
+// Writers sometimes log a typed interaction (meeting/email/call) for an event
+// and then *also* log a `note` paraphrasing it on the same date. The note is
+// pure noise — lower-signal restatement of the typed event. Detect by
+// comparing proper-noun overlap: capitalized multi-letter tokens that aren't
+// sentence-start function words. ≥3 shared proper nouns on the same
+// (contactId, date) is a strong paraphrase signal.
+
+// Common capitalized sentence-starters and short tokens we don't want to
+// count as proper nouns. Lowercased.
+const STOP_PROPER_NOUNS = new Set([
+  "the",
+  "a",
+  "an",
+  "and",
+  "or",
+  "but",
+  "if",
+  "then",
+  "he",
+  "she",
+  "they",
+  "we",
+  "i",
+  "it",
+  "this",
+  "that",
+  "these",
+  "those",
+  "his",
+  "her",
+  "their",
+  "our",
+  "my",
+  "your",
+  "af",
+  "ceo",
+  "cto",
+  "cfo",
+  "vp",
+  "svp",
+  "evp",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+  "sunday",
+  "january",
+  "february",
+  "march",
+  "april",
+  "may",
+  "june",
+  "july",
+  "august",
+  "september",
+  "october",
+  "november",
+  "december",
+  "yes",
+  "no",
+  "ok",
+  "okay",
+]);
+
+const PROPER_NOUN_RE = /\b[A-Z][a-zA-Z'-]{2,}\b/g;
+
+/**
+ * Extract candidate proper nouns from text. Returns a lowercased Set of
+ * tokens that look like proper nouns: capitalized, at least 3 chars, not in
+ * the stoplist. Case-insensitive comparison via lowercasing.
+ */
+export function extractProperNouns(text: string): Set<string> {
+  if (!text) return new Set();
+  const out = new Set<string>();
+  const matches = text.match(PROPER_NOUN_RE) ?? [];
+  for (const m of matches) {
+    const lower = m.toLowerCase();
+    if (!STOP_PROPER_NOUNS.has(lower)) out.add(lower);
+  }
+  return out;
+}
+
+/**
+ * Returns true if `noteContent` shares ≥`threshold` proper nouns with any
+ * provided `priorContents`. Used to detect a `note` that paraphrases a
+ * same-day typed interaction (meeting/email/call).
+ */
+export function sharesProperNouns(noteContent: string, priorContents: string[], threshold = 3): boolean {
+  const noteNouns = extractProperNouns(noteContent);
+  if (noteNouns.size < threshold) return false;
+  for (const prior of priorContents) {
+    const priorNouns = extractProperNouns(prior);
+    let overlap = 0;
+    for (const n of noteNouns) {
+      if (priorNouns.has(n)) {
+        overlap++;
+        if (overlap >= threshold) return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Same-day means the two interactions fall on the same calendar date in UTC.
+ * Interactions are stored at noon-UTC, so a simple yyyy-mm-dd compare works.
+ */
+export function sameUTCDate(a: Date | string, b: Date | string): boolean {
+  const da = typeof a === "string" ? new Date(a) : a;
+  const db = typeof b === "string" ? new Date(b) : b;
+  return (
+    da.getUTCFullYear() === db.getUTCFullYear() &&
+    da.getUTCMonth() === db.getUTCMonth() &&
+    da.getUTCDate() === db.getUTCDate()
+  );
+}


### PR DESCRIPTION
## Summary
Server-side defense against the same-day-paraphrase dual-write pattern (#125). Writers were logging a typed interaction (meeting/email/call) for an event and then writing a `note` on the same date that paraphrased it — lower-signal duplication.

`add_interaction` (both `app/server/mcp-remote.ts` and `app/server/mcp-server.ts`) now, when the incoming type is `note`, fetches existing same-UTC-date typed interactions for the contact and rejects the write if the note shares ≥3 proper nouns with any of them. The rejection nudges the caller to edit the existing typed entry instead.

New helpers in `app/shared/interactions.ts`:
- `extractProperNouns` — capitalized 3+ char tokens minus a stoplist of sentence-starters / weekdays / months / common initialisms.
- `sharesProperNouns(note, priors, threshold=3)` — set-intersection check, short-circuits once threshold met.
- `sameUTCDate(a, b)` — UTC y/m/d compare. Interactions are stored at noon-UTC so this is exact.

Threshold of 3 was chosen to match the issue's "≥3 proper nouns" spec — generic notes ("AF processed inbox") never trip it; concrete restatements of a logged event do.

Closes #125.

## Test plan
- [x] `npm run lint:fix` clean
- [x] `npm run format` clean
- [x] `npm run build` succeeds
- [ ] E2E skipped: existing E2E suite doesn't exercise MCP `add_interaction` directly. This is a pure server-side validator on the MCP tool surface with no UI / DB / migration impact — the defect only surfaces in agent-driven writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)