### PR TITLE
Rail + feed: collapse HOLD contacts behind a "Show N on hold" toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 2026-06-11
 
+### Rail + feed: collapse HOLD contacts behind a "Show N on hold" toggle
+The desktop rail (and the mobile single-column feed) used to show every contact, with HOLD parked alongside active prospects. Active vs inactive blurred into one stream.
+
+Now the rail and feed render active contacts (status = ACTIVE) by default and tuck HOLD contacts behind a small "Show N on hold" toggle row with a chevron. Click to expand inline beneath the divider; click again to collapse. State persists to localStorage (`crm-show-inactive`).
+
+Search overrides everything as before — when a query is active, every match shows regardless of status, and the toggle disappears.
+
 ### Dark mode (closes #101)
 Follows OS by default with a three-way override (System / Light / Dark) persisted to localStorage per device. Accent (teal) carries across both modes; the neutral palette (text, muted, border, page bg, card bg) flips between two static palettes inside `useColors()`. Token-driven — most components didn't need to change because they already read `style={{ color: C.text }}` from `useColors()`.
 

--- a/app/client/src/pages/crm-page.tsx
+++ b/app/client/src/pages/crm-page.tsx
@@ -170,7 +170,45 @@ export default function CrmPage() {
   const isSearching = searchResults !== null;
   const displayedContacts = isSearching ? searchResults : filteredContacts;
   const effectiveViewMode = isSearching ? "list" : viewMode;
-  const activeContact = displayedContacts.find((c) => c.id === activeContactId) ?? displayedContacts[0] ?? null;
+  // Use railContacts for the selection lookup so the detail pane follows what's
+  // actually visible in the rail. If a HOLD contact was selected and the user
+  // collapses inactive, selection falls back to the first visible contact.
+  // (Wait until railContacts derivation below before evaluating.)
+
+  // Split active vs inactive (HOLD status) so the rail and feed can hide
+  // parked contacts behind a single chevron by default. Search overrides:
+  // when a query is active, all matches show regardless of status.
+  const [showInactive, setShowInactive] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem("crm-show-inactive") === "1";
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (showInactive) window.localStorage.setItem("crm-show-inactive", "1");
+    else window.localStorage.removeItem("crm-show-inactive");
+  }, [showInactive]);
+  const activeDisplayed = useMemo(
+    () => (isSearching ? displayedContacts : displayedContacts.filter((c) => c.status === "ACTIVE")),
+    [isSearching, displayedContacts],
+  );
+  const inactiveDisplayed = useMemo(
+    () => (isSearching ? [] : displayedContacts.filter((c) => c.status !== "ACTIVE")),
+    [isSearching, displayedContacts],
+  );
+  // What the rail + feed actually render: active always, inactive only when
+  // expanded. When searching, the split is moot.
+  const railContacts = useMemo(
+    () => (showInactive || isSearching ? [...activeDisplayed, ...inactiveDisplayed] : activeDisplayed),
+    [showInactive, isSearching, activeDisplayed, inactiveDisplayed],
+  );
+  // Where to insert the "X on hold" delineator. -1 means don't show.
+  const inactiveDividerIndex = useMemo(() => {
+    if (isSearching) return -1;
+    if (inactiveDisplayed.length === 0) return -1;
+    return activeDisplayed.length;
+  }, [isSearching, activeDisplayed, inactiveDisplayed]);
+
+  const activeContact = railContacts.find((c) => c.id === activeContactId) ?? railContacts[0] ?? null;
 
   const renderContactBlock = (contact: ContactWithRelations) => (
     <ContactBlock
@@ -226,10 +264,10 @@ export default function CrmPage() {
 
   // Clamp the keyboard highlight whenever the result set shrinks.
   useEffect(() => {
-    if (highlightedIndex >= displayedContacts.length) {
-      setHighlightedIndex(Math.max(0, displayedContacts.length - 1));
+    if (highlightedIndex >= railContacts.length) {
+      setHighlightedIndex(Math.max(0, railContacts.length - 1));
     }
-  }, [displayedContacts.length, highlightedIndex]);
+  }, [railContacts.length, highlightedIndex]);
 
   // Scroll the highlighted contact into view as the user arrow-keys through
   // results. Mirrors the kanban onContactTap polling approach.
@@ -333,7 +371,7 @@ export default function CrmPage() {
                 }
                 searchInputRef.current?.blur();
               }}
-              onArrowDown={() => setHighlightedIndex((i) => Math.min(displayedContacts.length - 1, i + 1))}
+              onArrowDown={() => setHighlightedIndex((i) => Math.min(railContacts.length - 1, i + 1))}
               onArrowUp={() => setHighlightedIndex((i) => Math.max(0, i - 1))}
             />
             {/* Add contact — hidden on mobile (FAB covers it) and while searching */}
