### PR TITLE
Fix #129: Paginated list_interactions / list_followups MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-05-31
 
+### Paginated list_interactions / list_followups MCP tools
+Adds two read tools to `app/server/mcp-remote.ts` for audit and cleanup workflows over a single contact (#129). `list_interactions(contactId, limit, offset, since, until, type)` returns interactions newest-first with optional date-range and type filters; `list_followups(contactId, limit, offset, type, completed, since, until)` does the same for follow-ups. `get_contact` still returns the full blob for small-payload reads but its description now points heavy callers (dreaming, audit) at the paginated tools — for LIVE clients with 100+ interactions the inline `interactions[]` blob exceeded 150 KB and tripped token limits in consuming agents.
+
 ### Reject duplicate canonical journal sections + auto-sync title on rename
 Two structural-drift fixes for the relationship journal (#128). (1) `edit_journal` (`app/server/mcp-remote.ts`) now scans the resulting doc for duplicate canonical `## Section` headers — Key People, Wins / Case Study Material, Engagement History, Entries — and rejects edits that introduce a new duplicate (pre-existing dupes are tolerated so a writer can use `confirmed_with_user: true` to clean them up). Catches the writer-mistake pattern where a fresh skeleton scaffold gets appended on top of an already-populated journal, producing two `## Entries`, two `## Key People`, etc. New helper `findDuplicateCanonicalSections` in `app/shared/journal.ts`. (2) `storage.updateContact` now keeps the journal's leading `# Title` line in sync when `firstName`/`lastName` changes — previously a contact rename left the heading pointing at the previous person. New helper `syncJournalTitle` in `app/shared/journal.ts`; broadcasts a `journal_updated` SSE event so connected clients refresh.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ Reference prompts for scheduled agents that operate on your behalf live in [`doc
 |------|-------------|
 | `get_crm_guide` | Agent usage guide + live CRM snapshot. Recommended first call. |
 | `get_dashboard` | Contacts by stage, overdue tasks, upcoming meetings, violations. |
-| `get_contact` | Full contact with all related data. |
+| `get_contact` | Full contact with all related data. May exceed 150 KB on LIVE clients — for heavy reads use the paginated tools below. |
+| `list_interactions` | Paginated interactions for one contact (newest first) with `since` / `until` / `type` filters. |
+| `list_followups` | Paginated follow-ups for one contact with `type` / `completed` / `since` / `until` filters. |
 | `create_contact` | Add a new contact. |
 | `update_contact` | Modify contact fields. |
 | `delete_contact` | Permanently delete a contact and all related data. |

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -439,7 +439,7 @@ Tasks and interactions should be SHORT reminders. The journal is where detail li
   // --- Read Tools ---
   server.tool(
     "get_contact",
-    "Get full contact details including interactions, follow-ups, and violations.",
+    "Get full contact details including interactions, follow-ups, and violations. Response can exceed 150 KB for LIVE clients with long histories — for audit or cleanup workflows over a single contact, prefer the paginated list_interactions / list_followups tools instead.",
     {
       contactId: z.number().describe("Contact ID"),
     },
@@ -451,6 +451,90 @@ Tasks and interactions should be SHORT reminders. The journal is where detail li
       } catch (err: unknown) {
         return {
           content: [{ type: "text" as const, text: actionableError(`reading contact ${contactId}`, err) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "list_interactions",
+    "Paginated interactions for a single contact, newest first. Use this instead of get_contact when the contact has a long history (audit, dreaming, cleanup) to avoid 150KB+ blobs that trip token limits.",
+    {
+      contactId: z.number().describe("Contact ID"),
+      limit: z.number().optional().describe("Max results (default 25)"),
+      offset: z.number().optional().describe("Skip results (default 0)"),
+      since: z.string().optional().describe("ISO date — only interactions on/after this date"),
+      until: z.string().optional().describe("ISO date — only interactions on/before this date"),
+      type: interactionTypeEnum.optional().describe(`Filter by type: ${INTERACTION_TYPES.join(", ")}`),
+    },
+    async ({ contactId, limit, offset, since, until, type }) => {
+      try {
+        const contact = await storage.getContact(contactId);
+        if (!contact) return notFoundError("Contact", contactId, "get_dashboard");
+
+        let items = await storage.getInteractions(contactId);
+        if (type) items = items.filter((i) => i.type === type);
+        if (since) {
+          const s = new Date(since);
+          items = items.filter((i) => i.date >= s);
+        }
+        if (until) {
+          const u = new Date(until);
+          items = items.filter((i) => i.date <= u);
+        }
+        // Newest first for audit / dreaming workflows
+        items.sort((a, b) => b.date.getTime() - a.date.getTime());
+
+        const { items: page, totalCount, hasMore } = paginate(items, limit || 25, offset || 0);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ results: page, totalCount, hasMore }, null, 2) }],
+        };
+      } catch (err: unknown) {
+        return {
+          content: [{ type: "text" as const, text: actionableError(`listing interactions for ${contactId}`, err) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "list_followups",
+    "Paginated follow-ups (tasks and meetings) for a single contact. Use this instead of get_contact when a contact has many follow-ups to avoid oversize responses.",
+    {
+      contactId: z.number().describe("Contact ID"),
+      limit: z.number().optional().describe("Max results (default 25)"),
+      offset: z.number().optional().describe("Skip results (default 0)"),
+      type: taskTypeEnum.optional().describe(`Filter by type: ${TASK_TYPES.join(", ")}`),
+      completed: z.boolean().optional().describe("Filter by completion state"),
+      since: z.string().optional().describe("ISO date — only follow-ups due on/after this date"),
+      until: z.string().optional().describe("ISO date — only follow-ups due on/before this date"),
+    },
+    async ({ contactId, limit, offset, type, completed, since, until }) => {
+      try {
+        const contact = await storage.getContact(contactId);
+        if (!contact) return notFoundError("Contact", contactId, "get_dashboard");
+
+        let items = await storage.getFollowups(contactId);
+        if (type) items = items.filter((f) => (f.type || "task") === type);
+        if (typeof completed === "boolean") items = items.filter((f) => f.completed === completed);
+        if (since) {
+          const s = new Date(since);
+          items = items.filter((f) => f.dueDate >= s);
+        }
+        if (until) {
+          const u = new Date(until);
+          items = items.filter((f) => f.dueDate <= u);
+        }
+
+        const { items: page, totalCount, hasMore } = paginate(items, limit || 25, offset || 0);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ results: page, totalCount, hasMore }, null, 2) }],
+        };
+      } catch (err: unknown) {
+        return {
+          content: [{ type: "text" as const, text: actionableError(`listing followups for ${contactId}`, err) }],
           isError: true,
         };
       }


### PR DESCRIPTION
Closes #129.

## Summary
- `get_contact` returns contact + `interactions[]` + `followups[]` + `violations[]` + `briefing` in one blob. For LIVE clients with long histories (Jeff @ 104 interactions, Christiana @ 153) this easily exceeds 150 KB and trips token limits in the consuming agent harness — the May 31 dreaming pass had to work around it via a shell-read of a saved error dump.
- Adds two paginated read tools in `app/server/mcp-remote.ts`:
  - `list_interactions(contactId, limit, offset, since, until, type)` — newest-first, supports ISO date range + interaction-type filter.
  - `list_followups(contactId, limit, offset, type, completed, since, until)` — supports task/meeting filter, completion state, and due-date range.
- Both use the existing `paginate()` helper so they return `{ results, totalCount, hasMore }` identical to `list_violations` / `list_rules`.
- `get_contact` stays for small-payload reads but its description now points heavy callers (dreaming, audit, cleanup) at the paginated tools.

## Test plan
- [x] `npm run lint:fix && npm run format && npm run build` green.
- [ ] Manual: connect via MCP, call `list_interactions(contactId: <jeff_id>, limit: 25)` and confirm the response is well under the 150 KB ceiling that broke the dreaming pass.
- [ ] Manual: confirm `since`/`until`/`type` filters work.

E2E skipped — pure MCP tool surface change; the existing Playwright suite doesn't exercise raw MCP tool registrations.