### PR TITLE
Zero-friction install: Docker one-liner + Railway guide + production cookie fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 2026-06-10
 
+### Zero-friction install: Docker one-liner + Railway guide
+The target user keeps clients in Apple Notes — they were never going to provision Postgres and push a schema by hand. Adoption now starts with `docker compose up`:
+
+- **`docker-compose.yml`** (repo root) — Postgres 16 + the app, schema pushed idempotently at container start (`drizzle-kit push` before boot; boot-migrations still run as before). First visit walks through PIN setup. Data persists in a named volume.
+- **`app/Dockerfile` + `.dockerignore`** — single-image build (vite + esbuild), `NODE_ENV=production`.
+- **Session cookie fix** — `secure` was hard-`true` in production, which silently broke login for plain-HTTP self-hosts (the cookie never got set; login returned 200 but the session vanished). Now `"auto"`: Secure over HTTPS (Railway behind trust-proxy), plain over HTTP (Docker on localhost). Verified end-to-end on a cold container: setup → login → authed API → MCP initialize.
+- **README Quick Start rewritten** around three paths: Docker (recommended), Railway hosted (deploy-from-repo steps), local dev.
+
 ### New skill: `crm-management` — scheduled inbox/calendar sync agent
 Adds `skills/crm-management/SKILL.md` (#144), a sibling to the `crm` skill. Where `crm` provides the mental model and writing contract, `crm-management` orchestrates a periodic sync pass on top of it: read inbox (received + sent) for the last 1–2 days, read calendar for the next 48h, and reconcile every material event into the CRM as an interaction, task, meeting, journal entry, stage change, or briefing.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,29 @@ Most CRMs are built for sales teams. Claw is built for one person managing 10-50
 
 ## Quick Start
 
+### Docker (recommended — one command, ~2 minutes)
+
+```bash
+git clone https://github.com/MagneticStudio/claw-crm.git
+cd claw-crm
+docker compose up
+```
+
+Open [http://localhost:3000](http://localhost:3000) — the first visit walks you through choosing a PIN and hands you your API key + MCP token. No env files, no manual schema push; the schema is applied automatically on first boot. Data persists in a Docker volume across restarts.
+
+To connect your AI agent, grab the MCP URL from **Settings** inside the app (see [AI Agent Integration](#ai-agent-integration) below).
+
+### Railway (hosted, ~5 minutes)
+
+1. [Create a new Railway project](https://railway.com/new) → **Deploy from GitHub repo** → pick your fork of this repo.
+2. In the service settings, set **Root Directory** to `app`.
+3. Add a **PostgreSQL** database to the project, then set on the app service:
+   - `DATABASE_URL` → reference the Postgres `DATABASE_URL` variable
+   - `SESSION_SECRET` → any long random string
+4. Generate a domain for the service. Open it, set your PIN, done. Railway auto-deploys on every push to main.
+
+### Local development
+
 ```bash
 cd app
 cp .env.example .env   # set DATABASE_URL and SESSION_SECRET

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env
+*.log
+.DS_Store

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,17 @@
+# Claw CRM — single-image build for self-hosting.
+# Schema is pushed idempotently at container start (drizzle-kit push),
+# so a fresh Postgres works out of the box; boot-migrations handle the rest.
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+ENV NODE_ENV=production
+EXPOSE 3000
+
+CMD ["sh", "-c", "npx drizzle-kit push --force && node dist/index.js"]

--- a/app/server/auth.ts
+++ b/app/server/auth.ts
@@ -70,7 +70,10 @@ export function setupAuth(app: Express) {
       maxAge: 1000 * 60 * 60 * 24 * 30, // 30 days
       httpOnly: true,
       sameSite: "lax",
-      secure: process.env.NODE_ENV === "production",
+      // "auto": Secure over HTTPS (Railway, behind trust-proxy), plain over HTTP
+      // (Docker self-host on localhost). A hard `true` in production silently
+      // breaks login for plain-HTTP self-hosts — the cookie never gets set.
+      secure: process.env.NODE_ENV === "production" ? "auto" : false,
     },
   };
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+# Claw CRM — one-command self-host: `docker compose up`
+# App on http://localhost:3000 — first visit walks you through PIN setup.
+# Set SESSION_SECRET in your environment (or a .env file next to this compose file)
+# before exposing this to a network.
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: claw
+      POSTGRES_PASSWORD: claw
+      POSTGRES_DB: claw_crm
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U claw -d claw_crm"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  app:
+    build: ./app
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgresql://claw:claw@db:5432/claw_crm
+      SESSION_SECRET: ${SESSION_SECRET:-dev-only-change-me}
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary

The target user keeps clients in Apple Notes — they were never going to provision Postgres, copy env files, and push a schema by hand. This PR makes adoption start with one command.

- **`docker compose up`** from a fresh clone now yields a working CRM at localhost:3000 in ~2 minutes: Postgres 16 + app image, schema applied idempotently at container start (`drizzle-kit push` before boot; boot-migrations unchanged), first-visit PIN setup, data persisted in a named volume.
- **`app/Dockerfile` + `.dockerignore`** — single-image production build (vite + esbuild).
- **Session cookie fix (the real bug this surfaced):** `cookie.secure` was hard-`true` in production, so any plain-HTTP self-host got a login that returned 200 but never set the session cookie — silent total login failure. Now `"auto"`: Secure over HTTPS (Railway, behind the existing `trust proxy`), plain over HTTP (Docker on localhost).
- **README Quick Start rewritten** around three paths: Docker (recommended), Railway deploy-from-repo steps, local dev.

## Verification

- **Cold-start container (production mode, fresh volume):** `/api/setup` 201 → `/api/login` 200 with persisted session → authed `/api/contacts` 200 → MCP `initialize` 200.
- **Full E2E skill run** on this branch after the auth change: all 18 steps pass (manifest in `e2e-screenshots/run.json`).
- `npm run lint:fix` clean, `npm run build` passes.

## Follow-up (not in this PR)

Publishing a one-click Railway **marketplace template** requires the template-composer flow on a Railway account — a 10-minute manual step. The README documents the deploy-from-repo path that works today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)