### PR TITLE
Surface mutation failures via global error toast (#85, error half)

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -162,6 +162,12 @@ curl -s http://localhost:3000/api/user  # should return 401 (not authenticated)
 - Resize to 800px — verify the classic single-column card list returns (no rail, no detail pane). Resize to 390px — single column persists (mobile unchanged).
 - **Screenshot** → `e2e-screenshots/09-master-detail.png`
 
+### 6g. UI: Mutation failure toast
+- Intercept `POST /api/interactions` to return `400 {"message": "Interaction content cannot be empty"}` (Playwright route or devtools override).
+- Add a note via any contact input. Verify a destructive toast appears with title **"Couldn't save"** and the parsed server message as the description (not the raw `400: {...}` string).
+- Remove the interception, add a real note — verify it lands in the timeline with NO error toast.
+- **Screenshot** → `e2e-screenshots/10-error-toast.png`
+
 ### 9. MCP: Add interaction via agent
 - Call `add_interaction` via MCP with a test note
 - Navigate to the CRM page in the browser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-06-10
 
+### Global mutation-failure toast (#85, error half)
+Failed writes were invisible: optimistic updates rolled back silently, and the only error rendering anywhere was the briefing page's bespoke parser — everything else showed nothing (or a raw `400: {...}` string). Fatal for trust in an app where agents and humans share the write path. A `MutationCache.onError` in `lib/queryClient.ts` now parses the API error body and shows a destructive toast ("Couldn't save" + the server's `message`). Login and setup mutations opt out via `meta.suppressErrorToast` — their forms already render errors inline, and a double surface confused the auth flow. New `tests/error-toast.spec.ts` (route-interception forced 400) and E2E skill step 6g. The success-side half of #85 (replacing the per-card `flash` infra with toasts) is deliberately left open — the flashes are a taste decision worth a separate look.
+
 ### Seeding kit + README screenshot refresh
 Adds `docs/seeding-kit.md` — ready-to-paste submissions for every distribution channel (awesome-mcp-servers PR line, PulseMCP form text, Show HN title+body, MCP registry publish steps, Railway template composer walkthrough, label CLI commands, community-post guidance) with a status table. Converts the launch checklist into ~30 minutes of founder copy-paste. Also regenerates `app/client/public/screenshot.png` to show the current desktop master-detail layout (#82) — the old single-column screenshot was the first thing every repo visitor saw.
 

--- a/app/client/src/hooks/use-auth.tsx
+++ b/app/client/src/hooks/use-auth.tsx
@@ -35,6 +35,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const needsSetup = !!(user && !user.authenticated && user.needsSetup);
 
   const loginMutation = useMutation<AuthUser, Error, { pin: string }>({
+    // The auth page renders this error inline — skip the global toast.
+    meta: { suppressErrorToast: true },
     mutationFn: async ({ pin }) => {
       const res = await apiRequest("POST", "/api/login", { pin });
       return await res.json();
@@ -45,6 +47,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   });
 
   const setupMutation = useMutation<{ id: number; apiKey: string }, Error, { pin: string }>({
+    // The setup form renders this error inline — skip the global toast.
+    meta: { suppressErrorToast: true },
     mutationFn: async ({ pin }) => {
       const res = await apiRequest("POST", "/api/setup", { pin });
       return await res.json();

--- a/app/client/src/lib/queryClient.ts
+++ b/app/client/src/lib/queryClient.ts
@@ -1,5 +1,20 @@
 import type { QueryFunction } from "@tanstack/react-query";
-import { QueryClient } from "@tanstack/react-query";
+import { MutationCache, QueryClient } from "@tanstack/react-query";
+import { toast } from "@/hooks/use-toast";
+
+/** apiRequest throws `Error("<status>: <body>")` — pull a human message out of the body. */
+function parseApiError(err: unknown): string {
+  if (!(err instanceof Error)) return "Something went wrong";
+  const match = err.message.match(/^\d{3}:\s*(.*)$/s);
+  const body = match ? match[1] : err.message;
+  try {
+    const parsed = JSON.parse(body);
+    if (typeof parsed?.message === "string") return parsed.message;
+  } catch {
+    /* not JSON — fall through to the raw body */
+  }
+  return body.slice(0, 200) || "Something went wrong";
+}
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
@@ -37,6 +52,21 @@ export const getQueryFn: <T>(options: { on401: UnauthorizedBehavior }) => QueryF
   };
 
 export const queryClient = new QueryClient({
+  // Global failure surface (#85): optimistic updates roll back silently, so a
+  // failed write was previously invisible — fatal for trust when agents and
+  // humans share the same data. Per-mutation onError handlers still run for
+  // rollback; this only owns the user-facing message.
+  mutationCache: new MutationCache({
+    onError: (error, _vars, _ctx, mutation) => {
+      // Mutations with their own inline error surface (login, setup) opt out.
+      if (mutation.meta?.suppressErrorToast) return;
+      toast({
+        variant: "destructive",
+        title: "Couldn't save",
+        description: parseApiError(error),
+      });
+    },
+  }),
   defaultOptions: {
     queries: {
       queryFn: getQueryFn({ on401: "throw" }),

--- a/app/tests/error-toast.spec.ts
+++ b/app/tests/error-toast.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+
+// Global mutation-failure toast (#85): optimistic updates roll back silently,
+// so failed writes need an explicit surface. The MutationCache onError parses
+// the API error body and shows a destructive toast.
+
+test.describe("Mutation error toast", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/auth");
+    await page.locator('input[type="password"]').fill("1234");
+    await page.locator("button", { hasText: "Unlock" }).click();
+    await expect(page.locator("text=Upcoming")).toBeVisible({ timeout: 5000 });
+  });
+
+  test("a failed write surfaces a destructive toast with the server message", async ({ page }) => {
+    await page.route("**/api/interactions", (route) =>
+      route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Interaction content cannot be empty" }),
+      }),
+    );
+
+    const input = page.locator('input[placeholder*="note"]').first();
+    await input.fill("this write will fail");
+    await input.press("Enter");
+
+    await expect(page.getByText("Couldn't save")).toBeVisible({ timeout: 3000 });
+    await expect(page.getByText("Interaction content cannot be empty")).toBeVisible();
+  });
+
+  test("successful writes show no error toast", async ({ page }) => {
+    const input = page.locator('input[placeholder*="note"]').first();
+    await input.fill("toast success path note");
+    await input.press("Enter");
+
+    await expect(page.getByText("toast success path note").first()).toBeVisible({ timeout: 3000 });
+    await expect(page.getByText("Couldn't save")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

The error half of #85. Failed writes were invisible: optimistic updates rolled back silently and nothing surfaced the server's message (except the briefing page's bespoke parser). For an app where agents and humans share the write path, silent failure is a trust killer.

- **`MutationCache.onError`** in `lib/queryClient.ts`: one global handler parses the `"<status>: <json>"` error format from `apiRequest` and shows a destructive toast — "Couldn't save" + the server's `message`. Per-mutation `onError` rollback handlers are unaffected.
- **Opt-out via `meta.suppressErrorToast`** for login and setup — their forms render errors inline, and the double surface actually broke the auth Playwright spec (caught in the full-suite run, which is exactly what it's for).
- **Deliberately NOT done**: the success half of #85 (replacing the per-card `flash` infra with toasts). The flashes are a taste decision — #142 restored UI affordances on similar grounds — so that half deserves its own review rather than riding along here. Noted on the issue.

## Verification

- Forced `400 {"message": "Interaction content cannot be empty"}` on `/api/interactions` → destructive toast with the parsed message (screenshot `10-error-toast.png`); interception removed → write lands, no toast.
- Wrong PIN on `/auth` → inline error only, toast suppressed (screenshot `10b-login-inline-error.png`).
- New `tests/error-toast.spec.ts` (route-interception based); E2E skill step **6g** added.
- Full Playwright suite **18/18, twice consecutively**. Lint clean, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)