### PR TITLE
Add crm-migrate skill: bulk import from existing notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-06-10
 
+### New skill: `crm-migrate` — bulk import from existing notes
+Adds `skills/crm-migrate/SKILL.md`, the onboarding path. Nobody adopts a CRM from zero — the user's client history lives in Apple Notes, Notion, or a spreadsheet, and the CRM's value depends on that history coming across. The skill reads the whole source first, maps every person (identity, stage guess, dated events → interactions, narrative → journal, open loops → tasks), presents one migration plan for approval, then executes via `create_contact`, `add_interaction`, `batch_append_journal`, `edit_journal`, and `create_task` with per-write verification. Hard rules: never invent data, dates become absolute or stay in narrative, verbatim material goes in blockquotes, passing mentions become Key People (not contacts), layered confidentiality applies (pricing → journal only). Ends by pointing at `crm-management` for ongoing sync. README updated to document all three skills.
+
 ### Zero-friction install: Docker one-liner + Railway guide
 The target user keeps clients in Apple Notes — they were never going to provision Postgres and push a schema by hand. Adoption now starts with `docker compose up`:
 

--- a/README.md
+++ b/README.md
@@ -89,18 +89,19 @@ Uses `mcp-client.ts` which calls the REST API over HTTP:
 
 ### Skills (optional but recommended)
 
-Two skills ship with the repo:
+Three skills ship with the repo:
 
 - **`skills/crm/SKILL.md`** — a lightweight "when to use the CRM" guide that loads proactively. Claude sees the mental model (data-partition rule, five-layer structure, pre-write checklist, strategic-vs-operational meetings) before any tool call. The detailed writing contract, stage enums, and validation rules stay in `get_crm_guide` and load on-demand.
