### PR TITLE
Skill v2: pre-write checklist, journal anatomy, strategic-vs-operational meetings

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -79,7 +79,7 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 - Type: `/mtg 12/25 2pm E2E test meeting @ Test Location`
 - Verify the command hint appears in blue ("meeting ready")
 - Press Enter
-- Verify a meeting item appears with 📅 icon, `12/25 2:00 PM`, content, and location
+- Verify a meeting item appears with 📅 icon, `12/25 2pm` (time renders as typed — the parser stores the raw token), content, and location
 - **Screenshot** → `e2e-screenshots/04-meeting-created.png`
 
 ### 4c. UI: Edit a follow-up date
@@ -123,7 +123,7 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
   - A `Briefing` text link on the right of the header row **only when a briefing exists AND it's <7 days old** for that contact
 - Click the `Journal` link for a contact — verify it navigates to `/journal/<id>`
 - Navigate back; click the `Briefing` link for a contact that has one — verify it navigates to `/briefings/<id>`
-- Verify **no** stage pill, status pill, or emoji badges appear on the header row
+- Verify the stage pill and status pill appear on the header row before the Briefing/Journal links (restored in PR #142) — tinted rounded pills; no emoji badges
 - **Screenshot** → `e2e-screenshots/07b-header-links.png`
 
 ### 6c. UI: Briefing template + validation + staleness
@@ -156,7 +156,7 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 ### 10b. MCP: Read, append, and edit relationship journal
 - Call `read_journal` with a known `contactId`. Verify the response JSON includes `content`, `hash`, `initialized`, and `sizeBytes`. For a fresh contact, `initialized` should be false and `content` should be the seeded skeleton.
 - Call `append_journal` with that contactId, `title: "E2E seed entry"`, `body: "Logged from E2E on 2026-04-18. Confirmed live server accepts append."`. Verify `ok: true`, `seeded: true`, and `entryHeading` matches `### YYYY-MM-DD: E2E seed entry`.
-- Call `append_journal` again with `body: "follow up next week"` (intentionally relative). Verify `ok: false` and `reason: "relative_date"` naming the phrase `next week`.
+- Call `append_journal` again with `body: "follow up next week"` (intentionally relative). Verify `ok: false` and `reason: "relative_phrase"` with `offending: "next week"`.
 - Same-day fold: call `append_journal` again with `title: "E2E same-day follow"`, `body: "Second event on 2026-04-18. Should fold under the existing H3."`, `date: "2026-04-18"` (matching the seed entry's date). Verify `ok: true`, `foldedInto` is present and equals the seed entry's `### 2026-04-18: …` heading, and `entryHeading` is that same H3 (not a new sibling). Then call `read_journal` and verify the doc contains exactly ONE `### 2026-04-18:` heading followed by an `#### E2E same-day follow` subheading.
 - Call `edit_journal` with a stale `expectedHash` (e.g. `"0"`). Verify `ok: false`, `reason: "hash_conflict"`.
 - Call `edit_journal` to mutate an existing `### YYYY-MM-DD:` heading without `confirmed_with_user`. Verify `ok: false`, `reason: "destructive_edit"`. Retry with `confirmed_with_user: true` — verify it succeeds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-06-10
+
+### Skill v2: pre-write checklist, journal anatomy, strategic-vs-operational meetings
+Major revision of `skills/crm/SKILL.md` (#143), distilling months of real sync-cycle usage into the shared mental model. Six additions/edits, all aimed at the dominant agent failure modes — over-logging, duplicate writes across layers, journal sprawl, retrospective entries distorting the timeline, and briefing-candidate pollution:
+
+1. **Pre-write checklist** — five mandatory questions before any write tool call (which layer, six-month test, tense check, dedup check, thread-vs-message granularity).
+2. **Interaction shape hard rule** — one sentence, past tense, factual; strategic reads go to the journal.
+3. **Journal anatomy** — canonical section order (Key People, Wins / Case Study Material, Engagement History, Entries) with per-section editing semantics. Engagement History is the new home for retrospective span summaries that would distort the Entries timeline.
+4. **Strategic-vs-operational meetings** — the Meetings layer is curated, not comprehensive. Concrete log/skip lists, the two-part test ("prepare differently AND moves the relationship"), edge cases, and delete-on-sight cleanup for operational cadences from prior runs. Keeps the briefing-candidate selector pointed at the right meeting.
+5. **Writing rules expanded into practical patterns** — no date prefixes in titles, one entry per day with H4 facets, don't re-narrate the atom, blockquote escape for verbatim quotes, retrospectives → Engagement History, conditional rules → tasks, no note-paraphrasing-email duplicates, operational chatter stays out.
+6. **Layered confidentiality** — pricing/deal terms are now allowed in the journal only (the interpretive layer), still forbidden in tasks, interactions, briefings, and contact fields where leakage into dashboards and meeting prep is harder to contain. Cross-client specifics and credentials remain forbidden everywhere. README and CLAUDE.md updated to match.
+
 ## 2026-06-09
 
 ### Bring back the stage + status pills on contact cards

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,4 +67,4 @@ Every PR that modifies `app/shared/schema.ts` MUST also update `app/server/boot-
 ## Gotchas
 
 - Dates: use `fmtDate` from `lib/utils.ts`. Using `format()` from date-fns causes off-by-one timezone bugs.
-- Never store pricing, deal terms, or cross-reference clients.
+- Pricing and deal terms live in the relationship journal only — never in tasks, interactions, briefings, or contact fields. Never cross-reference clients anywhere.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Most CRMs are built for sales teams. Claw is built for one person managing 10-50
 - **Notebook view** — your entire pipeline in one scrollable feed, sorted by urgency
 - **Slash commands** — `/fu 4/15 check on proposal`, `/mtg 4/3 2pm Coffee @ Verve`, `/stage PROPOSAL`
 - **AI agents write, you verify** — Claude connects via MCP and manages your CRM through 27+ tools
-- **Relationship journal** — a per-contact markdown document that's the durable home for the narrative of the relationship: Key People, Wins / Case Study Material, and dated Entries. Absolute-dates-only validator, full revision history with diff view, verbatim blockquote escape for preserving emails and transcripts.
+- **Relationship journal** — a per-contact markdown document that's the durable home for the narrative of the relationship: Key People, Wins / Case Study Material, Engagement History, and dated Entries. Absolute-dates-only validator, full revision history with diff view, verbatim blockquote escape for preserving emails and transcripts.
 - **Rules engine** — business logic stored as data, not code. "Flag contacts with no interaction for 14 days." Agents can create, modify, and delete rules.
 - **Real-time** — SSE pushes every change to the UI instantly, whether you or an agent made it
-- **Privacy-first** — PIN-locked, teal privacy screen on window blur, no pricing or deal terms stored
+- **Privacy-first** — PIN-locked, teal privacy screen on window blur, pricing and deal terms confined to the journal (never in tasks, interactions, briefings, or contact fields), no cross-client references anywhere
 
 ## Quick Start
 
@@ -163,7 +163,7 @@ Exceptions: `has_future_followup`, `stage_in` (exclude specific stages from rule
 | **Follow-ups** | Action items with due dates. |
 | **Meetings** | Future scheduled events. |
 | **Briefings** | Per-contact prep for the next specific meeting. Canonical 8-section structure (TL;DR, About them, About the company, Shared ground, Our history, What to discuss, Offers / asks, Watch-outs) enforced by the server. Stale after 7 days — old briefings stop surfacing on contact cards but remain readable on the briefing page. |
-| **Journal** | Per-contact markdown narrative — Key People, Wins / Case Study Material, dated Entries. Full revision history. |
+| **Journal** | Per-contact markdown narrative — Key People, Wins / Case Study Material, Engagement History, dated Entries. Full revision history. |
 | **Rules** | Business logic — conditions + actions as JSONB. |
 | **Violations** | Alerts created by rules, auto-cleared when resolved. |
 

--- a/skills/crm/SKILL.md
+++ b/skills/crm/SKILL.md
@@ -19,6 +19,18 @@ It returns the current rule set, valid enums, stage definitions, writing contrac
 
 Every piece of information has exactly ONE home. **The DATE belongs to the atom. The MEANING belongs to the journal.** If you're about to write the same sentence in two places, one of them is wrong.
 
+## Pre-write checklist
+
+Before calling any CRM write tool, force a single-layer answer to each question. This is the failure mode that produces noise; treat the checklist as mandatory, not advisory.
+
+1. **Which layer does this belong to?** Exactly one of: contact field, interaction, task, meeting, briefing, journal. If you can name two, you are wrong. The atom holds the date; the journal holds the meaning. Same event in two layers is a duplicate.
+2. **Will this matter in six months?** If not, do not write it. Calendar churn, OOO notices, infra and tooling chatter, routine acknowledgments, and Calendly booking confirmations all fail this test. Skip them.
+3. **Is the verb in past tense?** If the content uses "should", "will", "send", "follow up", "review", "draft", or "prepare", it is a task, not an interaction. Route accordingly. Interactions describe events that already happened.
+4. **Is there already an entry for this event on this contact?** Check before every write. Re-narration in a different `type` field counts as a duplicate. A `type: note` that paraphrases a `type: email` you just wrote is forbidden.
+5. **Is this thread-level or message-level?** A single thread with multiple replies is one interaction summarizing the exchange, not one per message.
+
+If any answer is wrong or ambiguous, do not write.
+
 ## Five-layer mental model
 
 | Layer | What it is | Shape |
@@ -39,6 +51,51 @@ Interactions and tasks stay SHORT. The journal is where detail and meaning live.
 
 None of those three duplicate each other.
 
+**Interaction shape, hard rule:** one sentence, past tense, factual. If your interaction is longer than two sentences or contains a strategic read, the interpretation belongs in the journal. Cut the interaction down to one factual sentence and write the interpretation as a journal entry referencing the date.
+
+## Journal anatomy
+
+Canonical sections, in order:
+
+1. `## Key People` — stakeholder roster with roles and current relationship state. Edited in place. Populate as soon as a contact reaches MEETING. An empty roster on a MEETING+ contact is a smell worth fixing in the next pass.
+2. `## Wins / Case Study Material` — durable outcomes worth quoting later, edited in place.
+3. `## Engagement History` — retrospective phase summaries, scope evolution, role changes, compensation history. Edit in place. Use for content written *about* a multi-week or multi-month span rather than content tied to a single date. Dating retrospectives to event-start distorts the Entries timeline; this section is the right home.
+4. `## Entries` — dated narrative, append-mostly. Event-driven interpretation only. One entry per contact per day by default; use H4 subheadings for facets if multiple topics land the same day. Reserve sibling entries for genuinely orthogonal topics.
+
+Optional sections, only when real recurring signal does not fit the four canonicals: `## Open Questions`, `## Risks`, `## Next Moves`. Default answer is still Entries. Forward action items belong in tasks, not in journal prose.
+
+## Tasks and Meetings — the strategic-only rule
+
+The Meetings layer is **curated**, not comprehensive. Your calendar already holds every event you attend. The CRM Meetings layer is reserved for events that shift the relationship trajectory — moments worth preparing differently for.
+
+**Log as a Meeting (strategic):**
+- First meeting with a new contact, or first meeting with a new stakeholder on an existing contact
+- First conversation on a new engagement, lane, or scope
+- First external proof point (demo, pitch, working session for an audience outside the day-to-day team)
+- Stage-shifting conversations (proposal walkthrough, renegotiation, signing, escalation)
+- One-off high-stakes events (board meetings, investor updates, incident reviews)
+- Anything you want a briefing prepared for ahead of time
+
+**Never log as a Meeting (operational — leave on the calendar):**
+- Recurring 1:1 cadences (weekly client 1:1, monthly check-in)
+- Daily or weekly team standups and syncs
+- Ad-hoc internal alignment calls with an active client
+- Internal training and working sessions with recurring collaborators
+- "Catch-up" / "check-in" meetings with no new agenda
+- Cadence meetings inherited from a recurring calendar series
+
+**The test:** "Will I prepare for this differently than the last time, AND will what happens here move the relationship?" Both yes → log it. Either no → skip the Meetings layer.
+
+**Edge cases:**
+- A recurring 1:1 where something material happens — log the EVENT as an interaction. The 1:1 itself stays off the Meetings layer.
+- The first instance of what will become a cadence IS strategic. Subsequent instances are not.
+- An external-audience demo is strategic even if it's "just a demo" internally — the audience makes it strategic.
+- A discovery call on a brand-new lane is strategic. A working session two weeks in is not, unless it stage-shifts.
+
+**Cleanup:** Operational meetings found in the Meetings layer from prior agent runs should be deleted on sight. The calendar carries the historical record; the Meetings layer doesn't need to.
+
+**Why this matters:** Briefings are scoped to the next Meeting on a contact. If the layer is polluted with operational cadences, the briefing-candidate selector picks the wrong meeting and the agent preps for the wrong conversation. Keeping the layer curated preserves the signal value of every entry.
+
 ## When to invoke this skill
 
 - User mentions any person by name in a relationship context ("Alex said", "met with Jordan", "check in with Priya")
@@ -47,9 +104,18 @@ None of those three duplicate each other.
 - User asks to prep for a meeting or review notes on a client
 - User pastes historical notes, a transcript, or context they want preserved for someone
 
-## Writing rules
+## Writing rules (practical patterns)
 
-The server enforces strict validation — **absolute dates only, no relative phrases, dated entry headings, destructive-edit gates**. Full contract (accepted date formats, trigger words, section structure, confirmation flags) is in `get_crm_guide`. Call it once per session and operate from its output.
+The server enforces strict validation — absolute dates only, no relative phrases, dated entry headings, destructive-edit gates. Full contract in `get_crm_guide`. Call it once per session and operate from its output. Beyond the server contract, observe the following patterns to avoid the most common journal-hygiene issues:
+
+- **Do NOT prefix the title with the entry date.** The server prepends `### YYYY-MM-DD:` automatically. A title like `2026-05-10: Jordan split TPM` renders as `### 2026-05-10: 2026-05-10: Jordan split TPM`. Lead the title with a verb or noun, not a date.
+- **One entry per contact per day.** If two topics warrant capture on the same day, write one entry with H4 subheadings (`#### Topic A`, `#### Topic B`). Only create sibling entries for genuinely orthogonal subjects.
+- **Do not re-narrate the atom.** If an interaction already captures the fact, the journal entry references it by date and goes straight to the interpretation. "On 2026-05-10 the JD reply landed; the strategic read is..." not "They replied 2026-05-10 with minor changes; proposed using Friday for three things; the strategic read is..."
+- **Verbatim quotes go in markdown blockquotes** (lines starting with `>`). Blockquotes bypass the relative-date check; surrounding prose still has to use absolute dates. Use this when preserving someone else's exact words, especially if they used relative phrasing.
+- **Retrospective summaries belong in Engagement History.** A "Phase 1 / Q1 2025" entry written in April 2026 distorts the Entries timeline if dated to phase-start. Put it in Engagement History and reference the span ("Q1 2025") in the heading.
+- **Conditional rules belong in tasks, not prose.** "If silent by 2026-05-15, move to HOLD" is a task with a due date, not a journal sentence. Encode the action; let the journal hold the rationale.
+- **Never write a `type: note` interaction that paraphrases an `email`, `call`, or `meeting` interaction on the same event.** Pick one type and one entry per event. A "summary note" describing what just got logged as an email is a duplicate.
+- **Operational chatter is not relationship signal.** Infra logistics, tooling renames, permissions changes, calendar reschedules, OOO notices, Calendly bookings, ticket opens belong in the operational system, not the CRM. If you cannot complete the sentence "this will matter to the relationship six months from now because...", do not log it.
 
 ## If the connector isn't reachable
 
@@ -61,4 +127,8 @@ Do not attempt to install or configure the connector yourself.
 
 ## Confidentiality
 
-Never store pricing, deal terms, or cross-reference details between clients. This is a notebook, not a deal tracker.
+This is a notebook, not a deal tracker. The rules differ by layer.
+
+- **Pricing, dollar amounts, deal terms, fees, commission rates:** allowed in the journal only (Entries, Engagement History, Wins, Key People). The journal is the interpretive layer — compensation history, scope-and-cash reset narratives, and revenue-pattern reads belong there. **Forbidden** in tasks, interactions, briefings, contact fields (background, source, additionalContacts), and any other operational or atomic layer. Those surfaces show up in dashboards, exports, and meeting prep, and pricing leakage there is harder to contain. When a task or interaction needs to reference a payment or invoice, use date and scope only (`Acme paid invoice INV-2035 on 2026-05-11`), not the figure.
+- **Cross-client specifics:** never. Client A specifics do not appear on Client B's record; prospect specifics do not appear on another prospect's record. Generic patterns are fine; named-client details are not. This applies to all layers including the journal.
+- **Credentials, account numbers, secrets:** never, anywhere.


### PR DESCRIPTION
## Summary

Implements all six edits proposed in #143, distilling heavy real-world sync usage into the shared `crm` skill so every downstream consumer (ad-hoc use, scheduled sync agents, briefing flows) inherits the discipline:

1. **Pre-write checklist** — five mandatory questions before any CRM write (layer, six-month test, tense, dedup, thread-vs-message).
2. **Interaction shape hard rule** — one sentence, past tense, factual; interpretation goes to the journal.
3. **Journal anatomy** — canonical section order with editing semantics; adds `## Engagement History` as the home for retrospective span summaries.
4. **Tasks and Meetings — strategic-only rule** — curated Meetings layer with log/skip lists, the two-part test, edge cases, and delete-on-sight cleanup. Protects briefing-candidate selection.
5. **Writing rules → practical patterns** — the eight recurring journal-hygiene rules.
6. **Layered confidentiality** — pricing/deal terms journal-only; forbidden in tasks, interactions, briefings, contact fields. Cross-client specifics and credentials forbidden everywhere.

## Consistency updates

- README: journal sections now include Engagement History; privacy bullet states the layered policy.
- CLAUDE.md: gotcha line updated from blanket "never store pricing" to the layered rule.
- CHANGELOG entry added.

## E2E

Full E2E skill run on this branch: **all 18 steps pass** (manifest in `e2e-screenshots/run.json`). The run surfaced three stale assertions in the E2E skill doc itself, fixed in this PR: meeting time renders as typed (`2pm`, not normalized), stage/status pills are present per #142, and the journal relative-date rejection reason is `relative_phrase`.

Fixes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)