### PR TITLE
Fix #131: Expose list_stale_briefings MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-05-31
 
+### Expose `list_stale_briefings` MCP tool
+Adds a sweep tool to `app/server/mcp-remote.ts` (#131). `list_stale_briefings()` returns every briefing currently considered stale — by `age`, `meeting_completed`, or `wrong_meeting` — with `contactId`, `contactName`, `staleReason`, `ageDays`, and `meetingId`. Detection already existed inside `get_briefing` / `prepare_briefing`, but the only way to actually find stale briefings across the portfolio was a per-contact scan. A periodic skill (CRM dreaming) can now call this once and either refresh each entry (`prepare_briefing` + `save_briefing`) or delete it (`delete_briefing`) — complementing the existing auto-cleanup, which only handles the `meeting_completed`-plus-age case.
+
 ### Reject empty `append_journal` / `batch_append_journal` bodies
 Server-side guard against the heading-without-body pattern (#130). Writers were occasionally appending a dated Entry with a substantive title but an empty/whitespace-only body, producing a heading with no narrative — pure noise. `append_journal` and `batch_append_journal` in `app/server/mcp-remote.ts` now reject entries whose `body` or `title` trims to empty, returning a clear `empty_content` validation error with the offending field so the writer knows to retry with actual content. `edit_journal`'s `newString` is intentionally untouched — emptying a region is legitimate deletion there.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Reference prompts for scheduled agents that operate on your behalf live in [`doc
 | `get_upcoming_meetings` / `cancel_meeting` | Meeting management. |
 | `prepare_briefing` | Gather everything an agent needs before writing a briefing: contact record (with `linkedinUrl`), interactions, followups, journal, any previous briefing (with `ageDays` + `stale` flag), canonical 8-section template, and the research protocol. First call in every briefing workflow. |
 | `save_briefing` / `get_briefing` | Upsert / read the briefing. `save_briefing` validates the 8-section structure and rejects missing or out-of-order sections. `get_briefing` returns content + `ageDays` + `stale` (true after 7 days). |
+| `list_stale_briefings` / `cleanup_stale_briefings` / `delete_briefing` | Sweep tools for the stale-briefing lifecycle. `list_stale_briefings` returns every stale briefing with `staleReason` (`age` / `meeting_completed` / `wrong_meeting`) so a periodic skill can refresh or delete each. `cleanup_stale_briefings` bulk-deletes the `meeting_completed`-plus-age subset. `delete_briefing` removes a single one. |
 | `read_journal` / `peek_last_journal_entry` | Read the full `relationship_journal` (optional `section` scope) or just the most recent dated Entry + doc hash. |
 | `edit_journal` / `append_journal` / `batch_append_journal` | Modify the journal. Absolute-dates-only validator, verbatim blockquote escape, destructive edits gated behind `confirmed_with_user`. `batch_append_journal` writes many dated entries transactionally — the bulk-migration path. |
 

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -1355,6 +1355,62 @@ The outcome should be past tense: "Checked in with Idan — confirmed coffee nex
     },
   );
 
+  server.tool(
+    "list_stale_briefings",
+    `List every briefing currently marked stale, with the reason (\`age\` / \`meeting_completed\` / \`wrong_meeting\`). Use in a periodic sweep: for each entry, either call prepare_briefing + save_briefing to refresh, or delete_briefing if you can't refresh now. Cheaper than scanning per-contact. Returns { count, briefings: [{ contactId, contactName, staleReason, ageDays, meetingId }] }.`,
+    {},
+    async () => {
+      try {
+        const allBriefings = await db.select().from(briefings);
+        if (allBriefings.length === 0) {
+          return { content: [{ type: "text" as const, text: JSON.stringify({ count: 0, briefings: [] }, null, 2) }] };
+        }
+        const allFollowups = await db.select().from(followups);
+        const meetingsByContact = new Map<
+          number,
+          Array<{ id: number; dueDate: Date; completed: boolean; cancelled: boolean }>
+        >();
+        for (const f of allFollowups) {
+          if (f.type !== "meeting") continue;
+          const list = meetingsByContact.get(f.contactId) ?? [];
+          list.push({ id: f.id, dueDate: f.dueDate, completed: f.completed, cancelled: !!f.cancelledAt });
+          meetingsByContact.set(f.contactId, list);
+        }
+        const contactIds = Array.from(new Set(allBriefings.map((b) => b.contactId)));
+        const contactRows = await db
+          .select({ id: contacts.id, firstName: contacts.firstName, lastName: contacts.lastName })
+          .from(contacts)
+          .where(sql`${contacts.id} in (${sql.join(contactIds, sql`, `)})`);
+        const nameById = new Map(contactRows.map((c) => [c.id, `${c.firstName} ${c.lastName}`.trim()]));
+        const now = new Date();
+        const stale = allBriefings
+          .map((b) => {
+            const meetings = meetingsByContact.get(b.contactId) ?? [];
+            const s = getBriefingStaleness({ meetingId: b.meetingId, updatedAt: b.updatedAt }, meetings, now);
+            return { briefing: b, stale: s };
+          })
+          .filter((r) => r.stale.stale)
+          .map((r) => ({
+            contactId: r.briefing.contactId,
+            contactName: nameById.get(r.briefing.contactId) ?? null,
+            staleReason: r.stale.reason,
+            ageDays: briefingAgeDays(r.briefing.updatedAt, now),
+            meetingId: r.briefing.meetingId,
+          }));
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify({ count: stale.length, briefings: stale }, null, 2) },
+          ],
+        };
+      } catch (err: unknown) {
+        return {
+          content: [{ type: "text" as const, text: actionableError("listing stale briefings", err) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
   // --- Relationship journal ---
   // Short, shared contract text. The full "where does this go?" decision tree
   // lives in get_crm_guide; tool descriptions just point there to avoid drift.


### PR DESCRIPTION
Closes #131.

## Summary
- Adds `list_stale_briefings` to `app/server/mcp-remote.ts`. Loads all briefings, computes staleness via the existing `getBriefingStaleness` (the same logic `get_briefing` uses), and returns the stale ones with `contactId`, `contactName`, `staleReason` (`age` / `meeting_completed` / `wrong_meeting`), `ageDays`, `meetingId`.
- Pairs with the existing `cleanup_stale_briefings` (bulk-delete only the `meeting_completed`+age subset) and `delete_briefing` (single). A periodic sweep skill can now refresh stale briefings via `prepare_briefing` + `save_briefing` for the cases auto-cleanup leaves behind (`age`, `wrong_meeting`).

## Test plan
- Pure additive MCP tool — existing E2E doesn't exercise MCP tool registration. Verified via `npm run build` and `npm run lint:fix`.
- Implementation reuses shared `getBriefingStaleness` and `briefingAgeDays` (already covered by `get_briefing` paths).
- Manual smoke after deploy: call `list_stale_briefings` against the live MCP endpoint; confirm count + per-entry shape.