### PR TITLE
Toast success feedback on contact-card mutations (closes #85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2026-06-11
 
+### Wire contact-card success feedback through the global toast (closes #85)
+Error-side toasts already shipped via `MutationCache` in `queryClient.ts`. The remaining gap was the 17 per-card `showFlash("Note added")` / `showFlash("Stage → PROPOSAL")` calls in `contact-block.tsx`, which rendered as a local pulsing pill in the header — duplicate infra that no other surface used.
+
+Repointed `showFlash` to `toast({ description, duration: 2000 })`. Kept the function name so the 17 call sites stay terse. Dropped the `flash` state, the `setTimeout` cleanup, and the in-card `<span>` render. Every success confirmation now appears in the same global Radix viewport that errors use.
+
 ### Settings: blur secrets, confirm before regenerate (closes #90)
 The MCP URL and API key rendered in plaintext on every visit to /settings — fine when you're alone, awkward during a screen-share or demo. The Regenerate links beneath each were single-tap with no confirmation; one accidental press and every connected Claude session or script returned 401.
 

--- a/app/client/src/components/contact-block.tsx
+++ b/app/client/src/components/contact-block.tsx
@@ -6,6 +6,7 @@ import { fmtDate, fmtDateInput } from "@/lib/utils";
 import { useColors } from "@/App";
 import { getBriefingStaleness } from "@shared/briefing";
 import { DatePicker } from "@/components/date-picker";
+import { toast } from "@/hooks/use-toast";
 
 const HOLD_COLOR = "#6c5ce7";
 
@@ -77,7 +78,6 @@ export function ContactBlock({
   const [showAllInteractions, setShowAllInteractions] = useState(false);
   const [expandedInteractions, setExpandedInteractions] = useState<Set<number>>(new Set());
   const [newNote, setNewNote] = useState("");
-  const [flash, setFlash] = useState<string | null>(null);
   const [editingInteractionId, setEditingInteractionId] = useState<number | null>(null);
   const [editingInteractionText, setEditingInteractionText] = useState("");
   const [editingBackground, setEditingBackground] = useState(false);
@@ -108,9 +108,11 @@ export function ContactBlock({
     setBackgroundText(derivedBackground);
   }, [derivedBackground]);
 
+  // Per-card "Note added" / "Stage → PROPOSAL" confirmations route through the
+  // global toast system. Wrapped behind showFlash so call sites stay terse and
+  // the 2s auto-dismiss + visual treatment are decided in one place.
   const showFlash = useCallback((msg: string) => {
-    setFlash(msg);
-    setTimeout(() => setFlash(null), 2000);
+    toast({ description: msg, duration: 2000 });
   }, []);
 
   const handleNoteSubmit = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -245,14 +247,6 @@ export function ContactBlock({
       />
       {/* Header */}
       <div className="flex items-center gap-1.5">
-        {flash && (
-          <span
-            className="text-[10px] font-medium px-2 py-0.5 rounded animate-pulse order-last ml-auto"
-            style={{ color: C.accentDark, backgroundColor: C.accentLight }}
-          >
-            {flash}
-          </span>
-        )}
         <h2 className="text-sm font-bold leading-tight whitespace-nowrap" style={{ color: C.text }}>
           {contact.firstName} {contact.lastName}
         </h2>


### PR DESCRIPTION
Closes #85.

## Summary
Error-side toasts already shipped via `MutationCache` in `queryClient.ts` (per the existing comment on #85). The remaining gap was the 17 per-card `showFlash("Note added")` / `showFlash("Stage → PROPOSAL")` calls in `contact-block.tsx`, which rendered as a local pulsing pill in the header — duplicate infra that no other surface used.

Repointed `showFlash` to `toast({ description, duration: 2000 })`. Kept the function name so all 17 call sites stay terse and unchanged. Dropped the `flash` state, the `setTimeout` cleanup, and the in-card `<span>` render.

Every success confirmation — note added, stage change, status change, snooze, delete, complete — now appears in the same global Radix viewport that errors use. Uniform feedback across contact mutations, briefings, settings, journals.

## Test plan
- [x] Lint + build clean
- [x] Typed `test toast` into a contact-card slash-command input and pressed Enter → Radix toast appeared with description `Note added`
- [x] In-card `span.animate-pulse` flash element no longer in the DOM
- [x] Radix `[role="region"]` viewport mounted
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)