### PR TITLE
Add UI path to create contacts (#86)

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -143,6 +143,15 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 - Call `save_briefing` via MCP with a valid 8-section briefing. Verify it succeeds.
 - Call `get_briefing` via MCP on the contact. Verify the response JSON includes `content`, `updatedAt`, `ageDays`, and `stale: false`.
 
+### 6e. UI: Create a contact via the + button
+- On the CRM page (desktop width), verify a **UserPlus icon button** (`aria-label="Add contact"`) appears in the header between the search icon and the stage-filter icon.
+- Resize to mobile width (≤640px): verify the header button is hidden and a **56px round teal FAB** (`aria-label="Add contact"`) appears fixed bottom-right. Resize back to desktop.
+- Click the header Add contact button. Verify a bottom sheet (`data-testid="add-contact-sheet"`) slides up with fields: First name, Last name, Company, Title, Email, LinkedIn URL, and an **Add contact** submit button (disabled until First name has text).
+- Fill First name `E2E`, Last name `Contact`, Company `E2E Test Co`, click **Add contact**.
+- Verify the sheet closes and a new contact card "E2E Contact" appears in the list with company "E2E Test Co" (find-or-create company path: POST /api/contacts with `companyName`).
+- Create a second contact with the same company name `E2E Test Co` — verify via API or DB that both contacts share one company row (no duplicate company created).
+- **Screenshot** → `e2e-screenshots/08-contact-created.png`
+
 ### 9. MCP: Add interaction via agent
 - Call `add_interaction` via MCP with a test note
 - Navigate to the CRM page in the browser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 2026-06-10
 
+### Add a UI path to create contacts (#86)
+Until now the only ways to create a contact were MCP tools or seeding — a solo user on mobile with no agent was stuck. Two affordances, one new component:
+
+- **Desktop**: a UserPlus icon button in the header (between search and stage filter).
+- **Mobile (<640px)**: a 56px teal FAB fixed bottom-right; the header button hides.
+- Both open `add-contact-sheet.tsx` — a bottom sheet with First/Last name, Company, Title, Email, LinkedIn URL. Submit disabled until First name has text. Errors surface inline.
+- `POST /api/contacts` now accepts a free-form `companyName` and resolves it case-insensitively via the new `storage.findOrCreateCompanyByName` — the same convenience the MCP `create_contact` path has always had (its helper now delegates to the shared storage method).
+- New E2E step 6e covers the button/FAB visibility split, the sheet flow, and company dedup (two contacts entering the same company name share one company row).
+
 ### New skill: `crm-migrate` — bulk import from existing notes
 Adds `skills/crm-migrate/SKILL.md`, the onboarding path. Nobody adopts a CRM from zero — the user's client history lives in Apple Notes, Notion, or a spreadsheet, and the CRM's value depends on that history coming across. The skill reads the whole source first, maps every person (identity, stage guess, dated events → interactions, narrative → journal, open loops → tasks), presents one migration plan for approval, then executes via `create_contact`, `add_interaction`, `batch_append_journal`, `edit_journal`, and `create_task` with per-write verification. Hard rules: never invent data, dates become absolute or stay in narrative, verbatim material goes in blockquotes, passing mentions become Key People (not contacts), layered confidentiality applies (pricing → journal only). Ends by pointing at `crm-management` for ongoing sync. README updated to document all three skills.
 

--- a/app/client/src/components/add-contact-sheet.tsx
+++ b/app/client/src/components/add-contact-sheet.tsx
@@ -1,0 +1,136 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+import { useColors } from "@/App";
+
+interface AddContactSheetProps {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (data: Record<string, unknown>) => Promise<unknown>;
+}
+
+const EMPTY = { firstName: "", lastName: "", companyName: "", title: "", email: "", linkedinUrl: "" };
+
+export function AddContactSheet({ open, onClose, onCreate }: AddContactSheetProps) {
+  const C = useColors();
+  const [form, setForm] = useState(EMPTY);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const set = (key: keyof typeof EMPTY) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setForm((f) => ({ ...f, [key]: e.target.value }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.firstName.trim() || saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await onCreate({
+        firstName: form.firstName.trim(),
+        lastName: form.lastName.trim(),
+        ...(form.companyName.trim() ? { companyName: form.companyName.trim() } : {}),
+        ...(form.title.trim() ? { title: form.title.trim() } : {}),
+        ...(form.email.trim() ? { email: form.email.trim() } : {}),
+        ...(form.linkedinUrl.trim() ? { linkedinUrl: form.linkedinUrl.trim() } : {}),
+      });
+      setForm(EMPTY);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create contact");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const inputStyle = {
+    border: `1px solid ${C.border}`,
+    borderRadius: 8,
+    color: C.text,
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-[69] bg-black/20" onClick={onClose} />
+      <div
+        className="fixed bottom-0 left-1/2 -translate-x-1/2 z-[70] w-full max-w-[640px] px-4 pt-4 pb-6 bg-white"
+        style={{ borderRadius: "16px 16px 0 0", boxShadow: "0 -4px 24px rgba(0,0,0,0.12)" }}
+        data-testid="add-contact-sheet"
+      >
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-[13px] font-semibold tracking-[0.15em] uppercase" style={{ color: C.text }}>
+            New contact
+          </h2>
+          <button onClick={onClose} className="p-1.5 hover:opacity-70" style={{ color: C.muted }} aria-label="Close">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+          <div className="flex gap-2">
+            <input
+              autoFocus
+              required
+              placeholder="First name"
+              value={form.firstName}
+              onChange={set("firstName")}
+              className="flex-1 min-w-0 text-[13px] px-3 py-2.5 outline-none"
+              style={inputStyle}
+            />
+            <input
+              placeholder="Last name"
+              value={form.lastName}
+              onChange={set("lastName")}
+              className="flex-1 min-w-0 text-[13px] px-3 py-2.5 outline-none"
+              style={inputStyle}
+            />
+          </div>
+          <input
+            placeholder="Company"
+            value={form.companyName}
+            onChange={set("companyName")}
+            className="text-[13px] px-3 py-2.5 outline-none"
+            style={inputStyle}
+          />
+          <div className="flex gap-2">
+            <input
+              placeholder="Title"
+              value={form.title}
+              onChange={set("title")}
+              className="flex-1 min-w-0 text-[13px] px-3 py-2.5 outline-none"
+              style={inputStyle}
+            />
+            <input
+              type="email"
+              placeholder="Email"
+              value={form.email}
+              onChange={set("email")}
+              className="flex-1 min-w-0 text-[13px] px-3 py-2.5 outline-none"
+              style={inputStyle}
+            />
+          </div>
+          <input
+            placeholder="LinkedIn URL"
+            value={form.linkedinUrl}
+            onChange={set("linkedinUrl")}
+            className="text-[13px] px-3 py-2.5 outline-none"
+            style={inputStyle}
+          />
+          {error && (
+            <p className="text-[12px] px-1" style={{ color: C.red }}>
+              {error}
+            </p>
+          )}
+          <button
+            type="submit"
+            disabled={!form.firstName.trim() || saving}
+            className="mt-1 py-2.5 text-[13px] font-semibold text-white transition-opacity disabled:opacity-40"
+            style={{ backgroundColor: C.accent, borderRadius: 12 }}
+          >
+            {saving ? "Adding…" : "Add contact"}
+          </button>
+        </form>
+      </div>
+    </>
+  );
+}

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { useContactSearch } from "@/hooks/use-contact-search";
 import { ContactBlock } from "@/components/contact-block";
 import { SearchBar } from "@/components/search-bar";
+import { AddContactSheet } from "@/components/add-contact-sheet";
 import {
   Loader2,
   LogOut,
@@ -21,6 +22,8 @@ import {
   Menu,
   Check,
   Clock,
+  Plus,
+  UserPlus,
 } from "lucide-react";
 import { KanbanBoard } from "@/components/kanban/kanban-board";
 import { Link } from "wouter";
@@ -55,6 +58,7 @@ export default function CrmPage() {
     deleteFollowup,
     completeFollowup,
     updateContact,
+    createContact,
   } = useCrm();
   const { logoutMutation } = useAuth();
   const [activeStage, setActiveStage] = useState<string>("ALL");
@@ -67,6 +71,7 @@ export default function CrmPage() {
   }, [viewMode]);
   const [showFilter, setShowFilter] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
+  const [showAddContact, setShowAddContact] = useState(false);
   // Search state — lives at the CrmPage level because it overrides
   // displayedContacts and forces list view while a query is active.
   const [searchOpen, setSearchOpen] = useState(false);
@@ -249,6 +254,23 @@ export default function CrmPage() {
               onArrowDown={() => setHighlightedIndex((i) => Math.min(displayedContacts.length - 1, i + 1))}
               onArrowUp={() => setHighlightedIndex((i) => Math.max(0, i - 1))}
             />
+            {/* Add contact — hidden on mobile (FAB covers it) and while searching */}
+            {!searchOpen && (
+              <button
+                onClick={() => {
+                  setShowAddContact(true);
+                  setShowFilter(false);
+                  setShowMenu(false);
+                }}
+                className="p-2 transition-colors hidden sm:block"
+                style={{ color: C.muted }}
+                title="Add contact"
+                aria-label="Add contact"
+              >
+                <UserPlus className="h-4 w-4" />
+              </button>
+            )}
+
             {/* Filter button — hidden while searching to give the input room */}
             {!searchOpen && (
               <button
@@ -732,6 +754,22 @@ export default function CrmPage() {
           )}
         </main>
       )}
+
+      {/* Mobile FAB — the header button is hidden below sm */}
+      <button
+        onClick={() => setShowAddContact(true)}
+        className="sm:hidden fixed bottom-5 right-5 z-[60] h-14 w-14 flex items-center justify-center rounded-full text-white"
+        style={{ backgroundColor: C.accent, boxShadow: "0 4px 16px rgba(0,0,0,0.2)" }}
+        aria-label="Add contact"
+      >
+        <Plus className="h-6 w-6" />
+      </button>
+
+      <AddContactSheet
+        open={showAddContact}
+        onClose={() => setShowAddContact(false)}
+        onCreate={(data) => createContact.mutateAsync(data)}
+      />
     </div>
   );
 }