+- **`skills/crm-migrate/SKILL.md`** — one-time bulk import. Paste your existing client notes (Apple Notes, Notion, Google Docs, a spreadsheet — wherever they live today) and the agent maps every person, proposes a migration plan for your approval, then builds contacts, journals, interactions, and tasks in one pass. Nobody starts from zero; this is how your history comes across.
 - **`skills/crm-management/SKILL.md`** — a scheduled sync agent that reconciles the CRM with your inbox and calendar: logs material interactions, curates the Meetings layer, builds briefings for strategic meetings in the next 24h, and ends every run with an action-first summary (`DECIDE:` / `FLAG:` / `AT RISK:`). Pair it with an email + calendar MCP connector and a daily schedule ("run my CRM agent"). It depends on the `crm` skill for the data-model contract.
 
 Install paths:
 
 - **Claude Code**: copy the files into your personal skills directory.
   ```bash
-  mkdir -p ~/.claude/skills/crm ~/.claude/skills/crm-management
-  cp skills/crm/SKILL.md ~/.claude/skills/crm/
-  cp skills/crm-management/SKILL.md ~/.claude/skills/crm-management/
+  for s in crm crm-migrate crm-management; do
+    mkdir -p ~/.claude/skills/$s && cp skills/$s/SKILL.md ~/.claude/skills/$s/
+  done
   ```
   Claude Code auto-loads on session start.
 - **Claude Desktop / Claude.ai personal**: open a Project → Custom Instructions → paste the SKILL.md body. (Native plugin/skill install for claude.ai consumer isn't available yet; manual paste is the current path.)

--- a/skills/crm-migrate/SKILL.md
+++ b/skills/crm-migrate/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: crm-migrate
+description: One-time bulk import that turns existing client notes into a populated CRM — a pasted notes doc, an Apple Notes / Notion / Google Docs export, a spreadsheet of contacts, or a folder of per-client files. Use when the user wants to (1) set up their CRM from existing notes, (2) import or migrate contacts in bulk, (3) backfill history for clients they already work with. Trigger on "import my notes", "migrate my contacts", "set up my CRM from this", "here are my client notes", or any paste of multi-person historical notes into a fresh CRM. Do not invoke for logging new single events; use the `crm` skill for those.
+---
+
+# CRM Migration Agent
+
+Nobody starts from zero. The user has months or years of client history in a notes app, and the value of the CRM depends on that history coming across faithfully. This skill turns a messy source into clean contacts, journals, interactions, and tasks — in one pass, with one confirmation gate.
+
+## Non-negotiables
+
+- **Never invent data.** Empty field beats guessed field. No fabricated emails, titles, dates, or companies.
+- **One confirmation gate, then execute.** Present the full migration plan once, get a yes, run it end to end. Don't ask per-contact questions unless a record is genuinely undecidable.
+- **The source is history, not gospel.** Log what the notes say happened; route opinions and reads to the journal; route open loops to tasks.
+- **Dates must become absolute.** "Last Tuesday" in an undated note is unrecoverable — put the fact in the journal narrative without a fabricated date rather than guessing. If the source note itself is dated, resolve relative phrases against that date.
+- **Verbatim material goes in blockquotes.** Emails, quotes, transcripts pasted in the source are preserved exactly, inside `>` blockquotes (this also bypasses the relative-date validator).
+
+## Required inputs
+
+- The CRM MCP connector (stop with one line if missing).
+- The source material: pasted text, attached files, or a path the user names.
+- The `crm` skill's mental model applies throughout — data-partition rule, five-layer model, pre-write checklist, layered confidentiality.
+
+## Phase 1 — Read and map
+
+1. Call `get_crm_guide` for the live contract and enums.
+2. Call `get_dashboard` — if the CRM already has contacts, this is a merge, not a fresh import: check each source person against existing contacts before planning creates.
+3. Read the ENTIRE source before writing anything. Build a person-by-person map:
+   - **Identity**: name, company, title, email/phone/LinkedIn if present
+   - **Stage guess** from the narrative (use the guide's enums): actively scoping → `PROPOSAL`/`NEGOTIATION`; paying client → `LIVE`; went quiet or "not now" → `HOLD` status or `PASS`; warm non-prospect → `RELATIONSHIP`; everyone else → `LEAD`/`MEETING`
+   - **Dated events** → interaction candidates (past tense, one sentence each, thread/event-level not line-level)
+   - **Narrative, reads, and history** → journal material (Key People, Wins, Engagement History for span summaries, dated Entries where the source gives real dates)
+   - **Open loops** ("need to send", "waiting on", "follow up") → task candidates with due dates where stated
+4. People mentioned only in passing (a colleague CC'd once) are NOT contacts — they belong in the primary contact's journal `## Key People`.
+
+## Phase 2 — Propose
+
+Present one compact plan for approval:
+
+```
+MIGRATION PLAN — 12 contacts from <source>
+- Jane Doe (Acme, CEO) → LIVE. 6 interactions (2025-09 → 2026-04), journal w/ Engagement History, 1 task.
+- John Roe (Bolt) → PASS. 2 interactions, short journal.
+- …
+SKIPPED: 3 names mentioned in passing (→ Key People on their primary contact).
+UNRESOLVED: "Mike" appears in two clients' notes — same person? (only blocking question)
+```
+
+Wait for confirmation. Apply requested corrections to the plan, not mid-write.
+
+## Phase 3 — Execute
+
+Per contact, in this order:
+
+1. `create_contact` — identity fields plus `background` (one-line who-they-are), `source` (how they entered the orbit, if the notes say).
+2. `add_interaction` for each dated atomic event — past tense, one sentence, correct `type` (`meeting`/`call`/`email`/`note`). Thread-level granularity.
+3. Journal via `batch_append_journal` for dated Entries (chronological, absolute dates), and `edit_journal` to populate `## Key People`, `## Wins / Case Study Material`, and `## Engagement History` (the home for "Q3 2025: phase 1 delivered…" span summaries — do NOT fake a date to force these into Entries).
+4. `create_task` for open loops with real due dates. An open loop with no inferable date gets listed in the final report instead of a guessed deadline.
+5. Verify each write before moving on. On validation failure (relative date, duplicate section), fix and retry once; if still failing, note it in the report and continue.
+
+Confidentiality (layered, same as the `crm` skill): pricing and deal terms from the source go in the journal only — never into interactions, tasks, or contact fields. Cross-client specifics never cross records. Credentials never migrate at all.
+
+## Phase 4 — Report
+
+End with one summary: contacts created (by stage), interactions/journal entries/tasks written, anything skipped or unresolved, any write that failed validation. Then suggest the natural next step: connect the inbox/calendar sync agent (`crm-management`) so the CRM stays current from here.


### PR DESCRIPTION
## Summary

Adds `skills/crm-migrate/SKILL.md` — the onboarding path. The pitch for Claw is "your agent keeps your CRM," but the first hour is "how does my existing mess get in?" This skill is the answer: paste your client notes (Apple Notes / Notion / Google Docs / spreadsheet), the agent maps every person, proposes one migration plan for approval, then builds contacts, journals, interactions, and tasks in a single verified pass.

Design choices:
- **Read everything before writing anything**, then a single confirmation gate — not 12 rounds of per-contact questions.
- **Never invent data**: empty field beats guessed field; undatable events stay in journal narrative rather than getting fabricated dates.
- **Passing mentions become `## Key People` entries**, not contacts — keeps the contact list honest.
- **Merge-aware**: checks existing contacts first, so it's safe on a non-empty CRM.
- **Layered confidentiality enforced at import time** (pricing → journal only; credentials never migrate).
- Hands off to `crm-management` for ongoing sync at the end — the two skills together are the full lifecycle: migrate once, sync daily.

## Consistency updates

- README: Skills section now documents all three skills; install snippet loops over them.
- CHANGELOG entry added.

Docs/skill-only change — no app code touched. E2E manifest from the full run on the cookie-fix branch (~10 min ago, all 18 steps pass) is current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)