### PR TITLE
Desktop master-detail layout — break the 640px ceiling (#82)

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -152,6 +152,16 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 - Create a second contact with the same company name `E2E Test Co` — verify via API or DB that both contacts share one company row (no duplicate company created).
 - **Screenshot** → `e2e-screenshots/08-contact-created.png`
 
+### 6f. UI: Desktop master-detail layout (≥1024px)
+- At a 1280px viewport in list view, verify the page is two-pane: a left rail (`data-testid="contact-rail"`, ~360px) of compact contact rows (name + company + stage tag + status edge bar) with the Upcoming strip above it, and a right detail pane (`data-testid="contact-detail"`) showing ONE full contact card.
+- Verify the first displayed contact is selected by default (teal-highlighted row, its card in the detail pane).
+- Click a different row — verify the detail pane switches to that contact and the row highlights.
+- In the detail pane, add a note via the input — verify it lands on the selected contact.
+- Open search (Cmd+K), type a contact name, press ArrowDown then Enter — verify the highlighted result becomes the selected contact in the detail pane.
+- Switch to kanban view at 1280px: verify all six stage columns render side by side (no stacked pairs). Click a kanban card — verify it switches to list view with that contact selected in the detail pane.
+- Resize to 800px — verify the classic single-column card list returns (no rail, no detail pane). Resize to 390px — single column persists (mobile unchanged).
+- **Screenshot** → `e2e-screenshots/09-master-detail.png`
+
 ### 9. MCP: Add interaction via agent
 - Call `add_interaction` via MCP with a test note
 - Navigate to the CRM page in the browser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 2026-06-10
 
+### Desktop master-detail layout — break the 640px ceiling (#82)
+At 1280px the app was a single 640px column floating in empty space. Now, in list view at ≥1024px:
+
+- **Left rail (360px)**: the Upcoming strip plus compact one-line contact rows (`contact-row.tsx`) — name, company, stage tag, status edge bar. Selected row tinted teal.
+- **Right pane**: the full contact card (unchanged `ContactBlock`) for the selected contact only. First displayed contact selected by default; selection falls back gracefully when filters/search change the set.
+- Search integrates: ArrowDown highlights rows, Enter opens the highlighted result in the detail pane.
+- Kanban tap now selects the contact in the detail pane (in addition to switching to list view).
+- **Kanban at ≥1024px**: all six stages render as true side-by-side columns (the stacked-pairs layout now covers 768–1023px only; mobile swimlanes unchanged).
+- Below 1024px nothing changes — the classic single-column notebook is untouched, mobile-first stays first.
+- New E2E step 6f covers the two-pane structure, row selection, detail-pane writes, search-Enter selection, wide kanban, kanban tap-to-select, and responsive collapse at 800px/390px.
+
 ### CONTRIBUTING.md + launch essay draft
 Adds `CONTRIBUTING.md` — the taste test (simplicity + agent connectivity as the two pillars every change is measured against), setup, ground rules (single write path, MCP try/catch, schema/boot-migration pairing, E2E-before-PR), and conventions. Also adds `docs/launch-essay-draft.md`, the draft of the "I let Claude run my CRM for 90 days" launch essay distilling the agent-hygiene learnings from the changelog (over-logging, prompt-rule decay → server validation, retrospective timeline distortion, meetings-layer curation, cross-layer dedup, the unattended-sync unlock).
 

--- a/app/client/src/components/contact-row.tsx
+++ b/app/client/src/components/contact-row.tsx
@@ -1,0 +1,59 @@
+import type { ContactWithRelations } from "@shared/schema";
+import { useColors } from "@/App";
+
+// Mirrors the stage palette used by contact-block and the kanban board.
+const STAGE_ACCENT: Record<string, string> = {
+  LEAD: "#5a7a7a",
+  MEETING: "#2bbcb3",
+  PROPOSAL: "#2563eb",
+  NEGOTIATION: "#d4880f",
+  LIVE: "#2e7d32",
+  RELATIONSHIP: "#1a9e96",
+  PASS: "#c0392b",
+};
+
+const HOLD_COLOR = "#6c5ce7";
+
+interface ContactRowProps {
+  contact: ContactWithRelations;
+  selected: boolean;
+  highlighted?: boolean;
+  onSelect: () => void;
+}
+
+/** Compact one-line contact row for the desktop master-detail rail. */
+export function ContactRow({ contact, selected, highlighted, onSelect }: ContactRowProps) {
+  const C = useColors();
+  const statusColor = contact.status === "HOLD" ? HOLD_COLOR : C.accent;
+  const stageColor = STAGE_ACCENT[contact.stage] || C.accent;
+
+  return (
+    <button
+      onClick={onSelect}
+      data-testid={`contact-row-${contact.id}`}
+      className="w-full flex items-center gap-2.5 text-left px-3 py-2.5 transition-colors"
+      style={{
+        backgroundColor: selected ? C.accentLight : "transparent",
+        boxShadow: highlighted ? `inset 0 0 0 2px ${C.accent}` : undefined,
+        borderLeft: `3px solid ${statusColor}`,
+      }}
+    >
+      <span className="flex-1 min-w-0">
+        <span className="block text-[13px] font-medium truncate" style={{ color: selected ? C.accentDark : C.text }}>
+          {contact.firstName} {contact.lastName}
+        </span>
+        {contact.company && (
+          <span className="block text-[11px] truncate" style={{ color: C.muted }}>
+            {contact.company.name}
+          </span>
+        )}
+      </span>
+      <span
+        className="flex-shrink-0 text-[9px] font-semibold px-1.5 py-0.5 rounded-full"
+        style={{ backgroundColor: `${stageColor}15`, color: stageColor }}
+      >
+        {contact.stage}
+      </span>
+    </button>
+  );
+}

--- a/app/client/src/components/kanban/kanban-board.tsx
+++ b/app/client/src/components/kanban/kanban-board.tsx
@@ -53,6 +53,9 @@ interface KanbanBoardProps {
 export function KanbanBoard({ contacts, updateContact, onContactTap }: KanbanBoardProps) {
   const [activeId, setActiveId] = useState<number | null>(null);
   const isMobile = useIsMobile();
+  // ≥1024px: all six stages side by side (#82). 768–1023px keeps the
+  // stacked-pairs layout; <768px keeps the vertical swimlanes.
+  const isNarrowDesktop = useIsMobile(1024);
   const boardRef = useRef<HTMLDivElement>(null);
   const pointerStart = useRef<{ x: number; y: number; t: number } | null>(null);
   const didDrag = useRef(false);
@@ -160,8 +163,8 @@ export function KanbanBoard({ contacts, updateContact, onContactTap }: KanbanBoa
               </Fragment>
             ))}
           </div>
-        ) : (
-          /* Desktop: 3 columns with stacked stage pairs, compact cards */
+        ) : isNarrowDesktop ? (
+          /* Tablet (768–1023px): 3 columns with stacked stage pairs, compact cards */
           <div className="max-w-[640px] mx-auto px-4 py-4">
             <div className="grid grid-cols-3 gap-2">
               {DESKTOP_PAIRS.map(([top, bottom]) => (
@@ -179,6 +182,21 @@ export function KanbanBoard({ contacts, updateContact, onContactTap }: KanbanBoa
                     compact
                   />
                 </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          /* Wide desktop (≥1024px): every stage gets its own column (#82) */
+          <div className="max-w-[1400px] mx-auto px-4 py-4">
+            <div className="grid grid-cols-6 gap-2 items-start">
+              {COLUMN_ORDER.map((stage) => (
+                <KanbanColumn
+                  key={stage}
+                  stage={stage}
+                  contacts={grouped[stage]}
+                  accentColor={STAGE_ACCENT[stage] || "#5a7a7a"}
+                  compact
+                />
               ))}
             </div>
           </div>

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -5,6 +5,7 @@ import { useSSE } from "@/hooks/use-sse";
 import { useAuth } from "@/hooks/use-auth";
 import { useContactSearch } from "@/hooks/use-contact-search";
 import { ContactBlock } from "@/components/contact-block";
+import { ContactRow } from "@/components/contact-row";
 import { SearchBar } from "@/components/search-bar";
 import { AddContactSheet } from "@/components/add-contact-sheet";
 import {
@@ -28,7 +29,7 @@ import {
 import { KanbanBoard } from "@/components/kanban/kanban-board";
 import { Link } from "wouter";
 import { format, isPast, isToday, differenceInCalendarDays } from "date-fns";
-import type { Followup, ActivityLogEntry, Briefing } from "@shared/schema";
+import type { Followup, ActivityLogEntry, Briefing, ContactWithRelations } from "@shared/schema";
 import { fmtDate } from "@/lib/utils";
 import { useConfig, useColors } from "@/App";
 
@@ -72,6 +73,16 @@ export default function CrmPage() {
   const [showFilter, setShowFilter] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
   const [showAddContact, setShowAddContact] = useState(false);
+  // Desktop master-detail (#82): ≥1024px shows a compact contact rail + one
+  // full card. Below that, the classic single-column notebook is unchanged.
+  const [isDesktop, setIsDesktop] = useState(() => typeof window !== "undefined" && window.innerWidth >= 1024);
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 1024px)");
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  const [selectedContactId, setSelectedContactId] = useState<number | null>(null);
   // Search state — lives at the CrmPage level because it overrides
   // displayedContacts and forces list view while a query is active.
   const [searchOpen, setSearchOpen] = useState(false);
@@ -147,6 +158,25 @@ export default function CrmPage() {
   const isSearching = searchResults !== null;
   const displayedContacts = isSearching ? searchResults : filteredContacts;
   const effectiveViewMode = isSearching ? "list" : viewMode;
+  // Desktop detail pane: explicit selection if it's still in the displayed
+  // set, else fall back to the first displayed contact.
+  const selectedContact = displayedContacts.find((c) => c.id === selectedContactId) ?? displayedContacts[0] ?? null;
+
+  const renderContactBlock = (contact: ContactWithRelations) => (
+    <ContactBlock
+      contact={contact}
+      onAddInteraction={(content, date, type) => addInteraction.mutate({ contactId: contact.id, content, date, type })}
+      onUpdateInteraction={(id, data) => updateInteraction.mutate({ id, ...data })}
+      onDeleteInteraction={(id) => deleteInteraction.mutate(id)}
+      onCreateFollowup={(content, dueDate, opts) =>
+        createFollowup.mutate({ contactId: contact.id, content, dueDate, ...opts })
+      }
+      onUpdateFollowup={(id, data) => updateFollowup.mutate({ id, ...data })}
+      onDeleteFollowup={(id) => deleteFollowup.mutate(id)}
+      onCompleteFollowup={(id, outcome) => completeFollowup.mutate({ id, outcome })}
+      onUpdateContact={(data) => updateContact.mutate({ id: contact.id, ...data })}
+    />
+  );
 
   // Clamp the keyboard highlight whenever the result set shrinks.
   useEffect(() => {
@@ -231,7 +261,7 @@ export default function CrmPage() {
     <div className="min-h-screen" style={{ backgroundColor: "#f0f8f8" }}>
       {/* Header */}
       <header className="sticky top-0 z-50 bg-white" style={{ borderBottom: `1px solid ${C.border}` }}>
-        <div className="max-w-[640px] mx-auto px-4 py-3 flex items-center justify-between gap-2">
+        <div className="max-w-[640px] lg:max-w-[1200px] mx-auto px-4 py-3 flex items-center justify-between gap-2">
           {!searchOpen && (
             <h1 className="text-[13px] font-semibold tracking-[0.2em] uppercase" style={{ color: C.text }}>
               {orgName}
@@ -250,7 +280,13 @@ export default function CrmPage() {
                 requestAnimationFrame(() => searchInputRef.current?.focus());
               }}
               onClose={closeSearch}
-              onEnter={() => searchInputRef.current?.blur()}
+              onEnter={() => {
+                // On desktop, Enter opens the highlighted result in the detail pane.
+                if (isDesktop && isSearching && displayedContacts[highlightedIndex]) {
+                  setSelectedContactId(displayedContacts[highlightedIndex].id);
+                }
+                searchInputRef.current?.blur();
+              }}
               onArrowDown={() => setHighlightedIndex((i) => Math.min(displayedContacts.length - 1, i + 1))}
               onArrowUp={() => setHighlightedIndex((i) => Math.max(0, i - 1))}
             />
@@ -490,6 +526,7 @@ export default function CrmPage() {
           onContactTap={(id) => {
             setActiveStage("ALL");
             setViewMode("list");
+            setSelectedContactId(id);
             // Poll for the element to appear in the DOM after React renders the list
             let attempts = 0;
             const tryScroll = () => {
@@ -504,253 +541,280 @@ export default function CrmPage() {
           }}
         />
       ) : (
-        <main className="max-w-[640px] mx-auto px-4 py-5">
-          {/* Upcoming — all follow-ups and meetings in one list */}
-          {allFollowups.length > 0 && (
-            <div
-              className="bg-white mb-5"
-              style={{ border: `1px solid ${C.border}`, borderRadius: "12px", padding: "1rem 1.25rem" }}
-            >
-              <div className="mb-2">
-                <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: C.muted }}>
-                  Upcoming
-                </span>
-              </div>
-              <div className="space-y-1.5">
-                {allFollowups.map(({ followup: fu, contactName, briefing }) => {
-                  const due = new Date(fu.dueDate);
-                  // Meetings are scheduled events, not action items — a past meeting has
-                  // happened, it's not "overdue". Overdue only applies to tasks.
-                  const isOverdue = fu.type !== "meeting" && isPast(due) && !isToday(due);
-                  const isTodayDue = isToday(due);
-                  // Calendar-day difference — counts midnight crossings, so an item due tomorrow
-                  // reads as "1d" regardless of what hour it is today. differenceInDays measures
-                  // 24h periods, which is wrong for human-facing "days until".
-                  const daysUntil = differenceInCalendarDays(due, new Date());
-                  const dateColor = isOverdue ? C.red : isTodayDue ? C.stale : C.accentDark;
-                  const isCompleting = completingUpcomingId === fu.id;
+        <main className={`mx-auto px-4 py-5 ${isDesktop ? "max-w-[1200px] flex items-start gap-5" : "max-w-[640px]"}`}>
+          {/* Left rail on desktop (Upcoming + compact rows); the whole page on mobile */}
+          <div className={isDesktop ? "w-[360px] flex-shrink-0" : undefined}>
+            {/* Upcoming — all follow-ups and meetings in one list */}
+            {allFollowups.length > 0 && (
+              <div
+                className="bg-white mb-5"
+                style={{ border: `1px solid ${C.border}`, borderRadius: "12px", padding: "1rem 1.25rem" }}
+              >
+                <div className="mb-2">
+                  <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: C.muted }}>
+                    Upcoming
+                  </span>
+                </div>
+                <div className="space-y-1.5">
+                  {allFollowups.map(({ followup: fu, contactName, briefing }) => {
+                    const due = new Date(fu.dueDate);
+                    // Meetings are scheduled events, not action items — a past meeting has
+                    // happened, it's not "overdue". Overdue only applies to tasks.
+                    const isOverdue = fu.type !== "meeting" && isPast(due) && !isToday(due);
+                    const isTodayDue = isToday(due);
+                    // Calendar-day difference — counts midnight crossings, so an item due tomorrow
+                    // reads as "1d" regardless of what hour it is today. differenceInDays measures
+                    // 24h periods, which is wrong for human-facing "days until".
+                    const daysUntil = differenceInCalendarDays(due, new Date());
+                    const dateColor = isOverdue ? C.red : isTodayDue ? C.stale : C.accentDark;
+                    const isCompleting = completingUpcomingId === fu.id;
 
-                  if (isCompleting) {
-                    return (
-                      <div
-                        key={fu.id}
-                        className="rounded-lg px-3 py-2 space-y-2"
-                        style={{ backgroundColor: C.accentLight, border: `1px solid ${C.accent}40` }}
-                      >
-                        <div className="text-xs font-medium" style={{ color: C.accentDark }}>
-                          Completing: {fmtDate(due)} {fu.content} — {contactName}
-                        </div>
-                        <input
-                          autoFocus
-                          value={completingUpcomingText}
-                          onChange={(e) => setCompletingUpcomingText(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter" && completingUpcomingText.trim()) {
-                              completeFollowup.mutate({ id: fu.id, outcome: completingUpcomingText.trim() });
-                              setCompletingUpcomingId(null);
-                            }
-                            if (e.key === "Escape") setCompletingUpcomingId(null);
-                          }}
-                          placeholder="What happened?"
-                          className="w-full text-sm bg-white rounded px-2 py-1 outline-none"
-                          style={{ color: C.text, border: `1px solid ${C.accent}40` }}
-                        />
-                        <div className="flex items-center gap-2">
-                          <button
-                            onClick={() => {
-                              if (completingUpcomingText.trim()) {
+                    if (isCompleting) {
+                      return (
+                        <div
+                          key={fu.id}
+                          className="rounded-lg px-3 py-2 space-y-2"
+                          style={{ backgroundColor: C.accentLight, border: `1px solid ${C.accent}40` }}
+                        >
+                          <div className="text-xs font-medium" style={{ color: C.accentDark }}>
+                            Completing: {fmtDate(due)} {fu.content} — {contactName}
+                          </div>
+                          <input
+                            autoFocus
+                            value={completingUpcomingText}
+                            onChange={(e) => setCompletingUpcomingText(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter" && completingUpcomingText.trim()) {
                                 completeFollowup.mutate({ id: fu.id, outcome: completingUpcomingText.trim() });
                                 setCompletingUpcomingId(null);
                               }
+                              if (e.key === "Escape") setCompletingUpcomingId(null);
                             }}
-                            className="text-xs font-medium text-white px-2.5 py-1 rounded"
-                            style={{ backgroundColor: C.accentDark }}
-                          >
-                            Done
-                          </button>
-                          <button
-                            onClick={() => {
-                              completeFollowup.mutate({ id: fu.id });
-                              setCompletingUpcomingId(null);
-                            }}
-                            className="text-xs"
-                            style={{ color: C.muted }}
-                          >
-                            Skip note
-                          </button>
-                          <button
-                            onClick={() => setCompletingUpcomingId(null)}
-                            className="text-xs"
-                            style={{ color: C.muted }}
-                          >
-                            Cancel
-                          </button>
+                            placeholder="What happened?"
+                            className="w-full text-sm bg-white rounded px-2 py-1 outline-none"
+                            style={{ color: C.text, border: `1px solid ${C.accent}40` }}
+                          />
+                          <div className="flex items-center gap-2">
+                            <button
+                              onClick={() => {
+                                if (completingUpcomingText.trim()) {
+                                  completeFollowup.mutate({ id: fu.id, outcome: completingUpcomingText.trim() });
+                                  setCompletingUpcomingId(null);
+                                }
+                              }}
+                              className="text-xs font-medium text-white px-2.5 py-1 rounded"
+                              style={{ backgroundColor: C.accentDark }}
+                            >
+                              Done
+                            </button>
+                            <button
+                              onClick={() => {
+                                completeFollowup.mutate({ id: fu.id });
+                                setCompletingUpcomingId(null);
+                              }}
+                              className="text-xs"
+                              style={{ color: C.muted }}
+                            >
+                              Skip note
+                            </button>
+                            <button
+                              onClick={() => setCompletingUpcomingId(null)}
+                              className="text-xs"
+                              style={{ color: C.muted }}
+                            >
+                              Cancel
+                            </button>
+                          </div>
                         </div>
+                      );
+                    }
+
+                    const isMeeting = fu.type === "meeting";
+                    const meetingType = (fu.metadata as Record<string, unknown> | null)?.meetingType as
+                      | string
+                      | undefined;
+                    const meetingIcons: Record<string, string> = {
+                      call: "📞",
+                      video: "📹",
+                      "in-person": "🤝",
+                      coffee: "☕",
+                    };
+                    const meetingIcon = isMeeting ? (meetingType && meetingIcons[meetingType]) || "📅" : null;
+                    const isTodayMeeting = isMeeting && isTodayDue;
+                    const isExp = isTodayMeeting && expandedMeetingIds.has(fu.id);
+
+                    const handleUpcomingSnooze = (days: number) => {
+                      const newDate = new Date(due);
+                      newDate.setDate(newDate.getDate() + days);
+                      updateFollowup.mutate({ id: fu.id, dueDate: newDate.toISOString() });
+                    };
+
+                    return (
+                      <div key={fu.id} className="group/upcoming py-0.5">
+                        <div className="flex items-start gap-2">
+                          {isMeeting ? (
+                            <span
+                              className={`flex-shrink-0 leading-none mt-0.5 ${isTodayMeeting ? "cursor-pointer" : ""}`}
+                              onClick={isTodayMeeting ? () => toggleMeetingExpand(fu.id) : undefined}
+                            >
+                              {meetingIcon}
+                            </span>
+                          ) : (
+                            <button
+                              onClick={() => {
+                                setCompletingUpcomingId(fu.id);
+                                setCompletingUpcomingText(fu.content);
+                              }}
+                              className="flex-shrink-0 hover:opacity-70 transition-colors mt-1"
+                              title="Complete"
+                            >
+                              <Square className="h-3.5 w-3.5" style={{ color: dateColor }} />
+                            </button>
+                          )}
+                          <div className="flex-1 min-w-0">
+                            {/* Meta line — date, time, contact, relative pill, hover snooze */}
+                            <div className="flex items-center gap-1.5 text-[11px] leading-tight flex-wrap">
+                              <span
+                                className="font-semibold whitespace-nowrap"
+                                style={{ color: isMeeting ? "#2563eb" : dateColor }}
+                              >
+                                {fmtDate(due)}
+                                {fu.time ? ` ${fu.time}` : ""}
+                              </span>
+                              {isOverdue && (
+                                <span className="font-semibold uppercase tracking-wide" style={{ color: C.red }}>
+                                  · Overdue
+                                </span>
+                              )}
+                              {isTodayDue && (
+                                <span className="font-semibold uppercase tracking-wide" style={{ color: C.stale }}>
+                                  · Today
+                                </span>
+                              )}
+                              {!isOverdue && !isTodayDue && daysUntil <= 7 && (
+                                <span style={{ color: C.muted }}>· {daysUntil}d</span>
+                              )}
+                              <span style={{ color: C.muted }}>·</span>
+                              <span className="truncate" style={{ color: C.muted }}>
+                                {contactName}
+                              </span>
+                              <span className="hidden group-hover/upcoming:inline-flex items-center gap-1 ml-auto">
+                                <Clock className="h-3 w-3" style={{ color: C.muted }} />
+                                {[1, 7, 14].map((d) => (
+                                  <button
+                                    key={d}
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleUpcomingSnooze(d);
+                                    }}
+                                    className="text-[10px] px-1.5 py-0.5 rounded-full transition-colors hover:opacity-80"
+                                    style={{ backgroundColor: C.accentLight, color: C.accentDark }}
+                                    title={`Snooze ${d} day${d > 1 ? "s" : ""}`}
+                                  >
+                                    +{d}d
+                                  </button>
+                                ))}
+                              </span>
+                            </div>
+                            {/* Content line — full width, primary readable */}
+                            <div className="text-sm leading-snug mt-0.5" style={{ color: C.text }}>
+                              {fu.content}
+                              {fu.location ? <span style={{ color: C.muted }}> — {fu.location}</span> : null}
+                            </div>
+                          </div>
+                          {isTodayMeeting && (
+                            <ChevronDown
+                              className={`h-3.5 w-3.5 flex-shrink-0 mt-1 transition-transform cursor-pointer ${isExp ? "rotate-180" : ""}`}
+                              style={{ color: C.muted }}
+                              onClick={() => toggleMeetingExpand(fu.id)}
+                            />
+                          )}
+                        </div>
+                        {isExp && briefing && (
+                          <div
+                            className="mt-1.5 ml-6 text-xs rounded-lg px-3 py-2 whitespace-pre-wrap"
+                            style={{ backgroundColor: C.accentLight, color: C.text }}
+                          >
+                            <div
+                              className="text-[10px] font-semibold uppercase tracking-wider mb-1"
+                              style={{ color: C.accentDark }}
+                            >
+                              Briefing
+                            </div>
+                            {briefing.content}
+                          </div>
+                        )}
+                        {isExp && !briefing && (
+                          <div className="mt-1.5 ml-6 text-[10px] italic" style={{ color: C.muted }}>
+                            No briefing yet
+                          </div>
+                        )}
                       </div>
                     );
-                  }
+                  })}
+                </div>
+              </div>
+            )}
 
-                  const isMeeting = fu.type === "meeting";
-                  const meetingType = (fu.metadata as Record<string, unknown> | null)?.meetingType as
-                    | string
-                    | undefined;
-                  const meetingIcons: Record<string, string> = {
-                    call: "📞",
-                    video: "📹",
-                    "in-person": "🤝",
-                    coffee: "☕",
-                  };
-                  const meetingIcon = isMeeting ? (meetingType && meetingIcons[meetingType]) || "📅" : null;
-                  const isTodayMeeting = isMeeting && isTodayDue;
-                  const isExp = isTodayMeeting && expandedMeetingIds.has(fu.id);
-
-                  const handleUpcomingSnooze = (days: number) => {
-                    const newDate = new Date(due);
-                    newDate.setDate(newDate.getDate() + days);
-                    updateFollowup.mutate({ id: fu.id, dueDate: newDate.toISOString() });
-                  };
-
+            {/* Contacts: compact rows on desktop, full cards on mobile */}
+            {isDesktop ? (
+              <div
+                className="bg-white overflow-hidden"
+                style={{ border: `1px solid ${C.border}`, borderRadius: 12 }}
+                data-testid="contact-rail"
+              >
+                {displayedContacts.map((contact, idx) => (
+                  <ContactRow
+                    key={contact.id}
+                    contact={contact}
+                    selected={selectedContact?.id === contact.id}
+                    highlighted={isSearching && idx === highlightedIndex}
+                    onSelect={() => setSelectedContactId(contact.id)}
+                  />
+                ))}
+                {displayedContacts.length === 0 && (
+                  <p className="text-center py-10 text-sm" style={{ color: C.muted }}>
+                    {isSearching ? "No contacts match your search" : "No contacts in this stage"}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <>
+                {displayedContacts.map((contact, idx) => {
+                  const isHighlighted = isSearching && idx === highlightedIndex;
                   return (
-                    <div key={fu.id} className="group/upcoming py-0.5">
-                      <div className="flex items-start gap-2">
-                        {isMeeting ? (
-                          <span
-                            className={`flex-shrink-0 leading-none mt-0.5 ${isTodayMeeting ? "cursor-pointer" : ""}`}
-                            onClick={isTodayMeeting ? () => toggleMeetingExpand(fu.id) : undefined}
-                          >
-                            {meetingIcon}
-                          </span>
-                        ) : (
-                          <button
-                            onClick={() => {
-                              setCompletingUpcomingId(fu.id);
-                              setCompletingUpcomingText(fu.content);
-                            }}
-                            className="flex-shrink-0 hover:opacity-70 transition-colors mt-1"
-                            title="Complete"
-                          >
-                            <Square className="h-3.5 w-3.5" style={{ color: dateColor }} />
-                          </button>
-                        )}
-                        <div className="flex-1 min-w-0">
-                          {/* Meta line — date, time, contact, relative pill, hover snooze */}
-                          <div className="flex items-center gap-1.5 text-[11px] leading-tight flex-wrap">
-                            <span
-                              className="font-semibold whitespace-nowrap"
-                              style={{ color: isMeeting ? "#2563eb" : dateColor }}
-                            >
-                              {fmtDate(due)}
-                              {fu.time ? ` ${fu.time}` : ""}
-                            </span>
-                            {isOverdue && (
-                              <span className="font-semibold uppercase tracking-wide" style={{ color: C.red }}>
-                                · Overdue
-                              </span>
-                            )}
-                            {isTodayDue && (
-                              <span className="font-semibold uppercase tracking-wide" style={{ color: C.stale }}>
-                                · Today
-                              </span>
-                            )}
-                            {!isOverdue && !isTodayDue && daysUntil <= 7 && (
-                              <span style={{ color: C.muted }}>· {daysUntil}d</span>
-                            )}
-                            <span style={{ color: C.muted }}>·</span>
-                            <span className="truncate" style={{ color: C.muted }}>
-                              {contactName}
-                            </span>
-                            <span className="hidden group-hover/upcoming:inline-flex items-center gap-1 ml-auto">
-                              <Clock className="h-3 w-3" style={{ color: C.muted }} />
-                              {[1, 7, 14].map((d) => (
-                                <button
-                                  key={d}
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    handleUpcomingSnooze(d);
-                                  }}
-                                  className="text-[10px] px-1.5 py-0.5 rounded-full transition-colors hover:opacity-80"
-                                  style={{ backgroundColor: C.accentLight, color: C.accentDark }}
-                                  title={`Snooze ${d} day${d > 1 ? "s" : ""}`}
-                                >
-                                  +{d}d
-                                </button>
-                              ))}
-                            </span>
-                          </div>
-                          {/* Content line — full width, primary readable */}
-                          <div className="text-sm leading-snug mt-0.5" style={{ color: C.text }}>
-                            {fu.content}
-                            {fu.location ? <span style={{ color: C.muted }}> — {fu.location}</span> : null}
-                          </div>
-                        </div>
-                        {isTodayMeeting && (
-                          <ChevronDown
-                            className={`h-3.5 w-3.5 flex-shrink-0 mt-1 transition-transform cursor-pointer ${isExp ? "rotate-180" : ""}`}
-                            style={{ color: C.muted }}
-                            onClick={() => toggleMeetingExpand(fu.id)}
-                          />
-                        )}
-                      </div>
-                      {isExp && briefing && (
-                        <div
-                          className="mt-1.5 ml-6 text-xs rounded-lg px-3 py-2 whitespace-pre-wrap"
-                          style={{ backgroundColor: C.accentLight, color: C.text }}
-                        >
-                          <div
-                            className="text-[10px] font-semibold uppercase tracking-wider mb-1"
-                            style={{ color: C.accentDark }}
-                          >
-                            Briefing
-                          </div>
-                          {briefing.content}
-                        </div>
-                      )}
-                      {isExp && !briefing && (
-                        <div className="mt-1.5 ml-6 text-[10px] italic" style={{ color: C.muted }}>
-                          No briefing yet
-                        </div>
-                      )}
+                    <div
+                      key={contact.id}
+                      className="rounded-[10px]"
+                      style={{
+                        boxShadow: isHighlighted ? `0 0 0 2px ${C.accent}` : undefined,
+                        transition: "box-shadow 120ms ease-out",
+                      }}
+                    >
+                      {renderContactBlock(contact)}
                     </div>
                   );
                 })}
-              </div>
-            </div>
-          )}
+                {displayedContacts.length === 0 && (
+                  <p className="text-center py-16 text-sm" style={{ color: C.muted }}>
+                    {isSearching ? "No contacts match your search" : "No contacts in this stage"}
+                  </p>
+                )}
+              </>
+            )}
+          </div>
 
-          {/* Contact cards */}
-          {displayedContacts.map((contact, idx) => {
-            const isHighlighted = isSearching && idx === highlightedIndex;
-            return (
-              <div
-                key={contact.id}
-                className="rounded-[10px]"
-                style={{
-                  boxShadow: isHighlighted ? `0 0 0 2px ${C.accent}` : undefined,
-                  transition: "box-shadow 120ms ease-out",
-                }}
-              >
-                <ContactBlock
-                  contact={contact}
-                  onAddInteraction={(content, date, type) =>
-                    addInteraction.mutate({ contactId: contact.id, content, date, type })
-                  }
-                  onUpdateInteraction={(id, data) => updateInteraction.mutate({ id, ...data })}
-                  onDeleteInteraction={(id) => deleteInteraction.mutate(id)}
-                  onCreateFollowup={(content, dueDate, opts) =>
-                    createFollowup.mutate({ contactId: contact.id, content, dueDate, ...opts })
-                  }
-                  onUpdateFollowup={(id, data) => updateFollowup.mutate({ id, ...data })}
-                  onDeleteFollowup={(id) => deleteFollowup.mutate(id)}
-                  onCompleteFollowup={(id, outcome) => completeFollowup.mutate({ id, outcome })}
-                  onUpdateContact={(data) => updateContact.mutate({ id: contact.id, ...data })}
-                />
-              </div>
-            );
-          })}
-          {displayedContacts.length === 0 && (
-            <p className="text-center py-16 text-sm" style={{ color: C.muted }}>
-              {isSearching ? "No contacts match your search" : "No contacts in this stage"}
-            </p>
+          {/* Desktop detail pane — the selected contact's full card */}
+          {isDesktop && (
+            <div className="flex-1 min-w-0" data-testid="contact-detail">
+              {selectedContact ? (
+                renderContactBlock(selectedContact)
+              ) : (
+                <p className="text-center py-16 text-sm" style={{ color: C.muted }}>
+                  Select a contact
+                </p>
+              )}
+            </div>
           )}
         </main>
       )}

--- a/app/tests/master-detail.spec.ts
+++ b/app/tests/master-detail.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+// Desktop master-detail layout (#82): at ≥1024px the list view splits into a
+// compact contact rail + one full detail card. Below 1024px the classic
+// single-column notebook renders. Assumes the demo seed data (PIN 1234).
+
+test.describe("Master-detail layout", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/auth");
+    await page.locator('input[type="password"]').fill("1234");
+    await page.locator("button", { hasText: "Unlock" }).click();
+    await expect(page.locator("text=Upcoming")).toBeVisible({ timeout: 5000 });
+  });
+
+  test("≥1024px shows rail + detail pane with the first contact selected", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+
+    const rail = page.locator('[data-testid="contact-rail"]');
+    const detail = page.locator('[data-testid="contact-detail"]');
+    await expect(rail).toBeVisible();
+    await expect(detail).toBeVisible();
+
+    const rows = rail.locator('[data-testid^="contact-row-"]');
+    await expect(rows).toHaveCount(8);
+    // Exactly one full card (one note input) in the detail pane.
+    await expect(detail.locator('input[placeholder*="note"]')).toHaveCount(1);
+
+    // Default selection mirrors the first rail row.
+    const firstRowText = (await rows.first().textContent()) ?? "";
+    const detailName = (await detail.locator("h2").first().textContent()) ?? "";
+    expect(firstRowText).toContain(detailName.trim().split(" ")[0]);
+  });
+
+  test("clicking a rail row switches the detail pane", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+
+    const rail = page.locator('[data-testid="contact-rail"]');
+    await rail.locator('[data-testid^="contact-row-"]', { hasText: "Sarah Chen" }).click();
+
+    const detail = page.locator('[data-testid="contact-detail"]');
+    await expect(detail.locator("h2").first()).toHaveText("Sarah Chen");
+  });
+
+  test("below 1024px the single-column card list renders instead", async ({ page }) => {
+    await page.setViewportSize({ width: 800, height: 900 });
+
+    await expect(page.locator('[data-testid="contact-rail"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="contact-detail"]')).toHaveCount(0);
+    // All 8 seed contacts render as full cards.
+    await expect(page.locator('input[placeholder*="note"]')).toHaveCount(8);
+  });
+});

--- a/app/tests/search.spec.ts
+++ b/app/tests/search.spec.ts
@@ -64,7 +64,13 @@ test.describe("Cmd+K full-text search", () => {
 
     await page.keyboard.press("Escape");
     await expect(input).toHaveCount(0);
-    // Full list restored — there are 8 seed contacts.
-    await expect(names).toHaveCount(8);
+    // Full list restored — there are 8 seed contacts. At ≥1024px the list view
+    // is master-detail (#82): contacts render as compact rail rows and only the
+    // selected contact has an h2 card. Below 1024px each contact is a full card.
+    if (await page.locator('[data-testid="contact-rail"]').count()) {
+      await expect(page.locator('[data-testid^="contact-row-"]')).toHaveCount(8);
+    } else {
+      await expect(names).toHaveCount(8);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Implements #82's master-detail spec (the iPad Mail / Linear pattern):

- **≥1024px, list view**: left rail (360px) with the Upcoming strip + compact `ContactRow`s (name, company, stage tag, status edge bar); right pane renders the unchanged `ContactBlock` for the selected contact. First displayed contact selected by default; explicit selection survives filter/search changes with graceful fallback.
- **Search integration**: ArrowDown highlights rail rows; Enter opens the highlighted result in the detail pane.
- **Kanban**: at ≥1024px all six stages render side by side (stacked pairs now cover 768–1023px only; mobile swimlanes untouched). Tapping a kanban card switches to list view *and* selects that contact in the detail pane.
- **Below 1024px: zero change.** The single-column notebook renders exactly as before (the card map was extracted into a shared `renderContactBlock`, no behavioral delta). Settings/rules pages untouched per the issue.
- Header widens to 1200px on `lg` to align with the split view.

## Verification

- New E2E step **6f** added to the skill before testing. All assertions pass at 1280px: two-pane structure (rail measured at exactly 360px), default selection, row-click switching, detail-pane note lands on selected contact, search-Enter selection, six kanban columns, kanban tap-to-select, and clean collapse at 800px and 390px (8 single-column cards, no rail).
- Single-column regression at 800px: notes, truncation, task create/edit/complete (date persistence through reload), meeting create, stage command (DB-verified), search, briefing links — all pass.
- MCP smoke (dashboard, add_interaction with SSE push, journal append) green.
- Screenshot of the split view in `e2e-screenshots/09-master-detail.png`; wide kanban in `09b-kanban-wide.png`.
- `npm run lint:fix` clean, `npm run build` passes, `npm run format` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)