@@ -828,7 +866,7 @@ export default function CrmPage() {
                 style={{ border: `1px solid ${C.border}`, borderRadius: 12 }}
                 data-testid="contact-rail"
               >
-                {displayedContacts.map((contact, idx) => (
+                {activeDisplayed.map((contact, idx) => (
                   <ContactRow
                     key={contact.id}
                     contact={contact}
@@ -837,6 +875,33 @@ export default function CrmPage() {
                     onSelect={() => scrollToContact(contact.id)}
                   />
                 ))}
+                {inactiveDividerIndex > -1 && (
+                  <button
+                    onClick={() => setShowInactive((v) => !v)}
+                    data-testid="inactive-toggle"
+                    className="w-full flex items-center justify-between px-3 py-2 text-[11px] font-semibold uppercase tracking-wider transition-colors hover:opacity-70"
+                    style={{
+                      color: C.muted,
+                      borderTop: `1px solid ${C.border}`,
+                      ...(showInactive ? { borderBottom: `1px solid ${C.border}` } : {}),
+                    }}
+                  >
+                    <span>
+                      {showInactive ? "Hide" : "Show"} {inactiveDisplayed.length} on hold
+                    </span>
+                    <ChevronDown className={`h-3 w-3 transition-transform ${showInactive ? "rotate-180" : ""}`} />
+                  </button>
+                )}
+                {showInactive &&
+                  inactiveDisplayed.map((contact, idx) => (
+                    <ContactRow
+                      key={contact.id}
+                      contact={contact}
+                      selected={activeContact?.id === contact.id}
+                      highlighted={isSearching && activeDisplayed.length + idx === highlightedIndex}
+                      onSelect={() => scrollToContact(contact.id)}
+                    />
+                  ))}
                 {displayedContacts.length === 0 && (
                   <p className="text-center py-10 text-sm" style={{ color: C.muted }}>
                     {isSearching ? "No contacts match your search" : "No contacts in this stage"}
@@ -845,7 +910,7 @@ export default function CrmPage() {
               </div>
             ) : (
               <>
-                {displayedContacts.map((contact, idx) => {
+                {activeDisplayed.map((contact, idx) => {
                   const isHighlighted = isSearching && idx === highlightedIndex;
                   return (
                     <div
@@ -860,6 +925,39 @@ export default function CrmPage() {
                     </div>
                   );
                 })}
+                {inactiveDividerIndex > -1 && (
+                  <button
+                    onClick={() => setShowInactive((v) => !v)}
+                    data-testid="inactive-toggle"
+                    className="w-full flex items-center justify-between px-3 py-3 my-2 text-[11px] font-semibold uppercase tracking-wider transition-colors hover:opacity-70 rounded-[10px]"
+                    style={{
+                      color: C.muted,
+                      backgroundColor: C.cardBg,
+                      border: `1px dashed ${C.border}`,
+                    }}
+                  >
+                    <span>
+                      {showInactive ? "Hide" : "Show"} {inactiveDisplayed.length} on hold
+                    </span>
+                    <ChevronDown className={`h-3 w-3 transition-transform ${showInactive ? "rotate-180" : ""}`} />
+                  </button>
+                )}
+                {showInactive &&
+                  inactiveDisplayed.map((contact, idx) => {
+                    const isHighlighted = isSearching && activeDisplayed.length + idx === highlightedIndex;
+                    return (
+                      <div
+                        key={contact.id}
+                        className="rounded-[10px]"
+                        style={{
+                          boxShadow: isHighlighted ? `0 0 0 2px ${C.accent}` : undefined,
+                          transition: "box-shadow 120ms ease-out",
+                        }}
+                      >
+                        {renderContactBlock(contact)}
+                      </div>
+                    );
+                  })}
                 {displayedContacts.length === 0 && (
                   <p className="text-center py-16 text-sm" style={{ color: C.muted }}>
                     {isSearching ? "No contacts match your search" : "No contacts in this stage"}
@@ -873,7 +971,7 @@ export default function CrmPage() {
               The rail is an index: clicking a row scrolls here. */}
           {isDesktop && (
             <div className="flex-1 min-w-0" data-testid="contact-feed">
-              {displayedContacts.map((contact, idx) => {
+              {activeDisplayed.map((contact, idx) => {
                 const isHighlighted = isSearching && idx === highlightedIndex;
                 return (
                   <div
@@ -888,6 +986,40 @@ export default function CrmPage() {
                   </div>
                 );
               })}
+              {inactiveDividerIndex > -1 && (
+                <div
+                  className="flex items-center gap-2 my-3 text-[11px] font-semibold uppercase tracking-wider"
+                  style={{ color: C.muted }}
+                >
+                  <div className="flex-1 h-px" style={{ backgroundColor: C.border }} />
+                  <button
+                    onClick={() => setShowInactive((v) => !v)}
+                    className="flex items-center gap-1.5 transition-colors hover:opacity-70"
+                  >
+                    <span>
+                      {showInactive ? "Hide" : "Show"} {inactiveDisplayed.length} on hold
+                    </span>
+                    <ChevronDown className={`h-3 w-3 transition-transform ${showInactive ? "rotate-180" : ""}`} />
+                  </button>
+                  <div className="flex-1 h-px" style={{ backgroundColor: C.border }} />
+                </div>
+              )}
+              {showInactive &&
+                inactiveDisplayed.map((contact, idx) => {
+                  const isHighlighted = isSearching && activeDisplayed.length + idx === highlightedIndex;
+                  return (
+                    <div
+                      key={contact.id}
+                      className="rounded-[10px]"
+                      style={{
+                        boxShadow: isHighlighted ? `0 0 0 2px ${C.accent}` : undefined,
+                        transition: "box-shadow 120ms ease-out",
+                      }}
+                    >
+                      {renderContactBlock(contact)}
+                    </div>
+                  );
+                })}
               {displayedContacts.length === 0 && (
                 <p className="text-center py-16 text-sm" style={{ color: C.muted }}>
                   {isSearching ? "No contacts match your search" : "No contacts in this stage"}

--- a/app/tests/master-detail.spec.ts
+++ b/app/tests/master-detail.spec.ts
@@ -21,6 +21,11 @@ test.describe("Desktop rail + feed layout", () => {
     await expect(rail).toBeVisible();
     await expect(feed).toBeVisible();
 
+    // Inactive contacts (HOLD) are tucked behind a toggle by default — expand
+    // to expose all 8 so the rail/feed counts can be asserted.
+    const inactiveToggle = page.locator('[data-testid="inactive-toggle"]').first();
+    if (await inactiveToggle.count()) await inactiveToggle.click();
+
     // All 8 seed contacts appear BOTH as index rows and as full cards.
     await expect(rail.locator('[data-testid^="contact-row-"]')).toHaveCount(8);
     await expect(feed.locator('input[placeholder*="note"]')).toHaveCount(8);
@@ -55,6 +60,12 @@ test.describe("Desktop rail + feed layout", () => {
 
     await expect(page.locator('[data-testid="contact-rail"]')).toHaveCount(0);
     await expect(page.locator('[data-testid="contact-feed"]')).toHaveCount(0);
+
+    // Inactive contacts (HOLD) are tucked behind a toggle by default — expand
+    // to expose all 8 in the single column.
+    const inactiveToggle = page.locator('[data-testid="inactive-toggle"]').first();
+    if (await inactiveToggle.count()) await inactiveToggle.click();
+
     // All 8 seed contacts render as full cards in one column.
     await expect(page.locator('input[placeholder*="note"]')).toHaveCount(8);
   });

--- a/app/tests/search.spec.ts
+++ b/app/tests/search.spec.ts
@@ -64,6 +64,12 @@ test.describe("Cmd+K full-text search", () => {
 
     await page.keyboard.press("Escape");
     await expect(input).toHaveCount(0);
+
+    // Inactive contacts (HOLD) are tucked behind a toggle outside of search
+    // mode — expand to expose all 8 so the count assertion can include them.
+    const inactiveToggle = page.locator('[data-testid="inactive-toggle"]').first();
+    if (await inactiveToggle.count()) await inactiveToggle.click();
+
     // Full list restored — there are 8 seed contacts. At ≥1024px the list view
     // is master-detail (#82): contacts render as compact rail rows and only the
     // selected contact has an h2 card. Below 1024px each contact is a full card.


### PR DESCRIPTION
## Summary
The desktop rail (and mobile single-column feed) used to show every contact, with HOLD parked alongside active prospects. Active vs inactive blurred into one stream.

Now the rail and feed render **active contacts (status = ACTIVE) by default** and tuck HOLD contacts behind a small "Show N on hold" toggle row with a chevron. Click to expand inline beneath the divider; click again to collapse. State persists to localStorage (`crm-show-inactive`).

Layout:

```
Active rows (always)
──── Show 3 on hold  ⌄ ────  ← click to flip to "Hide 3 on hold ⌃"
HOLD rows (only when expanded)
```

**Search overrides everything as before** — when a query is active, every match shows regardless of status, and the toggle disappears. Selection lookup uses `railContacts` so if the user collapses inactive while a HOLD contact is selected, the detail pane falls back to the first visible row.

## Test plan
- [x] Lint + build clean
- [x] Default rail at 1280 × 800 shows 7 active contacts + toggle "Show 1 on hold"
- [x] Click toggle → label flips to "Hide 1 on hold", David Kim row appears beneath the divider, `localStorage["crm-show-inactive"] = "1"`
- [x] Reload preserves expand/collapse state
- [x] Cmd+K + "David" → David Kim appears in the rail anyway, no toggle rendered
- [x] Both desktop rail (`<ContactRow>` rows) and desktop feed (`<ContactBlock>` cards) split correctly
- [x] Mobile single-column also splits with a dashed-border toggle between sections
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)