### PR TITLE
Seeding kit: pivot to community posts + one-click deploy, park directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-06-10
 
+### Seeding strategy pivot: community posts + one-click deploy, directories parked
+Founder call: MCP directories are overfilled with low-effort listings — Claw won't differentiate there. `docs/seeding-kit.md` rewritten around the channels where the target user actually is: the Railway one-click template as the prerequisite (every post must end in a 60-second link), then the essay, Show HN, three tailored Reddit drafts (r/consulting pain-led, r/selfhosted deploy-led, r/ClaudeAI agent-led), an X thread skeleton, and the IH/Slack blurb. Directory submissions moved to a "parked" section with the rationale. Important template note: since the #154 startCommand pin, the Railway template MUST set `npx drizzle-kit push --force` as its pre-deploy command or fresh one-click instances get no schema.
+
 ### Desktop: rail becomes an index, right pane becomes the full feed
 Founder feedback on the #82 master-detail layout: showing one contact at a time forces a click per contact, when the whole point of the notebook is scanning everything top to bottom. Reworked:
 

--- a/docs/seeding-kit.md
+++ b/docs/seeding-kit.md
@@ -1,21 +1,21 @@
 # Seeding kit
 
-Ready-to-paste submissions for every distribution channel. Each section is one founder action — copy, paste, send. Keep this file updated as channels respond.
+Distribution strategy (decided 2026-06-10): **community posts + one-click deploy**, not directories. MCP directories are overfilled with low-effort listings — the project won't shine there. People who could love Claw hang out in founder/consultant communities and on HN/X/Reddit; the job is to reach them with the story and make trying it one click.
 
-## 1. awesome-mcp-servers (PR to punkpeye/awesome-mcp-servers)
+Sequence: **1 → 2 → stagger the rest.** The one-click deploy comes first because every post should end with a link that works in 60 seconds.
 
-Add under **📇 Customer Data Platforms** (or **🗄️ Databases** if CDP section absent), alphabetical order:
+## 1. Railway one-click template (~10 min, needs your account) — PREREQUISITE
 
-```markdown
-- [MagneticStudio/claw-crm](https://github.com/MagneticStudio/claw-crm) 📇 ☁️/🏠 - AI-native personal CRM for solo operators. Notebook-style pipeline with a 30+ tool MCP server: contacts, interactions, tasks, meeting briefings, relationship journals with server-enforced writing rules, and a rules engine agents can CRUD.
-```
+1. railway.com → New → Template (composer).
+2. Services: app from `MagneticStudio/claw-crm`, **root directory `app`**, plus a PostgreSQL service.
+3. Variables on app: `DATABASE_URL` → `${{Postgres.DATABASE_URL}}`, `SESSION_SECRET` → generated.
+4. **Pre-deploy command (required): `npx drizzle-kit push --force`.** Since the #154 hotfix, `railway.json` pins the start command to `node dist/index.js` (no schema push at boot — that's what protects YOUR production). Template users start from an empty Postgres, so without the pre-deploy push their instance has no tables. For their fresh instances the push is safe and is their schema lifecycle, same as compose self-hosters.
+5. Publish, then add the button near the top of README.md:
+   `[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/<TEMPLATE_CODE>)`
 
-## 2. PulseMCP (pulsemcp.com/submit)
+## 2. Publish the essay
 
-- **Name**: Claw CRM
-- **URL**: https://github.com/MagneticStudio/claw-crm
-- **Category**: CRM / Productivity
-- **Description** (short): Open-source personal CRM built for AI agents. Remote MCP (StreamableHTTP) + local stdio. 30+ tools with server-enforced data hygiene: agents log interactions, manage tasks and meetings, write relationship journals (absolute-dates validator, revision history), build meeting briefings, and manage automation rules stored as data. `docker compose up` to self-host.
+`docs/launch-essay-draft.md` → your Substack/LinkedIn, native (not a link post). It's the spine every other post links back to. Edit to taste first — it's a draft in your voice, not final copy.
 
 ## 3. Show HN
 
