### PR TITLE
Fix #126: auto-cleanup stale briefings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-05-31
 
+### Auto-cleanup stale briefings
+Briefings whose linked meeting has been marked completed AND which are older than `BRIEFING_STALE_DAYS` (7) now get auto-deleted on a daily schedule (#126). New module `app/server/briefing-cleanup.ts` exposes `cleanupStaleBriefings()` plus `startBriefingCleanupScheduler()`; the scheduler is started from `app/server/index.ts` alongside the rules engine and runs immediately at boot, then once per 24h. Each pass logs a `briefing.cleanup` activity entry and broadcasts `briefing_deleted` SSE events so connected clients refresh. Also exposes an MCP admin tool `cleanup_stale_briefings` in `app/server/mcp-remote.ts` for on-demand cleanup during a CRM dreaming pass. Briefings without a `meetingId` or whose linked meeting is still pending are left alone — agents may still want to refresh them rather than delete outright.
+
 ### Reject same-day note paraphrases of typed interactions
 Server-side guard against the paraphrase dual-write pattern (#125). Writers were logging a typed interaction (meeting/email/call) for an event and then *also* writing a `note` on the same date that restated the same content in fewer words — the note was pure noise. `add_interaction` (both `app/server/mcp-remote.ts` and `app/server/mcp-server.ts`) now scans existing same-day typed interactions for the contact and rejects a `note` write that shares ≥3 proper nouns with any of them. Threshold tuned to require enough overlap that the note is clearly the *same* event; bumping a generic note ("AF processed inbox") never trips it. New helpers `extractProperNouns`, `sharesProperNouns`, `sameUTCDate` in `app/shared/interactions.ts`.
 

--- a/app/server/briefing-cleanup.ts
+++ b/app/server/briefing-cleanup.ts
@@ -1,0 +1,65 @@
+// Auto-cleanup of stale briefings. Briefings are designed ephemeral (one per
+// contact, replaced at each prep) but the server doesn't currently prune them.
+// Briefings whose linked meeting has been marked completed and which are older
+// than BRIEFING_STALE_DAYS are deleted on a daily schedule.
+//
+// See issue #126.
+import { db } from "./db";
+import { briefings, followups } from "@shared/schema";
+import { eq, and, lt, sql } from "drizzle-orm";
+import { BRIEFING_STALE_DAYS } from "@shared/briefing";
+import { sseManager } from "./sse";
+import { storage } from "./storage";
+
+export interface CleanupResult {
+  deleted: number;
+  contactIds: number[];
+}
+
+/**
+ * Delete briefings whose linked meeting is completed AND whose updatedAt is
+ * older than BRIEFING_STALE_DAYS. Briefings without a meetingId, or whose
+ * linked meeting is still pending, are left alone — agents may still want to
+ * refresh them rather than delete outright.
+ */
+export async function cleanupStaleBriefings(): Promise<CleanupResult> {
+  const cutoff = new Date(Date.now() - BRIEFING_STALE_DAYS * 24 * 60 * 60 * 1000);
+
+  // Find briefings whose linked meeting is completed and which are older than cutoff.
+  const stale = await db
+    .select({ id: briefings.id, contactId: briefings.contactId })
+    .from(briefings)
+    .innerJoin(followups, eq(briefings.meetingId, followups.id))
+    .where(and(eq(followups.completed, true), lt(briefings.updatedAt, cutoff)));
+
+  if (stale.length === 0) {
+    return { deleted: 0, contactIds: [] };
+  }
+
+  const ids = stale.map((r) => r.id);
+  await db.delete(briefings).where(sql`${briefings.id} in (${sql.join(ids, sql`, `)})`);
+
+  for (const row of stale) {
+    sseManager.broadcast({ type: "briefing_deleted", contactId: row.contactId });
+  }
+  await storage.logActivity(
+    "briefing.cleanup",
+    `Auto-deleted ${stale.length} stale briefing${stale.length === 1 ? "" : "s"} (meeting completed, age > ${BRIEFING_STALE_DAYS}d)`,
+    { source: "system", metadata: { contactIds: stale.map((r) => r.contactId) } },
+  );
+
+  return { deleted: stale.length, contactIds: stale.map((r) => r.contactId) };
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Start a periodic cleanup. Runs once at boot and then every `intervalMs`.
+ */
+export function startBriefingCleanupScheduler(intervalMs: number = DAY_MS): NodeJS.Timeout {
+  console.warn(`Briefing cleanup: scheduled every ${intervalMs / 1000 / 60 / 60} hours`);
+  cleanupStaleBriefings().catch((err) => console.error("Briefing cleanup failed:", err));
+  return setInterval(() => {
+    cleanupStaleBriefings().catch((err) => console.error("Briefing cleanup failed:", err));
+  }, intervalMs);
+}

--- a/app/server/index.ts
+++ b/app/server/index.ts
@@ -61,6 +61,10 @@ app.use((req, res, next) => {
   const { startRulesScheduler } = await import("./rules-engine");
   startRulesScheduler();
 
+  // Daily auto-cleanup of stale briefings (issue #126).
+  const { startBriefingCleanupScheduler } = await import("./briefing-cleanup");
+  startBriefingCleanupScheduler();
+
   const port = process.env.PORT || 3000;
   server.listen({ port, host: "0.0.0.0" }, () => {
     log(`serving on port ${port}`);

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -1242,6 +1242,34 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
     },
   );
 
+  server.tool(
+    "cleanup_stale_briefings",
+    `Delete every briefing whose linked meeting has been marked completed AND which is older than ${BRIEFING_STALE_DAYS} days. Same job that runs on the server's daily schedule — call it manually when you want immediate cleanup (e.g. during a CRM dreaming pass). Returns { deleted, contactIds }.`,
+    {},
+    async () => {
+      try {
+        const { cleanupStaleBriefings } = await import("./briefing-cleanup");
+        const result = await cleanupStaleBriefings();
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text:
+                result.deleted === 0
+                  ? "No stale briefings to clean up."
+                  : `Deleted ${result.deleted} stale briefing(s) for contact IDs: ${result.contactIds.join(", ")}.`,
+            },
+          ],
+        };
+      } catch (err: unknown) {
+        return {
+          content: [{ type: "text" as const, text: actionableError("cleaning up stale briefings", err) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
   // --- Relationship journal ---
   // Short, shared contract text. The full "where does this go?" decision tree
   // lives in get_crm_guide; tool descriptions just point there to avoid drift.


### PR DESCRIPTION
Closes #126.

## Summary
Briefings are designed ephemeral but had no cleanup — stale ones with `staleReason: meeting_completed` were piling up on contact records (7 deleted in the dreaming pass that surfaced this issue, ages 8-35 days). This adds an automatic daily sweep plus a manual MCP tool.

## What changed
- **`app/server/briefing-cleanup.ts`** (new) — `cleanupStaleBriefings()` deletes briefings where the linked meeting is `completed` AND `updatedAt < now - BRIEFING_STALE_DAYS`. Logs a `briefing.cleanup` activity entry and broadcasts `briefing_deleted` SSE events. `startBriefingCleanupScheduler()` runs it at boot and every 24h.
- **`app/server/index.ts`** — wires the scheduler in next to `startRulesScheduler`.
- **`app/server/mcp-remote.ts`** — new MCP tool `cleanup_stale_briefings` for on-demand cleanup (returns `{ deleted, contactIds }`). Useful during dreaming passes.
- **`CHANGELOG.md`** — entry under today's date.

Briefings without a `meetingId` or with a still-pending meeting are intentionally left alone — those should be refreshed rather than deleted.

## Test plan
Pure server / MCP wiring. The existing user-facing E2E does not exercise briefing cleanup and the new code has no UI surface, so the e2e-test skill is being skipped per CLAUDE.md's exception.

- [x] `npm run lint:fix` clean
- [x] `npm run format` clean
- [x] `npm run build` succeeds
- [ ] After deploy: confirm `briefing.cleanup` entries appear in the activity log on the daily tick, and that an explicit MCP call to `cleanup_stale_briefings` returns a deletion count when stale records exist.