--- a/app/server/mcp-remote.ts
+++ b/app/server/mcp-remote.ts
@@ -52,11 +52,8 @@ import { randomUUID } from "crypto";
 // --- Helpers ---
 
 async function findOrCreateCompany(name: string): Promise<number> {
-  const allCompanies = await storage.getCompanies();
-  const match = allCompanies.find((c) => c.name.toLowerCase() === name.toLowerCase());
-  if (match) return match.id;
-  const created = await storage.createCompany({ name });
-  return created.id;
+  const company = await storage.findOrCreateCompanyByName(name);
+  return company.id;
 }
 
 /** Resolve contactId → "FirstName LastName" for enriching list responses */

--- a/app/server/routes.ts
+++ b/app/server/routes.ts
@@ -126,7 +126,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   app.post("/api/contacts", requireAuth, async (req, res) => {
-    const parsed = insertContactSchema.safeParse(req.body);
+    // Accept a free-form companyName (same convenience the MCP path offers)
+    // and resolve it to companyId before schema validation.
+    const { companyName, ...body } = req.body ?? {};
+    if (typeof companyName === "string" && companyName.trim()) {
+      const company = await storage.findOrCreateCompanyByName(companyName.trim());
+      body.companyId = company.id;
+    }
+    const parsed = insertContactSchema.safeParse(body);
     if (!parsed.success) return res.status(400).json({ message: parsed.error.message });
     const contact = await storage.createContact(parsed.data);
     res.status(201).json(contact);

--- a/app/server/storage.ts
+++ b/app/server/storage.ts
@@ -119,6 +119,13 @@ export class Storage {
     return company;
   }
 
+  async findOrCreateCompanyByName(name: string): Promise<Company> {
+    const all = await this.getCompanies();
+    const match = all.find((c) => c.name.toLowerCase() === name.toLowerCase());
+    if (match) return match;
+    return this.createCompany({ name });
+  }
+
   async updateCompany(id: number, data: Partial<InsertCompany>): Promise<Company | undefined> {
     const [company] = await db.update(companies).set(data).where(eq(companies.id, id)).returning();
     return company;


### PR DESCRIPTION
## Summary

Fixes the p0 gap from #86: there was no UI way to create a contact — MCP tools or slash commands on an *existing* contact were the only paths, which stranded a solo user on mobile with no agent.

- **Desktop**: UserPlus icon button in the header, consistent with the existing icon row (search / filter / menu).
- **Mobile (<640px)**: 56px primary-teal FAB fixed bottom-right (per the issue's spec); header button hides below `sm`.
- Both open a new bottom sheet (`add-contact-sheet.tsx`): First name (required), Last name, Company, Title, Email, LinkedIn URL. Inline error display, submit disabled until first name present.
- **Server**: `POST /api/contacts` accepts free-form `companyName`, resolved case-insensitively through the new `storage.findOrCreateCompanyByName` — extracted from the MCP path's helper so both write paths share one implementation.

## Verification

- New E2E step **6e** added to the skill (per the pre-PR rule) covering: header-button/FAB visibility split at 640px, sheet open/validate/submit, contact appears in list, and company dedup — verified in DB that two contacts entering "E2E Test Co"/"e2e test co" share a single company row.
- Full E2E suite re-run on this branch: **all 19 steps pass** (manifest in `e2e-screenshots/run.json`).
- `npm run lint:fix` clean, `npm run build` passes, `npm run format` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)