@@ -26,45 +26,67 @@ Add under **📇 Customer Data Platforms** (or **🗄️ Databases** if CDP sect
 >
 > The interesting part wasn't the app — it was 90 days of agent-hygiene lessons: agents over-log relentlessly; every prompt rule decays until you move it into a server-side validator; cheap writing means agents backfill retrospectives that silently corrupt timelines; "dedup" is a layer-partition problem, not string matching. All of it is encoded as rejection-with-actionable-error in the write path, so any agent on any harness writes clean data.
 >
-> AGPL, docker compose up to run, MCP server + three skills (mental model, bulk import from your existing notes, daily sync) included. Happy to answer anything.
+> AGPL. One-click deploy on Railway or `docker compose up`. MCP server + three skills (mental model, bulk import from your existing notes, daily sync) included. Happy to answer anything.
 
-(Publish the essay first if possible and link it in the first comment: `docs/launch-essay-draft.md`.)
+First comment: link the essay + the Railway button.
 
-## 4. MCP Registry (registry.modelcontextprotocol.io)
+## 4. Reddit (staggered over ~2 weeks, one sub at a time — drafts, edit to your voice)
 
-The registry indexes installable servers. Claw's remote MCP is per-deployment (each user's own URL + token), so list the **local stdio client**:
-- Run `mcp-publisher init` in repo root, point `server.json` at `app/server/mcp-client.ts` usage (`npx tsx .../mcp-client.ts` with `CRM_URL`/`CRM_API_KEY` env), namespace `io.github.magneticstudio/claw-crm`, then `mcp-publisher publish` (GitHub auth).
+**r/consulting or r/freelance** — lead with the pain, tech in comments:
 
-## 5. Railway marketplace template (~10 min, needs your account)
+> **I kept my client pipeline in Apple Notes for years. So I built the anti-CRM.**
+>
+> Solo advisor here. Every CRM I tried was built for sales teams — dashboards, seat licenses, mandatory fields. My actual system was one messy note per client and a guilty feeling.
+>
+> So I built what I actually wanted: a single scrollable notebook of my whole pipeline. The twist is that my AI assistant does the data entry — it reads my inbox and calendar every morning and keeps the thing true. I scroll it with coffee and make decisions.
+>
+> Open-sourced it this week. If you live in Apple Notes/Notion and have an AI assistant already, this might be your thing. Link in comments.
 
-1. railway.com → New → Template (composer).
-2. Services: app from `MagneticStudio/claw-crm` repo, **root directory `app`**, plus a PostgreSQL service.
-3. Variables on app: `DATABASE_URL` → `${{Postgres.DATABASE_URL}}`, `SESSION_SECRET` → generated.
-4. Start command default (`npm start`); pre-deploy command `npx drizzle-kit push --force` (or rely on Docker CMD if using the Dockerfile builder).
-5. Publish; then add the "Deploy on Railway" button markdown to README:
-   `[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/<TEMPLATE_CODE>)`
+**r/selfhosted** — lead with the deploy:
 
