### PR TITLE
Fix #130: reject empty append_journal bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-05-31
 
+### Reject empty `append_journal` / `batch_append_journal` bodies
+Server-side guard against the heading-without-body pattern (#130). Writers were occasionally appending a dated Entry with a substantive title but an empty/whitespace-only body, producing a heading with no narrative — pure noise. `append_journal` and `batch_append_journal` in `app/server/mcp-remote.ts` now reject entries whose `body` or `title` trims to empty, returning a clear `empty_content` validation error with the offending field so the writer knows to retry with actual content. `edit_journal`'s `newString` is intentionally untouched — emptying a region is legitimate deletion there.
+
 ### Paginated list_interactions / list_followups MCP tools
 Adds two read tools to `app/server/mcp-remote.ts` for audit and cleanup workflows over a single contact (#129). `list_interactions(contactId, limit, offset, since, until, type)` returns interactions newest-first with optional date-range and type filters; `list_followups(contactId, limit, offset, type, completed, since, until)` does the same for follow-ups. `get_contact` still returns the full blob for small-payload reads but its description now points heavy callers (dreaming, audit) at the paginated tools — for LIVE clients with 100+ interactions the inline `interactions[]` blob exceeded 150 KB and tripped token limits in consuming agents.
 

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -1719,6 +1719,41 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
           };
         }
 
+        if (title.trim().length === 0) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  ok: false,
+                  reason: "empty_content",
+                  field: "title",
+                  message:
+                    'Rejected title: empty or whitespace-only. Provide a short, verb-forward headline (e.g. "Jeff signaled pivot from vendor to partner").',
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        if (body.trim().length === 0) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  ok: false,
+                  reason: "empty_content",
+                  field: "body",
+                  message:
+                    "Rejected body: empty or whitespace-only. The body carries the substantive narrative — interpretation, context, what happened. A heading without a body is not a useful journal entry. Retry with content, or skip the append.",
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
+
         const tv = validateJournalContent(title, "title");
         if (!tv.ok) {
           return {
@@ -1826,6 +1861,25 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
               field: `entries[${i}].date`,
               offending: e.date,
               message: `"${e.date}" is not a valid ISO date.`,
+            };
+          }
+          if (e.title.trim().length === 0) {
+            return {
+              index: i,
+              ok: false as const,
+              reason: "empty_content" as const,
+              field: `entries[${i}].title`,
+              message: "Rejected title: empty or whitespace-only. Provide a short, verb-forward headline.",
+            };
+          }
+          if (e.body.trim().length === 0) {
+            return {
+              index: i,
+              ok: false as const,
+              reason: "empty_content" as const,
+              field: `entries[${i}].body`,
+              message:
+                "Rejected body: empty or whitespace-only. The body carries the substantive narrative. A heading without a body is not a useful journal entry.",
             };
           }
           const tv = validateJournalContent(e.title, `entries[${i}].title`);


### PR DESCRIPTION
## Summary
- `append_journal` and `batch_append_journal` in `app/server/mcp-remote.ts` now reject entries whose `body` or `title` trims to empty / whitespace-only.
- Returns a clear `empty_content` validation error with the offending field so the writer knows to retry with actual content.
- `edit_journal`'s `newString` is intentionally untouched — emptying a region is a legitimate delete there.

Closes #130.

## Test plan
- [x] `npm run lint:fix` clean
- [x] `npm run format` clean
- [x] `npm run build` succeeds
- [ ] E2E skipped: this is a server-side MCP validation guard with no user-facing UI change. Existing E2E suite does not exercise MCP tool calls.