### PR TITLE
Dark mode (closes #101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 2026-06-11
 
+### Dark mode (closes #101)
+Follows OS by default with a three-way override (System / Light / Dark) persisted to localStorage per device. Accent (teal) carries across both modes; the neutral palette (text, muted, border, page bg, card bg) flips between two static palettes inside `useColors()`. Token-driven — most components didn't need to change because they already read `style={{ color: C.text }}` from `useColors()`.
+
+Surfaces touched:
+- New `LIGHT_STATIC` + `DARK_STATIC` palettes inside `App.tsx`; `useColors()` returns the right one for the resolved mode.
+- Inline `style={{ backgroundColor: "#f0f8f8" }}` page bgs across 5 pages → `C.pageBg`.
+- `bg-white` class literals auto-flip via a `.dark .bg-white` rule in `index.css`. Auth + Setup card surfaces opt out by using inline `style={{ backgroundColor: "white" }}` instead (they sit on the teal gradient and stay branded-light).
+- `bg-stone-50` literals (secret blocks in Settings, etc.) get the same `.dark` override.
+- Body bg + text + border defaults flip in `index.css` `.dark body { … }`.
+- Date-picker popover bg → `C.cardBg`.
+- Theme toggle: Sun/Moon/Monitor icon in the header menu cycles System → Light → Dark. Three-way picker in Settings page.
+- Auth + Setup pages stay pinned light (brand surfaces on teal gradient).
+
+`ThemeContext` lives in a standalone `lib/theme.ts` module — keeping it next to the Provider in `App.tsx` caused Vite's react-refresh to instantiate two Context objects, producing a silent Provider/Consumer mismatch (Provider state correct, `useTheme()` reading defaults). Confirmed in dev with a window-attached identity check; standalone module resolves it.
+
 ### Wire contact-card success feedback through the global toast (closes #85)
 Error-side toasts already shipped via `MutationCache` in `queryClient.ts`. The remaining gap was the 17 per-card `showFlash("Note added")` / `showFlash("Stage → PROPOSAL")` calls in `contact-block.tsx`, which rendered as a local pulsing pill in the header — duplicate infra that no other surface used.
 

--- a/app/client/src/App.tsx
+++ b/app/client/src/App.tsx
@@ -6,6 +6,9 @@ import { Switch, Route } from "wouter";
 import { AuthProvider } from "./hooks/use-auth";
 import { ProtectedRoute } from "./lib/protected-route";
 
+import { ThemeContext, useTheme as _useTheme } from "@/lib/theme";
+import type { ThemePref } from "@/lib/theme";
+
 import CrmPage from "@/pages/crm-page";
 import RulesPage from "@/pages/rules-page";
 import SettingsPage from "@/pages/settings-page";
@@ -63,8 +66,10 @@ export function useConfig() {
   return useContext(ConfigContext);
 }
 
-// Static palette colors that don't change with the primary color
-const STATIC_COLORS = {
+// Mode-specific neutral palette. Accent (teal) stays the same across modes so
+// brand identity carries over. Page + card backgrounds and text colors flip.
+// `pageBg` is what surrounds cards; `cardBg` is the card surface itself.
+const LIGHT_STATIC = {
   text: "#1a2f2f",
   muted: "#5a7a7a",
   border: "#d4e8e8",
@@ -72,12 +77,35 @@ const STATIC_COLORS = {
   staleBg: "#fef7ec",
   red: "#c0392b",
   redBg: "#fde8e8",
+  pageBg: "#f0f8f8",
+  cardBg: "#ffffff",
+  inputBg: "#fafafa",
 } as const;
 
-/** Dynamic accent colors + static palette. Use instead of hardcoded C = {...} objects. */
+const DARK_STATIC = {
+  text: "#e6f0ef",
+  muted: "#7a9a9a",
+  border: "#22312f",
+  stale: "#f0a544",
+  staleBg: "#2a1f12",
+  red: "#e0594a",
+  redBg: "#3a1f1f",
+  pageBg: "#0c1414",
+  cardBg: "#152020",
+  inputBg: "#1c2828",
+} as const;
+
+// Re-export useTheme so the existing `import { useTheme } from "@/App"`
+// call sites keep working. ThemeContext + useTheme live in @/lib/theme to
+// avoid Vite's react-refresh splitting them across two module instances.
+export const useTheme = _useTheme;
+
+/** Dynamic accent colors + mode-specific static palette. */
 export function useColors() {
   const { colors } = useContext(ConfigContext);
-  return { ...STATIC_COLORS, ...colors };
+  const { resolved } = _useTheme();
+  const palette = resolved === "dark" ? DARK_STATIC : LIGHT_STATIC;
+  return { ...palette, ...colors };
 }
 
 function ConfigProvider({ children }: { children: React.ReactNode }) {
@@ -166,16 +194,59 @@ function PrivacyScreen() {
   );
 }
 
+function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<ThemePref>(() => {
+    if (typeof window === "undefined") return "system";
+    const stored = window.localStorage.getItem("claw-theme");
+    return stored === "light" || stored === "dark" ? stored : "system";
+  });
+
+  // System-preference media query, recalculated on change.
+  const [systemDark, setSystemDark] = useState<boolean>(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  });
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = (e: MediaQueryListEvent) => setSystemDark(e.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  const resolved: "light" | "dark" = theme === "system" ? (systemDark ? "dark" : "light") : theme;
+
+  // Apply class to <html> so Tailwind `dark:` variants work for the few
+  // class-literal surfaces that don't go through useColors().
+  useEffect(() => {
+    const root = document.documentElement;
+    if (resolved === "dark") root.classList.add("dark");
+    else root.classList.remove("dark");
+  }, [resolved]);
+
+  const setTheme = (t: ThemePref) => {
+    setThemeState(t);
+    if (typeof window !== "undefined") {
+      if (t === "system") window.localStorage.removeItem("claw-theme");
+      else window.localStorage.setItem("claw-theme", t);
+    }
+  };
+
+  return <ThemeContext.Provider value={{ theme, resolved, setTheme }}>{children}</ThemeContext.Provider>;
+}
+
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <ConfigProvider>
-        <AuthProvider>
-          <Toaster />
-          <PrivacyScreen />
-          <Router />
-        </AuthProvider>
-      </ConfigProvider>
+      <ThemeProvider>
+        <ConfigProvider>
+          <AuthProvider>
+            <Toaster />
+            <PrivacyScreen />
+            <Router />
+          </AuthProvider>
+        </ConfigProvider>
+      </ThemeProvider>
     </QueryClientProvider>
   );
 }

