### PR TITLE
App-styled date picker (closes #103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 2026-06-10
 
+### App-styled date picker (closes #103)
+The native `<input type="date">` in the followup edit row was the only date input in the app, and it stuck out — Safari rendered it in its own grey chrome, Chrome/Firefox in another, none of them matched the Montserrat-teal vocabulary. It also bit us with an onChange-on-blur quirk last month (the [#80](https://github.com/MagneticStudio/claw-crm/pull/80) followup-save fix needed a DOM ref to read the picker's committed value).
+
+New `<DatePicker>` component built on `@radix-ui/react-popover` (already in deps). Trigger button shows the formatted date (`Jun 13, 2026`) in the same teal-tinted pill that the native input used to occupy. Click opens a 280px-wide month-grid calendar — Montserrat throughout, teal selected day, subtle teal ring on today, muted out-of-month days, prev/next chevrons, weekday header. Bottom row has a `Today` shortcut and (when a date is set) a `Clear` link.
+
+Keyboard nav: arrow keys move by day across month boundaries, `Enter` selects, `Esc` closes. When the popover opens it auto-focuses the selected day (or today if no value), not the first chevron.
+
+Dropped the `followupDateRef` workaround and the `onMouseDown`-vs-`onClick` Save-button comment in `contact-block.tsx` — the controlled component dispatches state synchronously, no DOM-snooping needed.
+
 ### New MCP tool — `search_contacts`
 Agents could only fetch contacts by ID. There was no way to find a contact by name, company, email, or any substring from interactions/journal/briefing without already knowing the ID — get_dashboard returned counts but not search, and the browser's ⌘K search ran in the client only.
 

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { isPast, isToday, differenceInCalendarDays } from "date-fns";
 import { Square, AlertTriangle, Trash2, Clock } from "lucide-react";
 import type { ContactWithRelations } from "@shared/schema";
 import { fmtDate, fmtDateInput } from "@/lib/utils";
 import { useColors } from "@/App";
 import { getBriefingStaleness } from "@shared/briefing";
+import { DatePicker } from "@/components/date-picker";
 
 const HOLD_COLOR = "#6c5ce7";
 
@@ -84,10 +85,6 @@ export function ContactBlock({
   const [editingFollowupId, setEditingFollowupId] = useState<number | null>(null);
   const [editingFollowupText, setEditingFollowupText] = useState("");
   const [editingFollowupDate, setEditingFollowupDate] = useState("");
-  // Live reference to the date <input> so save can read the committed value
-  // directly. Bypasses any React batching / browser quirk where onChange
-  // doesn't fire until blur (Safari's <input type="date"> behavior).
-  const followupDateRef = useRef<HTMLInputElement>(null);
   const [completingFollowupId, setCompletingFollowupId] = useState<number | null>(null);
   const [completingFollowupText, setCompletingFollowupText] = useState("");
   const [showStageMenu, setShowStageMenu] = useState(false);
@@ -205,10 +202,8 @@ export function ContactBlock({
   const handleFollowupSave = (id: number, origDate: string) => {
     const updates: { content?: string; dueDate?: string } = {};
     if (editingFollowupText.trim()) updates.content = editingFollowupText;
-    // Prefer the live DOM value over React state — `<input type="date">` on
-    // Safari only fires onChange on blur, so state can lag behind the picker.
-    const liveDate = followupDateRef.current?.value || editingFollowupDate;
-    if (liveDate && liveDate !== origDate) updates.dueDate = new Date(liveDate + "T12:00:00").toISOString();
+    if (editingFollowupDate && editingFollowupDate !== origDate)
+      updates.dueDate = new Date(editingFollowupDate + "T12:00:00").toISOString();
     if (Object.keys(updates).length > 0) {
       onUpdateFollowup(id, updates);
       showFlash("Updated");
@@ -663,19 +658,7 @@ export function ContactBlock({
               if (isEditingFu) {
                 return (
                   <div key={fu.id} className="flex items-center gap-1.5 text-xs">
-                    <input
-                      ref={followupDateRef}
-                      type="date"
-                      value={editingFollowupDate}
-                      onChange={(e) => setEditingFollowupDate(e.target.value)}
-                      className="text-xs px-1.5 py-1 outline-none w-[120px] flex-shrink-0 font-[Montserrat]"
-                      style={{
-                        border: `1px solid ${C.accent}40`,
-                        borderRadius: 8,
-                        color: C.accentDark,
-                        backgroundColor: C.accentLight,
-                      }}
-                    />
+                    <DatePicker value={editingFollowupDate} onChange={setEditingFollowupDate} ariaLabel="Due date" />
                     <input
                       autoFocus
                       value={editingFollowupText}
@@ -688,11 +671,6 @@ export function ContactBlock({
                       style={{ border: `1px solid ${C.border}`, color: C.text }}
                     />
                     <button
-                      // onClick (not onMouseDown+preventDefault): the date inputs here
-                      // have no onBlur handler, so the focus-trap pattern used in the
-                      // interaction edit flow is unnecessary — and it actively breaks
-                      // the native date picker, which can leave its value uncommitted
-                      // when the user hits Save without first clicking elsewhere.
                       onClick={() => handleFollowupSave(fu.id, fmtDateInput(due))}
                       className="text-[10px] font-medium"
                       style={{ color: C.accentDark }}

--- a/app/client/src/components/date-picker.tsx
+++ b/app/client/src/components/date-picker.tsx
@@ -1,0 +1,252 @@
+// App-styled date picker — Radix Popover trigger + small month-grid calendar.
+// Replaces `<input type="date">`, which the native browsers render in their
+// own visual language (Safari's especially clashes) and which bit us last
+// week with an onChange-on-blur quirk.
+//
+// API mirrors a controlled input: pass `value` as YYYY-MM-DD, get
+// `onChange(YYYY-MM-DD)` when the user picks a day. Empty string clears.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import * as Popover from "@radix-ui/react-popover";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  addDays,
+  addMonths,
+  eachDayOfInterval,
+  endOfWeek,
+  format,
+  isSameDay,
+  isSameMonth,
+  isToday,
+  parse,
+  startOfMonth,
+  startOfWeek,
+  subMonths,
+} from "date-fns";
+import { useColors } from "@/App";
+
+interface DatePickerProps {
+  value: string; // YYYY-MM-DD; empty string = unset
+  onChange: (value: string) => void;
+  /** Optional accessible label for the trigger button. */
+  ariaLabel?: string;
+  /** Optional placeholder to show when value is empty. */
+  placeholder?: string;
+  /** Optional className applied to the trigger button (for layout). */
+  className?: string;
+}
+
+// Parse YYYY-MM-DD as a local-noon Date so display-day matches input-day
+// across timezones (mirrors toNoonUTC convention used by the rest of the app).
+function parseLocal(value: string): Date | null {
+  if (!value) return null;
+  const d = parse(value, "yyyy-MM-dd", new Date());
+  if (Number.isNaN(d.getTime())) return null;
+  return d;
+}
+
+function toIso(d: Date): string {
+  return format(d, "yyyy-MM-dd");
+}
+
+export function DatePicker({ value, onChange, ariaLabel, placeholder = "Pick a date", className }: DatePickerProps) {
+  const C = useColors();
+  const selected = parseLocal(value);
+  const [open, setOpen] = useState(false);
+  const [viewMonth, setViewMonth] = useState<Date>(() => selected ?? new Date());
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  // Keep the visible month anchored to the selected value whenever it changes
+  // from outside (e.g. resetting to original date on Cancel).
+  useEffect(() => {
+    if (selected) setViewMonth(selected);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  // Build the 6-week visible grid (always 42 cells so the popover doesn't
+  // jump height when months have different week counts).
+  const days = useMemo(() => {
+    const start = startOfWeek(startOfMonth(viewMonth), { weekStartsOn: 0 });
+    const end = endOfWeek(addDays(start, 41), { weekStartsOn: 0 });
+    return eachDayOfInterval({ start, end });
+  }, [viewMonth]);
+
+  const pick = (d: Date) => {
+    onChange(toIso(d));
+    setOpen(false);
+  };
+
+  // Keyboard navigation inside the grid: arrow keys move by day, Enter selects,
+  // Escape closes. The first focusable day mounts focused when the popover opens.
+  const onGridKeyDown = (e: React.KeyboardEvent) => {
+    if (!gridRef.current) return;
+    const focused = document.activeElement as HTMLElement | null;
+    if (!focused || !gridRef.current.contains(focused)) return;
+    const day = focused.dataset.day;
+    if (!day) return;
+    let next: Date | null = null;
+    const cur = parseLocal(day);
+    if (!cur) return;
+    if (e.key === "ArrowLeft") next = addDays(cur, -1);
+    else if (e.key === "ArrowRight") next = addDays(cur, 1);
+    else if (e.key === "ArrowUp") next = addDays(cur, -7);
+    else if (e.key === "ArrowDown") next = addDays(cur, 7);
+    else if (e.key === "Enter") {
+      e.preventDefault();
+      pick(cur);
+      return;
+    }
+    if (next) {
+      e.preventDefault();
+      // If we crossed a month boundary, flip the view.
+      if (!isSameMonth(next, viewMonth)) setViewMonth(next);
+      // Defer focus to next tick so the new buttons exist.
+      const targetIso = toIso(next);
+      requestAnimationFrame(() => {
+        const btn = gridRef.current?.querySelector<HTMLButtonElement>(`[data-day="${targetIso}"]`);
+        btn?.focus();
+      });
+    }
+  };
+
+  const triggerLabel = selected ? format(selected, "MMM d, yyyy") : placeholder;
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          aria-label={ariaLabel ?? "Select date"}
+          className={`text-xs px-1.5 py-1 outline-none w-[120px] flex-shrink-0 font-[Montserrat] text-left transition-colors hover:opacity-80 ${className ?? ""}`}
+          style={{
+            border: `1px solid ${C.accent}40`,
+            borderRadius: 8,
+            color: selected ? C.accentDark : C.muted,
+            backgroundColor: C.accentLight,
+          }}
+        >
+          {triggerLabel}
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="start"
+          sideOffset={6}
+          className="z-50 rounded-xl shadow-lg"
+          style={{
+            backgroundColor: "white",
+            border: `1px solid ${C.border}`,
+            padding: "0.75rem",
+            fontFamily: "Montserrat, sans-serif",
+            color: C.text,
+            width: 280,
+          }}
+          onOpenAutoFocus={(e) => {
+            // Don't auto-focus the first focusable element — focus a sensible
+            // day cell instead (selected, or today, or first of month).
+            e.preventDefault();
+            requestAnimationFrame(() => {
+              const target = selected ?? new Date();
+              const targetIso = toIso(target);
+              const btn = gridRef.current?.querySelector<HTMLButtonElement>(`[data-day="${targetIso}"]`);
+              (btn ?? gridRef.current?.querySelector<HTMLButtonElement>(`[data-day]`))?.focus();
+            });
+          }}
+        >
+          {/* Month header */}
+          <div className="flex items-center justify-between mb-2">
+            <button
+              type="button"
+              aria-label="Previous month"
+              onClick={() => setViewMonth((m) => subMonths(m, 1))}
+              className="p-1 rounded hover:opacity-70 transition-opacity"
+              style={{ color: C.muted }}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <div className="text-[13px] font-semibold" style={{ color: C.text }}>
+              {format(viewMonth, "MMMM yyyy")}
+            </div>
+            <button
+              type="button"
+              aria-label="Next month"
+              onClick={() => setViewMonth((m) => addMonths(m, 1))}
+              className="p-1 rounded hover:opacity-70 transition-opacity"
+              style={{ color: C.muted }}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+
+          {/* Weekday header */}
+          <div className="grid grid-cols-7 gap-0.5 mb-1">
+            {["S", "M", "T", "W", "T", "F", "S"].map((d, i) => (
+              <div
+                key={i}
+                className="text-[10px] font-semibold uppercase tracking-wider text-center"
+                style={{ color: C.muted }}
+              >
+                {d}
+              </div>
+            ))}
+          </div>
+
+          {/* Day grid */}
+          <div ref={gridRef} className="grid grid-cols-7 gap-0.5" onKeyDown={onGridKeyDown}>
+            {days.map((d) => {
+              const inMonth = isSameMonth(d, viewMonth);
+              const isSelected = selected && isSameDay(d, selected);
+              const today = isToday(d);
+              return (
+                <button
+                  key={d.toISOString()}
+                  type="button"
+                  data-day={toIso(d)}
+                  onClick={() => pick(d)}
+                  tabIndex={inMonth ? 0 : -1}
+                  className="text-[12px] h-9 rounded flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-2"
+                  style={{
+                    color: isSelected ? "white" : inMonth ? C.text : C.border,
+                    backgroundColor: isSelected ? C.accentDark : "transparent",
+                    fontWeight: isSelected || today ? 600 : 400,
+                    border: today && !isSelected ? `1px solid ${C.accent}80` : "1px solid transparent",
+                  }}
+                >
+                  {d.getDate()}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Footer with Today shortcut + Clear */}
+          <div
+            className="flex items-center justify-between mt-2 pt-2 text-[11px]"
+            style={{ borderTop: `1px dashed ${C.border}` }}
+          >
+            <button
+              type="button"
+              onClick={() => pick(new Date())}
+              className="font-medium transition-opacity hover:opacity-70"
+              style={{ color: C.accentDark }}
+            >
+              Today
+            </button>
+            {selected && (
+              <button
+                type="button"
+                onClick={() => {
+                  onChange("");
+                  setOpen(false);
+                }}
+                className="transition-opacity hover:opacity-70"
+                style={{ color: C.muted }}
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}


### PR DESCRIPTION
Closes #103.

## Summary
The native `<input type="date">` in the followup edit row was the only date input in the app — Safari rendered it in its own grey chrome, Chrome/Firefox in another, none of them matched the Montserrat-teal visual vocabulary. It also bit us last month with the onChange-on-blur quirk that #80 had to work around with a DOM ref.

New `<DatePicker>` component built on `@radix-ui/react-popover` (already in deps):

- **Trigger button** — same teal-tinted pill the native input used to occupy. Shows the formatted date (`Jun 13, 2026`) or placeholder when empty.
- **280 px month-grid calendar** — Montserrat throughout, teal selected day, subtle teal ring on today, muted out-of-month days, prev/next chevrons in the header, weekday labels.
- **Footer** — `Today` shortcut + (when a date is set) `Clear` link, with a dashed teal divider.
- **Keyboard nav** — arrow keys move by day across week/month boundaries (the view flips automatically when crossing), `Enter` selects, `Esc` closes. Auto-focuses the selected day on open (or today if no value).

Dropped the `followupDateRef` workaround and the `onMouseDown`-vs-`onClick` Save-button comment in `contact-block.tsx` — the controlled component dispatches state synchronously, so the DOM-snooping is no longer needed.

## Test plan
- [x] Lint + build clean
- [x] Trigger button renders with formatted date matching the followup's due date
- [x] Click → popover opens with correct month header, 42-cell grid (always 6 weeks), selected day auto-focused
- [x] Click a different day → trigger updates + popover closes + Save commits the change to the row
- [x] Arrow keys: 6/20 → ArrowRight → 6/21 → ArrowDown → 6/28 (focused day tracks correctly across the week boundary)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)