-## 6. good-first-issue labels (permission-gated for agents)
+> **Claw CRM — self-hosted, AI-agent-native personal CRM (AGPL, docker compose up)**
+>
+> Personal CRM for solo operators with a different design center: the primary writer is your AI agent over MCP, not you. Single Express/React/Postgres app, one compose file, PIN auth, no telemetry. The server enforces the data-hygiene contract (date validators, dedup folding, destructive-edit gates), so whatever agent you point at it writes clean data. Railway one-click if you don't want to host.
+
+**r/ClaudeAI** — lead with the agent angle:
+
+> **I gave Claude write access to my CRM for 90 days — here's what the server had to learn to defend against**
+>
+> Short version: agents over-log, backfilled retrospectives corrupt timelines, and every prompt rule decays — so every rule that mattered became a server-side validator with actionable errors. The repo (AGPL) includes the MCP server (30+ tools) and the skills for daily inbox/calendar sync and bulk import from your existing notes.
+
+## 5. X thread (skeleton — your voice)
+
+1. I kept 30 client relationships in Apple Notes. Every CRM I tried died within a month. So I built the anti-CRM — and made my AI agent the primary user. 🧵
+2. The design center: a CRM should be a notebook you scroll, not a database you maintain. One scrollable feed of every client, sorted by urgency.
+3. The twist: Claude does ~90% of the writes via MCP. Every morning a scheduled agent reads my inbox + calendar and reconciles the CRM. I just read it.
+4. What 90 days taught me: agents over-log relentlessly. Fix: a "will this matter in 6 months?" test, enforced server-side.
+5. Prompt rules decay. Validators don't. Every rule that mattered moved from the prompt into the write path: reject with an actionable error, the agent self-corrects mid-session.
+6. It's open source (AGPL). One-click deploy on Railway, or docker compose up. Bring your own agent. [link]
+
+## 6. Indie Hackers / founder Slacks & Discords
+
+2-sentence version + the gif: "Open-sourced the CRM my AI assistant runs for me — I scroll the notebook, it does the data entry. One-click deploy, bring your own agent."
+
+## 7. good-first-issue labels (one CLI paste)
 
 ```bash
 gh label create "good first issue" --repo MagneticStudio/claw-crm --description "Self-contained, well-scoped — great entry point for new contributors" --color 7057ff
 for i in 88 97 99 101 102 103 104; do gh issue edit $i --repo MagneticStudio/claw-crm --add-label "good first issue"; done
 ```
 
-## 7. Community posts (after HN, staggered)
+## Parked: directories (deliberate non-goal)
 
-- **r/consulting / r/freelance**: lead with the pain ("I kept clients in Apple Notes until..."), not the tech. Link the essay, mention open source + self-host in comments.
-- **Fractional-exec / solo-consultant Slack & Discord groups**: 2-sentence version + gif.
-- **LinkedIn/Substack**: the essay itself, native.
+awesome-mcp-servers, PulseMCP, and the MCP registry are deprioritized — overfilled with low-effort listings; the project won't differentiate there, and the audience intent is weaker than community channels. Revisit only if inbound users report discovering tools that way.
 
 ## Status
 
 | Channel | Status |
 |---|---|
-| awesome-mcp-servers | ready to PR |
-| PulseMCP | ready to submit |
-| Show HN | ready (publish essay first) |
-| MCP Registry | needs `mcp-publisher` run |
-| Railway template | needs account flow |
-| Labels | needs one CLI paste |
-| Community posts | after HN |
+| Railway one-click template | **next — prerequisite for all posts** |
+| Essay (Substack/LinkedIn) | draft ready, needs your edit + publish |
+| Show HN | ready (after template + essay) |
+| Reddit (3 subs) | drafts ready, stagger |
+| X thread | skeleton ready |
+| IH / Slacks / Discords | blurb ready |
+| Labels | one CLI paste |
+| Directories | parked |


### PR DESCRIPTION
## Summary

Implements the founder's distribution decision: skip the MCP directories (overfilled with low-effort listings — Claw won't shine there), focus on community channels + a one-click Railway deploy.

The rewritten `docs/seeding-kit.md`:

- **Sequences the Railway template first** — every post should end in a link that works in 60 seconds. Includes the critical post-#154 note: the template MUST set `npx drizzle-kit push --force` as its **pre-deploy command**, because `railway.json` now pins the start command to a bare `node dist/index.js` (that pin protects the founder's production; template users start from empty databases and need the push).
- **Ready-to-edit drafts per channel**: Show HN title+body, three Reddit posts each leading with the right angle for its sub (r/consulting → the Apple Notes pain; r/selfhosted → compose/AGPL/no-telemetry; r/ClaudeAI → the agent-hygiene lessons), a six-tweet X thread skeleton, and the Indie Hackers / Slack blurb. All flagged as drafts in the founder's voice to edit before posting.
- **Directories parked** with the rationale recorded, revisit condition included.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)