--- a/app/client/src/components/date-picker.tsx
+++ b/app/client/src/components/date-picker.tsx
@@ -134,7 +134,7 @@ export function DatePicker({ value, onChange, ariaLabel, placeholder = "Pick a d
           sideOffset={6}
           className="z-50 rounded-xl shadow-lg"
           style={{
-            backgroundColor: "white",
+            backgroundColor: C.cardBg,
             border: `1px solid ${C.border}`,
             padding: "0.75rem",
             fontFamily: "Montserrat, sans-serif",

--- a/app/client/src/index.css
+++ b/app/client/src/index.css
@@ -6,6 +6,9 @@
   * {
     @apply border-[#d4e8e8];
   }
+  .dark * {
+    border-color: #22312f;
+  }
 
   body {
     font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -13,8 +16,24 @@
     background-color: #f0f8f8;
     color: #1a2f2f;
   }
+  .dark body {
+    background-color: #0c1414;
+    color: #e6f0ef;
+  }
 
   .font-mono {
     font-family: 'JetBrains Mono', ui-monospace, monospace;
+  }
+
+  /* Dark-mode overrides for class literals that still use raw white/stone tints.
+     Keeps the existing markup unchanged — every `className="bg-white"` already in
+     the codebase auto-flips to the card surface in dark mode. Anywhere we want
+     a literal white (e.g. auth-page card on the teal gradient), use an inline
+     `style={{ backgroundColor: 'white' }}` to bypass these overrides. */
+  .dark .bg-white {
+    background-color: #152020;
+  }
+  .dark .bg-stone-50 {
+    background-color: #1c2828;
   }
 }

--- a/app/client/src/lib/theme.ts
+++ b/app/client/src/lib/theme.ts
@@ -1,0 +1,26 @@
+// Standalone theme context — kept in its own module so Vite's react-refresh
+// (which doesn't fast-refresh hook-and-component combo files cleanly) can't
+// instantiate two copies of the Context object across the Provider and the
+// Consumer. The bug surfaced as: Provider state correctly set to "dark", but
+// useTheme() in child components returning the default context value
+// ("system") — classic two-instance Context split.
+
+import { createContext, useContext } from "react";
+
+export type ThemePref = "system" | "light" | "dark";
+
+export interface ThemeContextValue {
+  theme: ThemePref;
+  resolved: "light" | "dark";
+  setTheme: (t: ThemePref) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue>({
+  theme: "system",
+  resolved: "light",
+  setTheme: () => {},
+});
+
+export function useTheme(): ThemeContextValue {
+  return useContext(ThemeContext);
+}

--- a/app/client/src/pages/auth-page.tsx
+++ b/app/client/src/pages/auth-page.tsx
@@ -57,7 +57,7 @@ export default function AuthPage() {
         className="flex flex-col items-center justify-center min-h-screen p-4"
         style={{ background: "linear-gradient(135deg, #2bbcb3, #30bfb7, #3cc8c0)" }}
       >
-        <div className="w-full max-w-sm bg-white rounded-xl shadow-lg p-8 text-center">
+        <div className="w-full max-w-sm rounded-xl shadow-lg p-8 text-center" style={{ backgroundColor: "white" }}>
           <h1 className="text-lg font-semibold" style={{ color: "#1a2f2f" }}>
             Setup Complete
           </h1>

--- a/app/client/src/pages/briefing-page.tsx
+++ b/app/client/src/pages/briefing-page.tsx
@@ -82,7 +82,7 @@ export default function BriefingPage() {
   );
 
   return (
-    <div className="min-h-screen" style={{ backgroundColor: "#f0f8f8" }}>
+    <div className="min-h-screen" style={{ backgroundColor: C.pageBg }}>
       <header className="sticky top-0 z-50 bg-white" style={{ borderBottom: `1px solid ${C.border}` }}>
         <div className="max-w-[640px] mx-auto px-4 py-3 flex items-center gap-3">
           <Link href="/" className="transition-colors hover:opacity-70" style={{ color: C.muted }}>

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -25,13 +25,16 @@ import {
   Clock,
   Plus,
   UserPlus,
+  Sun,
+  Moon,
+  Monitor,
 } from "lucide-react";
 import { KanbanBoard } from "@/components/kanban/kanban-board";
 import { Link } from "wouter";
 import { format, isPast, isToday, differenceInCalendarDays } from "date-fns";
 import type { Followup, ActivityLogEntry, Briefing, ContactWithRelations } from "@shared/schema";
 import { fmtDate } from "@/lib/utils";
-import { useConfig, useColors } from "@/App";
+import { useConfig, useColors, useTheme } from "@/App";
 
 // Pipeline order (funnel flow, top to bottom)
 const STAGES = ["ALL", "LEAD", "MEETING", "PROPOSAL", "NEGOTIATION", "LIVE", "RELATIONSHIP", "PASS"] as const;
@@ -64,6 +67,13 @@ export default function CrmPage() {
   const { logoutMutation } = useAuth();
   const [activeStage, setActiveStage] = useState<string>("ALL");
   const { orgName, upcomingDays: days } = useConfig();
+  const { theme, setTheme } = useTheme();
+  const cycleTheme = () => {
+    // System → Light → Dark → System
+    setTheme(theme === "system" ? "light" : theme === "light" ? "dark" : "system");
+  };
+  const themeLabel = theme === "system" ? "System" : theme === "light" ? "Light" : "Dark";
+  const ThemeIcon = theme === "system" ? Monitor : theme === "light" ? Sun : Moon;
   const [viewMode, setViewMode] = useState<"list" | "kanban">(
     () => (localStorage.getItem("crm-view-mode") as "list" | "kanban") || "list",
   );
@@ -287,14 +297,14 @@ export default function CrmPage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center min-h-screen" style={{ backgroundColor: "#f0f8f8" }}>
+      <div className="flex items-center justify-center min-h-screen" style={{ backgroundColor: C.pageBg }}>
         <Loader2 className="h-5 w-5 animate-spin" style={{ color: C.accent }} />
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen" style={{ backgroundColor: "#f0f8f8" }}>
+    <div className="min-h-screen" style={{ backgroundColor: C.pageBg }}>
       {/* Header */}
       <header className="sticky top-0 z-50 bg-white" style={{ borderBottom: `1px solid ${C.border}` }}>
         <div className="max-w-[640px] lg:max-w-[1200px] mx-auto px-4 py-3 flex items-center justify-between gap-2">
@@ -478,6 +488,18 @@ export default function CrmPage() {
                     <Settings className="h-4 w-4" style={{ color: C.muted }} />
                     <span>Settings</span>
                   </Link>
+                  <button
+                    onClick={() => {
+                      cycleTheme();
+                    }}
+                    className="w-full flex items-center gap-3 px-4 py-2.5 text-[13px] transition-colors hover:bg-gray-50"
+                    style={{ color: C.text }}
+                  >
+                    <ThemeIcon className="h-4 w-4" style={{ color: C.muted }} />
+                    <span>
+                      Theme: <span style={{ color: C.accentDark, fontWeight: 600 }}>{themeLabel}</span>
+                    </span>
+                  </button>
                   <button
                     onClick={() => {
                       setShowActivityDrawer(!showActivityDrawer);

--- a/app/client/src/pages/journal-page.tsx
+++ b/app/client/src/pages/journal-page.tsx
@@ -113,7 +113,7 @@ export default function JournalPage() {
   const companyName = contact?.company?.name || "";
 
   return (
-    <div className="min-h-screen" style={{ backgroundColor: "#f0f8f8" }}>
+    <div className="min-h-screen" style={{ backgroundColor: C.pageBg }}>
       <header className="sticky top-0 z-50 bg-white" style={{ borderBottom: `1px solid ${C.border}` }}>
         <div className="max-w-[640px] mx-auto px-4 py-3 flex items-center gap-3">
           <Link href="/" className="transition-colors hover:opacity-70" style={{ color: C.muted }}>

--- a/app/client/src/pages/rules-page.tsx
+++ b/app/client/src/pages/rules-page.tsx
@@ -56,7 +56,7 @@ export default function RulesPage() {
   }
 
   return (
-    <div className="min-h-screen" style={{ backgroundColor: "#f0f8f8" }}>
+    <div className="min-h-screen" style={{ backgroundColor: C.pageBg }}>
       <header className="sticky top-0 z-50 bg-white" style={{ borderBottom: `1px solid ${C.border}` }}>
         <div className="max-w-[640px] mx-auto px-4 py-3 flex items-center gap-3">
           <Link href="/" className="transition-colors hover:opacity-70" style={{ color: C.muted }}>

--- a/app/client/src/pages/settings-page.tsx
+++ b/app/client/src/pages/settings-page.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { ArrowLeft, Copy, RefreshCw, Check, Eye, EyeOff } from "lucide-react";
 import { Link } from "wouter";
-import { useColors, useConfig } from "@/App";
+import { useColors, useConfig, useTheme } from "@/App";
 
 export default function SettingsPage() {
   const C = useColors();
@@ -25,6 +25,7 @@ export default function SettingsPage() {
   const [showMcp, setShowMcp] = useState(false);
   const [showApi, setShowApi] = useState(false);
   const { upcomingDays } = useConfig();
+  const { theme, setTheme } = useTheme();
 
   const saveDays = useMutation({
     mutationFn: async (d: number) => {
@@ -110,7 +111,7 @@ export default function SettingsPage() {
   const mcpUrl = settings?.mcpToken ? `${window.location.origin}/mcp/${settings.mcpToken}` : "";
 
   return (
-    <div className="min-h-screen" style={{ backgroundColor: "#f0f8f8" }}>
+    <div className="min-h-screen" style={{ backgroundColor: C.pageBg }}>
       <header className="sticky top-0 z-50 bg-white" style={{ borderBottom: `1px solid ${C.border}` }}>
         <div className="max-w-[640px] mx-auto px-4 py-3 flex items-center gap-3">
           <Link href="/" className="transition-colors hover:opacity-70" style={{ color: C.muted }}>
@@ -198,6 +199,41 @@ export default function SettingsPage() {
             >
               Save
             </button>
+          </div>
+        </div>
+
+        {/* Theme */}
+        <div
+          className="bg-white"
+          style={{ border: `1px solid ${C.border}`, borderRadius: "12px", padding: "1rem 1.25rem" }}
+        >
+          <label className="text-xs font-semibold uppercase tracking-wider" style={{ color: C.muted }}>
+            Theme
+          </label>
+          <p className="text-[11px] mt-0.5 mb-2" style={{ color: C.muted }}>
+            System follows your OS preference. Override is persisted per device.
+          </p>
+          <div className="flex gap-1">
+            {(
+              [
+                { val: "system", label: "System" },
+                { val: "light", label: "Light" },
+                { val: "dark", label: "Dark" },
+              ] as const
+            ).map(({ val, label }) => (
+              <button
+                key={val}
+                onClick={() => setTheme(val)}
+                className="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+                style={{
+                  backgroundColor: theme === val ? C.accent : "transparent",
+                  color: theme === val ? "white" : C.muted,
+                  border: theme === val ? "none" : `1px solid ${C.border}`,
+                }}
+              >
+                {label}
+              </button>
+            ))}
           </div>
         </div>
 

--- a/app/client/src/pages/setup-page.tsx
+++ b/app/client/src/pages/setup-page.tsx
@@ -65,7 +65,7 @@ export default function SetupPage() {
         className="min-h-screen flex items-center justify-center p-4"
         style={{ background: "linear-gradient(135deg, #2bbcb3, #30bfb7, #3cc8c0)" }}
       >
-        <div className="w-full max-w-md bg-white rounded-xl shadow-lg p-8">
+        <div className="w-full max-w-md rounded-xl shadow-lg p-8" style={{ backgroundColor: "white" }}>
           <h1 className="text-lg font-semibold mb-1" style={{ color: C.text }}>
             Connect Your AI Agent
           </h1>


### PR DESCRIPTION
Closes #101.

## Summary
Follows OS by default with a three-way override (System / Light / Dark) persisted to localStorage per device. Accent (teal) carries across both modes; the neutral palette flips between two static palettes inside `useColors()`.

Token-driven approach: most components didn't need to change because they already read `style={{ color: C.text }}` from `useColors()`. Adding `pageBg`, `cardBg`, `inputBg` to the palette + flipping `useColors()` based on resolved mode delivered most of the visual change for free.

Surfaces touched:
- `LIGHT_STATIC` + `DARK_STATIC` palettes inside `App.tsx`; `useColors()` returns the right one.
- Inline `style={{ backgroundColor: "#f0f8f8" }}` page bgs across 5 pages → `C.pageBg`.
- `bg-white` class literals auto-flip via a `.dark .bg-white` rule in `index.css`. Auth + Setup card surfaces opt out by using inline `style={{ backgroundColor: "white" }}` (they sit on the teal gradient and stay branded-light).
- `bg-stone-50` literals get the same `.dark` override.
- Body bg + text + border defaults flip in `.dark body { … }`.
- Date-picker popover bg → `C.cardBg`.
- **Header menu**: Sun/Moon/Monitor icon cycles System → Light → Dark.
- **Settings**: explicit three-way picker.

## Gotcha — solved
`ThemeContext` lives in a standalone `lib/theme.ts` module. Keeping it next to the Provider in `App.tsx` caused Vite's react-refresh to instantiate **two different `ThemeContext` objects** during dev — the Provider wrote to instance A, the Consumer (`useTheme()`) read instance B's default value. Symptom: Provider state correctly `"dark"`, `useTheme()` returning `"system"`. Caught via a window-attached identity check. Splitting Context + hook into a tiny standalone module fixed it cleanly.

## Test plan
- [x] Lint + build clean
- [x] localStorage='dark' on load → `htmlClass='dark'`, body bg `rgb(12, 20, 20)`, header menu reads "Theme: Dark"
- [x] Cycling: dark → system (htmlClass clears), system → light (no class), light → dark (class added)
- [x] Auth + Setup pages stay light (branded teal gradient)
- [x] Provider/Consumer share single `ThemeContext` instance (window-attached identity check)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)